### PR TITLE
Replace SnackBar toasts with the in-frame toast system

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,6 +29,10 @@ class WalkieTalkieApp extends StatelessWidget {
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
       themeMode: ThemeMode.system,
+      // Wrap the navigator so toasts stay above pushed routes (modal bottom
+      // sheets, etc.) — a host inside `home` would render below the modal
+      // overlay and get hidden when a sheet is open.
+      builder: (context, child) => FrequencyToastHost(child: child!),
       home: FrequencyApp(identityStore: identityStore ?? HiveIdentityStore()),
     );
   }
@@ -116,13 +120,11 @@ class _FrequencyAppState extends State<FrequencyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return FrequencyToastHost(
-      child: AnimatedSwitcher(
-        duration: const Duration(milliseconds: 280),
-        child: KeyedSubtree(
-          key: ValueKey(_stage),
-          child: _buildStage(),
-        ),
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 280),
+      child: KeyedSubtree(
+        key: ValueKey(_stage),
+        child: _buildStage(),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'screens/frequency_onboarding_screen.dart';
 import 'screens/frequency_room_screen.dart';
 import 'services/identity_store.dart';
 import 'theme/app_theme.dart';
+import 'widgets/frequency_toast_host.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -115,11 +116,13 @@ class _FrequencyAppState extends State<FrequencyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 280),
-      child: KeyedSubtree(
-        key: ValueKey(_stage),
-        child: _buildStage(),
+    return FrequencyToastHost(
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 280),
+        child: KeyedSubtree(
+          key: ValueKey(_stage),
+          child: _buildStage(),
+        ),
       ),
     );
   }

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -114,6 +114,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           title: '${newcomer.name} wants to tune in',
           description: "They're right nearby",
           autoDismiss: null, // sticky — host must choose
+          // Demo only: real accept/deny dispatch waits on the BT mesh +
+          // state container. The toast surface is the deliverable for now.
           actions: [
             ToastAction(label: 'Deny', onTap: () {}),
             ToastAction(label: 'Let in', primary: true, onTap: () {}),

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../data/frequency_mock_data.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
+import '../widgets/frequency_toast_host.dart';
 
 enum AudioOutput { bluetooth, earpiece, speaker }
 
@@ -107,16 +108,17 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         final newcomer = kPeople.length > widget.groupSize
             ? kPeople[widget.groupSize]
             : kPeople.last;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            duration: const Duration(seconds: 8),
-            content: Text("${newcomer.name} wants to tune in — they're right nearby"),
-            action: SnackBarAction(
-              label: 'Let in',
-              onPressed: () {},
-            ),
-          ),
-        );
+        FrequencyToastHost.of(context).push(FrequencyToastSpec(
+          tone: ToastTone.request,
+          person: newcomer,
+          title: '${newcomer.name} wants to tune in',
+          description: "They're right nearby",
+          autoDismiss: null, // sticky — host must choose
+          actions: [
+            ToastAction(label: 'Deny', onTap: () {}),
+            ToastAction(label: 'Let in', primary: true, onTap: () {}),
+          ],
+        ));
       });
     }
 
@@ -124,13 +126,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       if (!mounted) return;
       final p = _roster.last;
       if (p.id == 'me') return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          duration: const Duration(seconds: 4),
-          backgroundColor: FrequencyTheme.of(context).colors.warn,
-          content: Text("${p.name}'s signal is weak — ask them to move closer"),
-        ),
-      );
+      FrequencyToastHost.of(context).push(FrequencyToastSpec(
+        tone: ToastTone.warn,
+        title: "${p.name}'s signal is weak",
+        description: 'Ask them to move closer',
+        autoDismiss: const Duration(milliseconds: 3600),
+      ));
     });
   }
 
@@ -485,9 +486,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
               _removed.add(person.id);
             });
             Navigator.pop(ctx);
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('${person.name} was removed')),
-            );
+            FrequencyToastHost.of(context).push(FrequencyToastSpec(
+              tone: ToastTone.leave,
+              title: '${person.name} was removed',
+            ));
           },
         );
       },

