### PR TITLE
Wire onboarding permissions to permission_handler

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 import 'bloc/bluetooth_bloc.dart';
 import 'data/frequency_mock_data.dart';
@@ -14,18 +13,7 @@ import 'theme/app_theme.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
-  await _requestPermissions();
   runApp(const WalkieTalkieApp());
-}
-
-Future<void> _requestPermissions() async {
-  await [
-    Permission.bluetoothConnect,
-    Permission.bluetoothScan,
-    Permission.bluetoothAdvertise,
-    Permission.microphone,
-    Permission.notification,
-  ].request();
 }
 
 class WalkieTalkieApp extends StatelessWidget {

--- a/lib/screens/frequency_onboarding_screen.dart
+++ b/lib/screens/frequency_onboarding_screen.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 
+import '../services/onboarding_permission_gateway.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
 
 /// 3-step onboarding: welcome → permissions → display name.
 class FrequencyOnboardingScreen extends StatefulWidget {
   final ValueChanged<String> onDone;
-  const FrequencyOnboardingScreen({super.key, required this.onDone});
+
+  /// Override for tests; defaults to the real `permission_handler` gateway.
+  final OnboardingPermissionGateway? permissionGateway;
+
+  const FrequencyOnboardingScreen({
+    super.key,
+    required this.onDone,
+    this.permissionGateway,
+  });
 
   @override
   State<FrequencyOnboardingScreen> createState() => _FrequencyOnboardingScreenState();
@@ -14,9 +23,13 @@ class FrequencyOnboardingScreen extends StatefulWidget {
 
 class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen> {
   int _step = 0;
-  bool _btGranted = false;
-  bool _micGranted = false;
+  OnboardingPermissionStatus _btStatus = OnboardingPermissionStatus.denied;
+  OnboardingPermissionStatus _micStatus = OnboardingPermissionStatus.denied;
+  bool _btRequestInFlight = false;
+  bool _micRequestInFlight = false;
   final TextEditingController _nameCtrl = TextEditingController();
+  late final OnboardingPermissionGateway _gateway =
+      widget.permissionGateway ?? const DefaultOnboardingPermissionGateway();
 
   @override
   void dispose() {
@@ -24,7 +37,33 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen> {
     super.dispose();
   }
 
-  bool get _allGranted => _btGranted && _micGranted;
+  bool get _allGranted =>
+      _btStatus == OnboardingPermissionStatus.granted &&
+      _micStatus == OnboardingPermissionStatus.granted;
+
+  Future<void> _requestBluetooth() async {
+    if (_btRequestInFlight) return;
+    setState(() => _btRequestInFlight = true);
+    try {
+      final result = await _gateway.requestBluetooth();
+      if (!mounted) return;
+      setState(() => _btStatus = result);
+    } finally {
+      if (mounted) setState(() => _btRequestInFlight = false);
+    }
+  }
+
+  Future<void> _requestMicrophone() async {
+    if (_micRequestInFlight) return;
+    setState(() => _micRequestInFlight = true);
+    try {
+      final result = await _gateway.requestMicrophone();
+      if (!mounted) return;
+      setState(() => _micStatus = result);
+    } finally {
+      if (mounted) setState(() => _micRequestInFlight = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -64,10 +103,13 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen> {
         return _Welcome(onNext: () => setState(() => _step = 1));
       case 1:
         return _Permissions(
-          btGranted: _btGranted,
-          micGranted: _micGranted,
-          onBt: () => setState(() => _btGranted = true),
-          onMic: () => setState(() => _micGranted = true),
+          btStatus: _btStatus,
+          micStatus: _micStatus,
+          btInFlight: _btRequestInFlight,
+          micInFlight: _micRequestInFlight,
+          onRequestBt: _requestBluetooth,
+          onRequestMic: _requestMicrophone,
+          onOpenSettings: _gateway.openAppSettings,
           onContinue: _allGranted ? () => setState(() => _step = 2) : null,
         );
       default:
@@ -130,17 +172,23 @@ class _Welcome extends StatelessWidget {
 }
 
 class _Permissions extends StatelessWidget {
-  final bool btGranted;
-  final bool micGranted;
-  final VoidCallback onBt;
-  final VoidCallback onMic;
+  final OnboardingPermissionStatus btStatus;
+  final OnboardingPermissionStatus micStatus;
+  final bool btInFlight;
+  final bool micInFlight;
+  final VoidCallback onRequestBt;
+  final VoidCallback onRequestMic;
+  final Future<void> Function() onOpenSettings;
   final VoidCallback? onContinue;
 
   const _Permissions({
-    required this.btGranted,
-    required this.micGranted,
-    required this.onBt,
-    required this.onMic,
+    required this.btStatus,
+    required this.micStatus,
+    required this.btInFlight,
+    required this.micInFlight,
+    required this.onRequestBt,
+    required this.onRequestMic,
+    required this.onOpenSettings,
     required this.onContinue,
   });
 
@@ -175,16 +223,20 @@ class _Permissions extends StatelessWidget {
             icon: Icons.bluetooth,
             title: 'Bluetooth nearby devices',
             desc: 'Discover and connect to phones and headphones',
-            granted: btGranted,
-            onGrant: onBt,
+            status: btStatus,
+            inFlight: btInFlight,
+            onAllow: onRequestBt,
+            onOpenSettings: onOpenSettings,
           ),
           const SizedBox(height: 10),
           _PermRow(
             icon: Icons.mic_none,
             title: 'Microphone',
             desc: 'Send your voice to the frequency',
-            granted: micGranted,
-            onGrant: onMic,
+            status: micStatus,
+            inFlight: micInFlight,
+            onAllow: onRequestMic,
+            onOpenSettings: onOpenSettings,
           ),
           const Spacer(),
           PrimaryButton(
@@ -204,19 +256,28 @@ class _PermRow extends StatelessWidget {
   final IconData icon;
   final String title;
   final String desc;
-  final bool granted;
-  final VoidCallback onGrant;
+  final OnboardingPermissionStatus status;
+  final bool inFlight;
+  final VoidCallback onAllow;
+  final Future<void> Function() onOpenSettings;
   const _PermRow({
     required this.icon,
     required this.title,
     required this.desc,
-    required this.granted,
-    required this.onGrant,
+    required this.status,
+    required this.inFlight,
+    required this.onAllow,
+    required this.onOpenSettings,
   });
 
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
+    final granted = status == OnboardingPermissionStatus.granted;
+    final permanentlyDenied = status == OnboardingPermissionStatus.permanentlyDenied;
+    final effectiveDesc = permanentlyDenied
+        ? 'Blocked — re-enable in system settings'
+        : desc;
     return FreqCard(
       padding: const EdgeInsets.all(14),
       child: Row(
@@ -232,7 +293,11 @@ class _PermRow extends StatelessWidget {
             child: Icon(
               granted ? Icons.check : icon,
               size: 18,
-              color: granted ? c.accentInk : c.ink2,
+              color: granted
+                  ? c.accentInk
+                  : permanentlyDenied
+                      ? c.danger
+                      : c.ink2,
             ),
           ),
           const SizedBox(width: 12),
@@ -250,11 +315,11 @@ class _PermRow extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  desc,
+                  effectiveDesc,
                   style: TextStyle(
                     fontFamily: 'Inter',
                     fontSize: 12,
-                    color: c.ink3,
+                    color: permanentlyDenied ? c.danger : c.ink3,
                     height: 1.4,
                   ),
                 ),
@@ -271,12 +336,19 @@ class _PermRow extends StatelessWidget {
                 fontWeight: FontWeight.w500,
               ),
             )
-          else
+          else if (permanentlyDenied)
             FreqButton(
-              label: 'Allow',
+              label: 'Open settings',
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
               fontSize: 13,
-              onPressed: onGrant,
+              onPressed: () => onOpenSettings(),
+            )
+          else
+            FreqButton(
+              label: inFlight ? 'Asking…' : 'Allow',
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+              fontSize: 13,
+              onPressed: inFlight ? null : onAllow,
             ),
         ],
       ),

--- a/lib/screens/frequency_onboarding_screen.dart
+++ b/lib/screens/frequency_onboarding_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import '../services/onboarding_permission_gateway.dart';
@@ -341,7 +343,7 @@ class _PermRow extends StatelessWidget {
               label: 'Open settings',
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
               fontSize: 13,
-              onPressed: () => onOpenSettings(),
+              onPressed: () => unawaited(onOpenSettings()),
             )
           else
             FreqButton(

--- a/lib/services/onboarding_permission_gateway.dart
+++ b/lib/services/onboarding_permission_gateway.dart
@@ -1,0 +1,57 @@
+import 'package:permission_handler/permission_handler.dart' as ph;
+
+/// Tri-state result of a permission request, surfaced to the onboarding UI.
+///
+/// We collapse `permission_handler`'s richer enum to the three states the UI
+/// actually needs — granted, denied (can re-prompt), or permanently denied
+/// (must send the user to system settings).
+enum OnboardingPermissionStatus { denied, granted, permanentlyDenied }
+
+/// Thin abstraction so the onboarding screen can be tested without spinning
+/// up `permission_handler`'s platform channels.
+abstract class OnboardingPermissionGateway {
+  Future<OnboardingPermissionStatus> requestBluetooth();
+  Future<OnboardingPermissionStatus> requestMicrophone();
+  Future<void> openAppSettings();
+}
+
+/// Default implementation backed by the `permission_handler` package.
+///
+/// Bluetooth on Android 13+ requires three runtime permissions; we ask for
+/// all of them together and only report `granted` when every one is granted.
+class DefaultOnboardingPermissionGateway implements OnboardingPermissionGateway {
+  const DefaultOnboardingPermissionGateway();
+
+  static const _bluetoothPermissions = <ph.Permission>[
+    ph.Permission.bluetoothScan,
+    ph.Permission.bluetoothConnect,
+    ph.Permission.bluetoothAdvertise,
+  ];
+
+  @override
+  Future<OnboardingPermissionStatus> requestBluetooth() async {
+    final results = await _bluetoothPermissions.request();
+    return _reduce(results.values);
+  }
+
+  @override
+  Future<OnboardingPermissionStatus> requestMicrophone() async {
+    final status = await ph.Permission.microphone.request();
+    return _reduce([status]);
+  }
+
+  @override
+  Future<void> openAppSettings() async {
+    await ph.openAppSettings();
+  }
+
+  static OnboardingPermissionStatus _reduce(Iterable<ph.PermissionStatus> values) {
+    if (values.any((s) => s.isPermanentlyDenied)) {
+      return OnboardingPermissionStatus.permanentlyDenied;
+    }
+    if (values.every((s) => s.isGranted || s.isLimited)) {
+      return OnboardingPermissionStatus.granted;
+    }
+    return OnboardingPermissionStatus.denied;
+  }
+}

--- a/test/screens/frequency_onboarding_screen_test.dart
+++ b/test/screens/frequency_onboarding_screen_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/screens/frequency_onboarding_screen.dart';
+import 'package:walkie_talkie/services/onboarding_permission_gateway.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+
+class _FakeGateway implements OnboardingPermissionGateway {
+  OnboardingPermissionStatus btResult;
+  OnboardingPermissionStatus micResult;
+  int btRequests = 0;
+  int micRequests = 0;
+  int settingsOpens = 0;
+
+  _FakeGateway({
+    this.btResult = OnboardingPermissionStatus.granted,
+    this.micResult = OnboardingPermissionStatus.granted,
+  });
+
+  @override
+  Future<OnboardingPermissionStatus> requestBluetooth() async {
+    btRequests++;
+    return btResult;
+  }
+
+  @override
+  Future<OnboardingPermissionStatus> requestMicrophone() async {
+    micRequests++;
+    return micResult;
+  }
+
+  @override
+  Future<void> openAppSettings() async {
+    settingsOpens++;
+  }
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: AppTheme.light(),
+    home: child,
+  );
+}
+
+void main() {
+  group('FrequencyOnboardingScreen', () {
+    testWidgets('happy path: welcome → grant both → name → onDone fires', (tester) async {
+      final gateway = _FakeGateway();
+      String? doneName;
+
+      await tester.pumpWidget(_wrap(
+        FrequencyOnboardingScreen(
+          permissionGateway: gateway,
+          onDone: (name) => doneName = name,
+        ),
+      ));
+
+      // Welcome step
+      expect(find.text('Get started'), findsOneWidget);
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      // Permissions step — Continue is disabled until both granted.
+      expect(find.text('Continue'), findsOneWidget);
+      expect(gateway.btRequests, 0);
+
+      await tester.tap(find.text('Allow').first);
+      await tester.pumpAndSettle();
+      expect(gateway.btRequests, 1);
+      expect(find.text('Allowed'), findsOneWidget);
+
+      await tester.tap(find.text('Allow'));
+      await tester.pumpAndSettle();
+      expect(gateway.micRequests, 1);
+      expect(find.text('Allowed'), findsNWidgets(2));
+
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      // Name step
+      expect(find.text('Find a frequency'), findsOneWidget);
+      await tester.enterText(find.byType(TextField), '  Caleb  ');
+      await tester.pump();
+      await tester.tap(find.text('Find a frequency'));
+      await tester.pumpAndSettle();
+
+      expect(doneName, 'Caleb');
+    });
+
+    testWidgets('denied permission can be re-requested', (tester) async {
+      final gateway = _FakeGateway(btResult: OnboardingPermissionStatus.denied);
+
+      await tester.pumpWidget(_wrap(
+        FrequencyOnboardingScreen(
+          permissionGateway: gateway,
+          onDone: (_) {},
+        ),
+      ));
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      // First request: denied → button should still say Allow.
+      await tester.tap(find.text('Allow').first);
+      await tester.pumpAndSettle();
+      expect(gateway.btRequests, 1);
+      expect(find.text('Allow'), findsNWidgets(2));
+
+      // Caller flipped a setting; next attempt grants.
+      gateway.btResult = OnboardingPermissionStatus.granted;
+      await tester.tap(find.text('Allow').first);
+      await tester.pumpAndSettle();
+      expect(gateway.btRequests, 2);
+      expect(find.text('Allowed'), findsOneWidget);
+    });
+
+    testWidgets('permanently-denied permission shows Open settings', (tester) async {
+      final gateway = _FakeGateway(
+        btResult: OnboardingPermissionStatus.permanentlyDenied,
+      );
+
+      await tester.pumpWidget(_wrap(
+        FrequencyOnboardingScreen(
+          permissionGateway: gateway,
+          onDone: (_) {},
+        ),
+      ));
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Allow').first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open settings'), findsOneWidget);
+      expect(find.text('Blocked — re-enable in system settings'), findsOneWidget);
+
+      await tester.tap(find.text('Open settings'));
+      await tester.pumpAndSettle();
+      expect(gateway.settingsOpens, 1);
+    });
+
+    testWidgets('Continue stays disabled when only one permission is granted', (tester) async {
+      final gateway = _FakeGateway(
+        micResult: OnboardingPermissionStatus.denied,
+      );
+      String? doneName;
+
+      await tester.pumpWidget(_wrap(
+        FrequencyOnboardingScreen(
+          permissionGateway: gateway,
+          onDone: (n) => doneName = n,
+        ),
+      ));
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      // Grant only Bluetooth.
+      await tester.tap(find.text('Allow').first);
+      await tester.pumpAndSettle();
+
+      // Tapping Continue should not advance.
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+      expect(find.text('Find a frequency'), findsNothing);
+      expect(doneName, isNull);
+    });
+
+    testWidgets('in-flight request label shows while gateway is pending', (tester) async {
+      final completer = Completer<OnboardingPermissionStatus>();
+      final gateway = _SlowGateway(completer);
+
+      await tester.pumpWidget(_wrap(
+        FrequencyOnboardingScreen(
+          permissionGateway: gateway,
+          onDone: (_) {},
+        ),
+      ));
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Allow').first);
+      await tester.pump(); // run the future microtask but don't settle
+
+      expect(find.text('Asking…'), findsOneWidget);
+
+      completer.complete(OnboardingPermissionStatus.granted);
+      await tester.pumpAndSettle();
+      expect(find.text('Asking…'), findsNothing);
+      expect(find.text('Allowed'), findsOneWidget);
+    });
+  });
+}
+
+class _SlowGateway implements OnboardingPermissionGateway {
+  final Completer<OnboardingPermissionStatus> btCompleter;
+  _SlowGateway(this.btCompleter);
+
+  @override
+  Future<OnboardingPermissionStatus> requestBluetooth() => btCompleter.future;
+
+  @override
+  Future<OnboardingPermissionStatus> requestMicrophone() async =>
+      OnboardingPermissionStatus.granted;
+
+  @override
+  Future<void> openAppSettings() async {}
+}


### PR DESCRIPTION
## Summary

Closes #3.

The permissions step in [the onboarding flow](lib/screens/frequency_onboarding_screen.dart) used to flip two booleans when the user tapped *Allow* — it never asked the OS for anything. The real request was happening in `main()` before any UI rendered, so the user saw the system dialogs out of context and the in-app explanation was decorative.

This PR moves the request to the row's *Allow* button.

## What changed

- **`main.dart`** — drop the eager `_requestPermissions()` call (and the `permission_handler` import).
- **`lib/services/onboarding_permission_gateway.dart`** (new) — a small abstraction over `permission_handler` that surfaces a tri-state `OnboardingPermissionStatus` (`granted` / `denied` / `permanentlyDenied`) plus an `openAppSettings()` shim. Lets the screen be widget-tested without platform channels.
- **`frequency_onboarding_screen.dart`** — the *Allow* button now calls the gateway. The row reflects the real status:
  - `denied` → *Allow* button stays, can re-prompt
  - `granted` → *Allowed* label, accent check icon
  - `permanentlyDenied` → *Open settings* button, danger-tinted icon, copy changes to "Blocked — re-enable in system settings"
  - while a request is in flight, the button label flips to *Asking…* and is non-tappable
- Bluetooth needs three Android 13+ runtime permissions (`bluetoothScan`, `bluetoothConnect`, `bluetoothAdvertise`); they're asked together and only collapse to *granted* when **all three** are granted.
- **`test/screens/frequency_onboarding_screen_test.dart`** (new) — five widget tests covering the happy path, denied → re-prompt, permanently-denied → *Open settings*, *Continue* gating when only one permission is granted, and the in-flight *Asking…* label.

## Reviewer notes

- The notification permission previously requested in `main.dart` is **not** surfaced anywhere in this PR. That belongs with whichever PR introduces the foreground-service notifications (#6 / #9 likely). Flagged in #3's description.
- Android manifest already has `BLUETOOTH_CONNECT`, `BLUETOOTH_SCAN`, `BLUETOOTH_ADVERTISE`, `RECORD_AUDIO` declared — no manifest changes needed.
- iOS path isn't tested; this app is Android-first per the README.

## Test plan

- [ ] `flutter analyze` clean
- [ ] `flutter test` passes (5 new tests + smoke test)
- [ ] On a real device: launch app → onboarding → tap *Allow* on Bluetooth row → system dialog appears → grant → row flips to *Allowed*
- [ ] Same for Microphone
- [ ] Deny twice in a row → row should flip to *Open settings* on the second deny (Android marks it permanently denied); tapping *Open settings* opens app settings
- [ ] *Continue* is non-tappable until both rows show *Allowed*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer permission UI: “Allowed” vs “Blocked — re-enable…”, color changes for permanently denied, and an “Open settings” button.
  * Real-time “Asking…” feedback while requests are in progress; prevents duplicate concurrent requests.
  * Continue button remains disabled until required permissions are granted.
  * Name entry trims surrounding whitespace before submission.

* **Chores**
  * Removed automatic permission prompts on app startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->