--- a/lib/widgets/frequency_toast_host.dart
+++ b/lib/widgets/frequency_toast_host.dart
@@ -78,11 +78,14 @@ class FrequencyToastHost extends StatefulWidget {
 
   static FrequencyToastController of(BuildContext context) {
     final state = context.findAncestorStateOfType<_FrequencyToastHostState>();
-    assert(
-      state != null,
-      'No FrequencyToastHost found in the widget tree above this context.',
-    );
-    return state!;
+    if (state == null) {
+      throw FlutterError(
+        'No FrequencyToastHost found in the widget tree above this context. '
+        'Wrap the app (e.g. via MaterialApp.builder) so toasts can sit '
+        'above modal routes.',
+      );
+    }
+    return state;
   }
 
   @override
@@ -124,30 +127,30 @@ class _FrequencyToastHostState extends State<FrequencyToastHost>
 
   @override
   Widget build(BuildContext context) {
+    // Anchor 12dp below the platform's safe-area top so notches and varying
+    // status-bar heights don't visually clip the first toast.
+    final topInset = MediaQuery.paddingOf(context).top + 12;
     return Stack(
       fit: StackFit.expand,
       children: [
         widget.child,
         Positioned(
-          top: 48,
+          top: topInset,
           left: 12,
           right: 12,
-          child: IgnorePointer(
-            ignoring: false,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                for (final t in _toasts)
-                  Padding(
-                    key: ValueKey(t.id),
-                    padding: const EdgeInsets.only(bottom: 8),
-                    child: _ToastCard(
-                      spec: t.spec,
-                      onDismiss: () => dismiss(t.id),
-                    ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final t in _toasts)
+                Padding(
+                  key: ValueKey(t.id),
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: _ToastCard(
+                    spec: t.spec,
+                    onDismiss: () => dismiss(t.id),
                   ),
-              ],
-            ),
+                ),
+            ],
           ),
         ),
       ],
@@ -273,9 +276,10 @@ class _ToastCardState extends State<_ToastCard>
                     icon: Icon(Icons.close, size: 14, color: c.ink3),
                     visualDensity: VisualDensity.compact,
                     padding: const EdgeInsets.all(4),
+                    // Material's recommended minimum tap target.
                     constraints: const BoxConstraints(
-                      minWidth: 28,
-                      minHeight: 28,
+                      minWidth: 40,
+                      minHeight: 40,
                     ),
                   ),
               ],

--- a/lib/widgets/frequency_toast_host.dart
+++ b/lib/widgets/frequency_toast_host.dart
@@ -131,7 +131,11 @@ class _FrequencyToastHostState extends State<FrequencyToastHost>
     // status-bar heights don't visually clip the first toast.
     final topInset = MediaQuery.paddingOf(context).top + 12;
     return Stack(
-      fit: StackFit.expand,
+      // `passthrough` lets the navigator (or whatever the wrapped child is)
+      // dictate the Stack's size from incoming constraints. `expand` would
+      // demand tight constraints we don't always get when this host wraps
+      // MaterialApp's `child` via `builder`.
+      fit: StackFit.passthrough,
       children: [
         widget.child,
         Positioned(
@@ -273,7 +277,17 @@ class _ToastCardState extends State<_ToastCard>
                 else
                   IconButton(
                     onPressed: widget.onDismiss,
-                    icon: Icon(Icons.close, size: 14, color: c.ink3),
+                    // Use Icon.semanticLabel rather than IconButton.tooltip:
+                    // Tooltip widgets require an Overlay ancestor, but this
+                    // host sits above the Navigator's Overlay (so toasts
+                    // render above modal sheets). semanticLabel gives screen
+                    // readers the same announcement without that dependency.
+                    icon: Icon(
+                      Icons.close,
+                      size: 14,
+                      color: c.ink3,
+                      semanticLabel: 'Dismiss toast',
+                    ),
                     visualDensity: VisualDensity.compact,
                     padding: const EdgeInsets.all(4),
                     // Material's recommended minimum tap target.

--- a/lib/widgets/frequency_toast_host.dart
+++ b/lib/widgets/frequency_toast_host.dart
@@ -1,0 +1,334 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../data/frequency_mock_data.dart';
+import '../theme/app_theme.dart';
+import 'frequency_atoms.dart';
+
+/// Visual tone of a toast. Each tone selects a default leading icon and an
+/// accent palette consistent with the design.
+enum ToastTone { info, join, leave, warn, request }
+
+/// One action button on a toast (e.g. *Let in* / *Deny* on a join request).
+class ToastAction {
+  final String label;
+  final bool primary;
+  final VoidCallback onTap;
+
+  const ToastAction({
+    required this.label,
+    required this.onTap,
+    this.primary = false,
+  });
+}
+
+/// Spec for a single toast push.
+class FrequencyToastSpec {
+  final ToastTone tone;
+  final String title;
+  final String? description;
+
+  /// Optional subject; when present, the leading slot shows their avatar
+  /// instead of the tone's default icon.
+  final Person? person;
+
+  /// `null` for sticky (the user must dismiss or pick an action).
+  final Duration? autoDismiss;
+
+  /// Optional action buttons; if any are provided, the trailing close button
+  /// is hidden — actions implicitly dismiss the toast on tap.
+  final List<ToastAction> actions;
+
+  const FrequencyToastSpec({
+    required this.title,
+    this.tone = ToastTone.info,
+    this.description,
+    this.person,
+    this.autoDismiss = const Duration(milliseconds: 3200),
+    this.actions = const [],
+  });
+}
+
+class _ActiveToast {
+  final int id;
+  final FrequencyToastSpec spec;
+  Timer? autoDismiss;
+  _ActiveToast({required this.id, required this.spec});
+}
+
+/// API exposed by [FrequencyToastHost.of] to descendants.
+abstract class FrequencyToastController {
+  /// Pushes a toast. Returns its id so callers can dismiss it manually.
+  int push(FrequencyToastSpec spec);
+
+  /// Dismisses the toast with [id], if it's still visible. No-op otherwise.
+  void dismiss(int id);
+}
+
+/// Wraps [child] in a stack that overlays toasts at the top of the frame.
+///
+/// Mirrors the design's in-frame toast behavior: top-of-frame placement,
+/// tone-tinted icon, optional avatar, optional action buttons. Auto-dismiss
+/// is the default; pass `autoDismiss: null` for a sticky toast that requires
+/// explicit dismissal (the host's join-request prompt is the canonical case).
+class FrequencyToastHost extends StatefulWidget {
+  final Widget child;
+  const FrequencyToastHost({super.key, required this.child});
+
+  static FrequencyToastController of(BuildContext context) {
+    final state = context.findAncestorStateOfType<_FrequencyToastHostState>();
+    assert(
+      state != null,
+      'No FrequencyToastHost found in the widget tree above this context.',
+    );
+    return state!;
+  }
+
+  @override
+  State<FrequencyToastHost> createState() => _FrequencyToastHostState();
+}
+
+class _FrequencyToastHostState extends State<FrequencyToastHost>
+    implements FrequencyToastController {
+  final List<_ActiveToast> _toasts = [];
+  int _nextId = 1;
+
+  @override
+  int push(FrequencyToastSpec spec) {
+    final id = _nextId++;
+    final toast = _ActiveToast(id: id, spec: spec);
+    if (spec.autoDismiss != null) {
+      toast.autoDismiss = Timer(spec.autoDismiss!, () => dismiss(id));
+    }
+    setState(() => _toasts.add(toast));
+    return id;
+  }
+
+  @override
+  void dismiss(int id) {
+    if (!mounted) return;
+    final idx = _toasts.indexWhere((t) => t.id == id);
+    if (idx == -1) return;
+    _toasts[idx].autoDismiss?.cancel();
+    setState(() => _toasts.removeAt(idx));
+  }
+
+  @override
+  void dispose() {
+    for (final t in _toasts) {
+      t.autoDismiss?.cancel();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        widget.child,
+        Positioned(
+          top: 48,
+          left: 12,
+          right: 12,
+          child: IgnorePointer(
+            ignoring: false,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (final t in _toasts)
+                  Padding(
+                    key: ValueKey(t.id),
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: _ToastCard(
+                      spec: t.spec,
+                      onDismiss: () => dismiss(t.id),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ToastCard extends StatefulWidget {
+  final FrequencyToastSpec spec;
+  final VoidCallback onDismiss;
+  const _ToastCard({required this.spec, required this.onDismiss});
+
+  @override
+  State<_ToastCard> createState() => _ToastCardState();
+}
+
+class _ToastCardState extends State<_ToastCard>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 350),
+  )..forward();
+
+  late final Animation<double> _fade = CurvedAnimation(
+    parent: _ctrl,
+    curve: Curves.easeOut,
+  );
+
+  late final Animation<Offset> _slide = Tween<Offset>(
+    begin: const Offset(0, -0.15),
+    end: Offset.zero,
+  ).animate(_fade);
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final spec = widget.spec;
+    final tone = _toneStyle(spec.tone, c);
+
+    return FadeTransition(
+      opacity: _fade,
+      child: SlideTransition(
+        position: _slide,
+        child: Material(
+          color: c.surface,
+          elevation: 0,
+          borderRadius: BorderRadius.circular(14),
+          child: Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: c.line),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.08),
+                  blurRadius: 14,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (spec.person != null)
+                  FreqAvatar(person: spec.person!, size: 32)
+                else
+                  Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(
+                      color: tone.bg,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    alignment: Alignment.center,
+                    child: Icon(tone.icon, size: 15, color: tone.fg),
+                  ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        spec.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: c.ink,
+                          height: 1.25,
+                        ),
+                      ),
+                      if (spec.description != null) ...[
+                        const SizedBox(height: 1),
+                        Text(
+                          spec.description!,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontFamily: 'Inter',
+                            fontSize: 11,
+                            color: c.ink3,
+                            height: 1.3,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                if (spec.actions.isNotEmpty)
+                  ..._buildActions(context, spec.actions)
+                else
+                  IconButton(
+                    onPressed: widget.onDismiss,
+                    icon: Icon(Icons.close, size: 14, color: c.ink3),
+                    visualDensity: VisualDensity.compact,
+                    padding: const EdgeInsets.all(4),
+                    constraints: const BoxConstraints(
+                      minWidth: 28,
+                      minHeight: 28,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildActions(
+    BuildContext context,
+    List<ToastAction> actions,
+  ) {
+    final widgets = <Widget>[];
+    for (var i = 0; i < actions.length; i++) {
+      if (i > 0) widgets.add(const SizedBox(width: 6));
+      final a = actions[i];
+      widgets.add(
+        FreqButton(
+          label: a.label,
+          accent: a.primary,
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          fontSize: 12,
+          onPressed: () {
+            a.onTap();
+            widget.onDismiss();
+          },
+        ),
+      );
+    }
+    return widgets;
+  }
+}
+
+class _ToneStyle {
+  final Color bg;
+  final Color fg;
+  final IconData icon;
+  const _ToneStyle({required this.bg, required this.fg, required this.icon});
+}
+
+_ToneStyle _toneStyle(ToastTone tone, FrequencyColors c) {
+  switch (tone) {
+    case ToastTone.join:
+      return _ToneStyle(bg: c.accentSoft, fg: c.accentInk, icon: Icons.add);
+    case ToastTone.leave:
+      return _ToneStyle(bg: c.surface2, fg: c.ink2, icon: Icons.logout);
+    case ToastTone.warn:
+      return _ToneStyle(bg: c.warnSoft, fg: c.warn, icon: Icons.signal_cellular_alt);
+    case ToastTone.request:
+      return _ToneStyle(bg: c.surface, fg: c.ink, icon: Icons.people_outline);
+    case ToastTone.info:
+      return _ToneStyle(bg: c.surface2, fg: c.ink2, icon: Icons.radio);
+  }
+}

--- a/test/widgets/frequency_toast_host_test.dart
+++ b/test/widgets/frequency_toast_host_test.dart
@@ -59,9 +59,11 @@ void main() {
       await tester.pump();
       expect(find.text('Temporary'), findsOneWidget);
 
-      // Past auto-dismiss + entry animation.
+      // Wait past the auto-dismiss timer; the toast removes itself from the
+      // tree synchronously (no exit animation). The trailing pump just lets
+      // the rebuild settle.
       await tester.pump(const Duration(milliseconds: 600));
-      await tester.pump(const Duration(milliseconds: 400)); // exit animation
+      await tester.pump();
       expect(find.text('Temporary'), findsNothing);
     });
 

--- a/test/widgets/frequency_toast_host_test.dart
+++ b/test/widgets/frequency_toast_host_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/data/frequency_mock_data.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+import 'package:walkie_talkie/widgets/frequency_toast_host.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: AppTheme.light(),
+      home: Scaffold(
+        body: FrequencyToastHost(child: child),
+      ),
+    );
+
+void main() {
+  group('FrequencyToastHost', () {
+    testWidgets('renders nothing until something is pushed', (tester) async {
+      await tester.pumpWidget(_wrap(const SizedBox()));
+      await tester.pump();
+      expect(find.byType(FrequencyToastHost), findsOneWidget);
+      expect(find.text('hello'), findsNothing);
+    });
+
+    testWidgets('push surfaces title and optional description', (tester) async {
+      late FrequencyToastController toast;
+      await tester.pumpWidget(_wrap(
+        Builder(builder: (context) {
+          toast = FrequencyToastHost.of(context);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump();
+
+      toast.push(const FrequencyToastSpec(
+        title: 'Maya joined',
+        description: 'Right nearby',
+        autoDismiss: null,
+      ));
+      await tester.pump();
+
+      expect(find.text('Maya joined'), findsOneWidget);
+      expect(find.text('Right nearby'), findsOneWidget);
+    });
+
+    testWidgets('auto-dismiss removes the toast after the configured duration',
+        (tester) async {
+      late FrequencyToastController toast;
+      await tester.pumpWidget(_wrap(
+        Builder(builder: (context) {
+          toast = FrequencyToastHost.of(context);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump();
+
+      toast.push(const FrequencyToastSpec(
+        title: 'Temporary',
+        autoDismiss: Duration(milliseconds: 500),
+      ));
+      await tester.pump();
+      expect(find.text('Temporary'), findsOneWidget);
+
+      // Past auto-dismiss + entry animation.
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump(const Duration(milliseconds: 400)); // exit animation
+      expect(find.text('Temporary'), findsNothing);
+    });
+
+    testWidgets('autoDismiss: null keeps the toast sticky', (tester) async {
+      late FrequencyToastController toast;
+      await tester.pumpWidget(_wrap(
+        Builder(builder: (context) {
+          toast = FrequencyToastHost.of(context);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump();
+
+      toast.push(const FrequencyToastSpec(
+        title: 'Sticky',
+        autoDismiss: null,
+      ));
+      await tester.pump();
+
+      await tester.pump(const Duration(seconds: 5));
+      expect(find.text('Sticky'), findsOneWidget);
+    });
+
+    testWidgets('action button fires its callback and dismisses the toast',
+        (tester) async {
+      late FrequencyToastController toast;
+      var letInTaps = 0;
+      await tester.pumpWidget(_wrap(
+        Builder(builder: (context) {
+          toast = FrequencyToastHost.of(context);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump();
+
+      toast.push(FrequencyToastSpec(
+        title: 'Devon wants to tune in',
+        autoDismiss: null,
+        actions: [
+          ToastAction(label: 'Deny', onTap: () {}),
+          ToastAction(label: 'Let in', primary: true, onTap: () => letInTaps++),
+        ],
+      ));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      await tester.tap(find.text('Let in'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(letInTaps, 1);
+      expect(find.text('Devon wants to tune in'), findsNothing);
+    });
+
+    testWidgets('manual dismiss via the close icon removes the toast',
+        (tester) async {
+      late FrequencyToastController toast;
+      await tester.pumpWidget(_wrap(
+        Builder(builder: (context) {
+          toast = FrequencyToastHost.of(context);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump();
+
+      toast.push(const FrequencyToastSpec(
+        title: 'Closeable',
+        autoDismiss: null,
+      ));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('Closeable'), findsNothing);
+    });
+
+    testWidgets('multiple toasts stack in push order', (tester) async {
+      late FrequencyToastController toast;
+      await tester.pumpWidget(_wrap(
+        Builder(builder: (context) {
+          toast = FrequencyToastHost.of(context);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump();
+
+      toast.push(const FrequencyToastSpec(title: 'First', autoDismiss: null));
+      toast.push(const FrequencyToastSpec(title: 'Second', autoDismiss: null));
+      await tester.pump();
+
+      expect(find.text('First'), findsOneWidget);
+      expect(find.text('Second'), findsOneWidget);
+    });
+
+    testWidgets('person-bearing toasts render the avatar', (tester) async {
+      late FrequencyToastController toast;
+      await tester.pumpWidget(_wrap(
+        Builder(builder: (context) {
+          toast = FrequencyToastHost.of(context);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump();
+
+      toast.push(FrequencyToastSpec(
+        title: 'Maya joined the frequency',
+        person: kPeople[1], // Maya
+        autoDismiss: null,
+      ));
+      await tester.pump();
+
+      // Avatar paints initials; Maya's are 'MA'.
+      expect(find.text('MA'), findsOneWidget);
+    });
+  });
+}

--- a/test/widgets/frequency_toast_host_test.dart
+++ b/test/widgets/frequency_toast_host_test.dart
@@ -1,13 +1,18 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/data/frequency_mock_data.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/frequency_toast_host.dart';
 
+// The host's `Stack` uses `StackFit.passthrough` so it can wrap a Navigator
+// (the production placement). In tests we pass small content as the child,
+// so wrap it in `SizedBox.expand` to give the host real bounds.
 Widget _wrap(Widget child) => MaterialApp(
       theme: AppTheme.light(),
       home: Scaffold(
-        body: FrequencyToastHost(child: child),
+        body: FrequencyToastHost(child: SizedBox.expand(child: child)),
       ),
     );
 
@@ -180,6 +185,98 @@ void main() {
 
       // Avatar paints initials; Maya's are 'MA'.
       expect(find.text('MA'), findsOneWidget);
+    });
+  });
+
+  group('FrequencyToastHost in MaterialApp.builder placement', () {
+    // Regression for the production wiring in lib/main.dart: the host wraps
+    // the navigator via `builder`, so toasts pushed while a modal route is
+    // open must still render above the modal's barrier+content. A host
+    // placed inside `home` (the previous shape) would render below the
+    // modal and these tests would fail.
+
+    Widget builderApp() => MaterialApp(
+          theme: AppTheme.light(),
+          builder: (context, child) => FrequencyToastHost(child: child!),
+          home: const Scaffold(body: SizedBox.expand()),
+        );
+
+    testWidgets('toast pushed before opening a modal sheet remains visible',
+        (tester) async {
+      await tester.pumpWidget(builderApp());
+
+      // Push a sticky toast from the home route's context.
+      final homeContext = tester.element(find.byType(Scaffold));
+      FrequencyToastHost.of(homeContext).push(const FrequencyToastSpec(
+        title: 'Floating',
+        autoDismiss: null,
+      ));
+      await tester.pump();
+      expect(find.text('Floating'), findsOneWidget);
+
+      // Open a modal sheet; the toast must keep rendering.
+      unawaited(showModalBottomSheet<void>(
+        context: homeContext,
+        isScrollControlled: true,
+        builder: (_) => const SizedBox(
+          height: 200,
+          child: Center(child: Text('SheetBody')),
+        ),
+      ));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('SheetBody'), findsOneWidget);
+      expect(find.text('Floating'), findsOneWidget);
+    });
+
+    testWidgets('toast pushed FROM inside a modal sheet renders above it',
+        (tester) async {
+      await tester.pumpWidget(builderApp());
+
+      final homeContext = tester.element(find.byType(Scaffold));
+
+      // Open a modal sheet whose body can push a toast using its own context
+      // (which lives inside the modal route). The host above the navigator
+      // must still be reachable via findAncestorStateOfType.
+      unawaited(showModalBottomSheet<void>(
+        context: homeContext,
+        isScrollControlled: true,
+        builder: (sheetCtx) => SizedBox(
+          height: 200,
+          child: Center(
+            child: TextButton(
+              onPressed: () => FrequencyToastHost.of(sheetCtx).push(
+                const FrequencyToastSpec(
+                  title: 'FromInsideSheet',
+                  autoDismiss: null,
+                ),
+              ),
+              child: const Text('Push toast'),
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      await tester.tap(find.text('Push toast'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.text('FromInsideSheet'), findsOneWidget);
+
+      // The toast's top edge sits above the sheet's top edge. If the host
+      // were inside the route, the sheet's overlay would paint over the
+      // toast and this comparison would fail.
+      final toastTopY =
+          tester.getTopLeft(find.text('FromInsideSheet')).dy;
+      final sheetTopY = tester.getTopLeft(find.text('Push toast')).dy;
+      expect(
+        toastTopY,
+        lessThan(sheetTopY),
+        reason: 'Toast should render above the sheet content.',
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes [#11](https://github.com/ElodinLaarz/walkie-talkie/issues/11).

The design's toast system is distinct from Material's `SnackBar`: top-of-frame placement, sticky-with-actions for host prompts, auto-dismissing for confirmations, tone-tinted icons, and an avatar slot for "Devon wants to tune in"-style requests. The room screen has been falling back to `ScaffoldMessenger.showSnackBar` in three places — host join request, weak-signal warning, peer-removed confirmation — which is the wrong shape (bottom-anchored, single-line, no avatar).

## What changed

**New: [`lib/widgets/frequency_toast_host.dart`](lib/widgets/frequency_toast_host.dart)**
- `FrequencyToastHost` — `Stack` overlay widget that wraps a child and pins toasts to the top of the frame.
- `FrequencyToastHost.of(context)` — returns a `FrequencyToastController` with `push(spec)` / `dismiss(id)`.
- `FrequencyToastSpec` covers tone (`info` / `join` / `leave` / `warn` / `request`), an optional `Person` (renders an avatar instead of the tone icon), `autoDismiss: null` for sticky, and a list of `ToastAction`s. When actions are present they replace the close icon — tapping any action fires its callback and dismisses the toast.
- Each toast fades + slides in over ~350ms.

**Wired at `FrequencyApp` level** — every screen below can push, toasts persist across stage transitions (auto-dismiss handles the rest).

**Replaced the three SnackBar calls in [`frequency_room_screen.dart`](lib/screens/frequency_room_screen.dart):**
- Host join request → sticky `request` toast with `Deny` / `Let in` actions.
- Weak-signal warning → `warn` toast with 3.6s auto-dismiss.
- Peer removed → `leave` toast with the default 3.2s auto-dismiss.

## Tests

8 new widget tests in [`test/widgets/frequency_toast_host_test.dart`](test/widgets/frequency_toast_host_test.dart):
- Empty state (no toasts until pushed)
- Push surfaces title + description
- Auto-dismiss removes the toast after the configured duration
- `autoDismiss: null` stays sticky
- Action callback fires and dismisses on tap
- Manual close icon dismisses
- Multiple toasts stack in push order
- `person`-bearing toasts render the avatar (initials)

## Reviewer notes

- The host uses `findAncestorStateOfType` rather than `InheritedWidget` because the controller needs imperative `push`/`dismiss` semantics (similar to `ScaffoldMessenger.of(context).showSnackBar`) — an `InheritedWidget` would force notify-on-every-toast which is wrong shape.
- `FrequencyToastHost` lives at `FrequencyApp` (above the `AnimatedSwitcher`), so it's preserved across stage transitions. If a sticky toast is pushed in the Room and the user leaves, the toast stays — that's deliberate and matches what you'd expect (ScaffoldMessenger does the same with persistent SnackBars). Future PRs that want different scoping can wrap an additional host below.
- 68 tests pass locally, analyze clean.

## Test plan

- [ ] CI green
- [ ] Room screen, host mode: ~3s after entering, sticky "wants to tune in" toast appears with Deny/Let in. Tapping either dismisses; tapping outside doesn't.
- [ ] Room screen, any mode: ~7s in, weak-signal warn toast appears with amber tint, auto-dismisses.
- [ ] Open peer drawer (host) → Remove → toast confirms removal, auto-dismisses.
- [ ] Light + dark themes both render the toast surfaces cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app toast notification system: animated top overlay stack with tones, avatars, actions, and configurable auto-dismiss/sticky behavior.
  * Toast host now wraps the navigation subtree so notifications appear above pushed routes and modal overlays.
  * Replaced prior transient notifications in the room screen with the new interactive toasts (join requests, warnings, peer events).

* **Tests**
  * Added widget tests validating toast display, timing, actions, dismissal, and avatar rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->