### PR TITLE
Introduce FrequencySessionCubit for session-level state

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -5,12 +5,12 @@ import '../services/identity_store.dart';
 import 'frequency_session_state.dart';
 
 /// Owns session-level Frequency state and the side-effects that mutate it:
-/// reading and persisting the user's display name, advancing the navigation
-/// stage, and tracking which frequency the user joined.
+/// reading and persisting the user's display name, advancing the
+/// navigation stage, and tracking which frequency the user joined.
 ///
 /// Created by `WalkieTalkieApp` and provided to the widget tree via
 /// `BlocProvider`. Screens read state with `BlocBuilder` and dispatch via
-/// the cubit's methods (no setState in `FrequencyApp`).
+/// the cubit's methods.
 ///
 /// Side-effects through the [identityStore] (a filesystem boundary) are
 /// wrapped in try/catch: persistence failures are logged but never block
@@ -20,11 +20,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   final IdentityStore identityStore;
 
   FrequencySessionCubit({required this.identityStore})
-      : super(const FrequencySessionState.booting());
+      : super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
-  /// exists, otherwise into Onboarding. Always exits the booting stage —
-  /// even if the read throws, so we never strand the user on the splash.
+  /// exists, otherwise into Onboarding. Always exits Booting — even if the
+  /// read throws — so the user never strands on the splash.
   Future<void> bootstrap() async {
     String? persisted;
     try {
@@ -33,18 +33,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       debugPrint('Failed to load persisted display name: $error');
       debugPrintStack(stackTrace: stackTrace);
     }
-    if (persisted != null) {
-      emit(state.copyWith(
-        stage: SessionStage.discovery,
-        myName: persisted,
-      ));
-    } else {
-      emit(state.copyWith(stage: SessionStage.onboarding));
-    }
+    if (isClosed) return;
+    emit(persisted != null
+        ? SessionDiscovery(myName: persisted)
+        : const SessionOnboarding());
   }
 
-  /// Persists [name] and advances to Discovery. The in-memory name updates
-  /// even if the write fails so the user isn't stranded on the name screen.
+  /// Persists [name] and advances to Discovery. The state changes even if
+  /// the write fails so the user isn't stranded on the name screen.
   Future<void> completeOnboarding(String name) async {
     try {
       await identityStore.setDisplayName(name);
@@ -52,11 +48,16 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       debugPrint('Failed to persist display name: $error');
       debugPrintStack(stackTrace: stackTrace);
     }
-    emit(state.copyWith(stage: SessionStage.discovery, myName: name));
+    if (isClosed) return;
+    emit(SessionDiscovery(myName: name));
   }
 
   /// Persists the new [name] without changing the current stage. Same
   /// failure semantics as [completeOnboarding].
+  ///
+  /// Only makes sense after onboarding — calls in Booting/Onboarding are
+  /// no-ops on the visible state (the next stage transition will pick up
+  /// whatever the store now holds).
   Future<void> rename(String name) async {
     try {
       await identityStore.setDisplayName(name);
@@ -64,24 +65,41 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       debugPrint('Failed to persist display name: $error');
       debugPrintStack(stackTrace: stackTrace);
     }
-    emit(state.copyWith(myName: name));
+    if (isClosed) return;
+    switch (state) {
+      case SessionDiscovery():
+        emit(SessionDiscovery(myName: name));
+      case SessionRoom(:final roomFreq, :final roomIsHost):
+        emit(SessionRoom(
+          myName: name,
+          roomFreq: roomFreq,
+          roomIsHost: roomIsHost,
+        ));
+      case SessionBooting():
+      case SessionOnboarding():
+        break;
+    }
   }
 
-  /// Enters the Room stage on [freq]. [isHost] is true when the user
-  /// created the frequency, false when they tuned in to someone else's.
+  /// Enters Room on [freq]. [isHost] is true when the user created the
+  /// frequency, false when they tuned in to an existing one. No-op if
+  /// the user isn't on Discovery (shouldn't happen — Discovery is the
+  /// only screen that triggers it).
   void joinRoom({required String freq, required bool isHost}) {
-    emit(state.copyWith(
-      stage: SessionStage.room,
+    final current = state;
+    if (current is! SessionDiscovery) return;
+    emit(SessionRoom(
+      myName: current.myName,
       roomFreq: freq,
       roomIsHost: isHost,
     ));
   }
 
-  /// Drops the user back on Discovery and clears the current-room fields.
+  /// Drops back to Discovery and forgets the room. No-op if not in a
+  /// room (e.g. duplicate leave triggered during a transition).
   void leaveRoom() {
-    emit(state.copyWith(
-      stage: SessionStage.discovery,
-      clearRoom: true,
-    ));
+    final current = state;
+    if (current is! SessionRoom) return;
+    emit(SessionDiscovery(myName: current.myName));
   }
 }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../services/identity_store.dart';
+import 'frequency_session_state.dart';
+
+/// Owns session-level Frequency state and the side-effects that mutate it:
+/// reading and persisting the user's display name, advancing the navigation
+/// stage, and tracking which frequency the user joined.
+///
+/// Created by `WalkieTalkieApp` and provided to the widget tree via
+/// `BlocProvider`. Screens read state with `BlocBuilder` and dispatch via
+/// the cubit's methods (no setState in `FrequencyApp`).
+///
+/// Side-effects through the [identityStore] (a filesystem boundary) are
+/// wrapped in try/catch: persistence failures are logged but never block
+/// the UI from advancing — the rename takes effect in memory and surfaces
+/// the divergence on next launch when the previous value loads back.
+class FrequencySessionCubit extends Cubit<FrequencySessionState> {
+  final IdentityStore identityStore;
+
+  FrequencySessionCubit({required this.identityStore})
+      : super(const FrequencySessionState.booting());
+
+  /// Reads the persisted display name; routes the user to Discovery if one
+  /// exists, otherwise into Onboarding. Always exits the booting stage —
+  /// even if the read throws, so we never strand the user on the splash.
+  Future<void> bootstrap() async {
+    String? persisted;
+    try {
+      persisted = await identityStore.getDisplayName();
+    } catch (error, stackTrace) {
+      debugPrint('Failed to load persisted display name: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
+    if (persisted != null) {
+      emit(state.copyWith(
+        stage: SessionStage.discovery,
+        myName: persisted,
+      ));
+    } else {
+      emit(state.copyWith(stage: SessionStage.onboarding));
+    }
+  }
+
+  /// Persists [name] and advances to Discovery. The in-memory name updates
+  /// even if the write fails so the user isn't stranded on the name screen.
+  Future<void> completeOnboarding(String name) async {
+    try {
+      await identityStore.setDisplayName(name);
+    } catch (error, stackTrace) {
+      debugPrint('Failed to persist display name: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
+    emit(state.copyWith(stage: SessionStage.discovery, myName: name));
+  }
+
+  /// Persists the new [name] without changing the current stage. Same
+  /// failure semantics as [completeOnboarding].
+  Future<void> rename(String name) async {
+    try {
+      await identityStore.setDisplayName(name);
+    } catch (error, stackTrace) {
+      debugPrint('Failed to persist display name: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
+    emit(state.copyWith(myName: name));
+  }
+
+  /// Enters the Room stage on [freq]. [isHost] is true when the user
+  /// created the frequency, false when they tuned in to someone else's.
+  void joinRoom({required String freq, required bool isHost}) {
+    emit(state.copyWith(
+      stage: SessionStage.room,
+      roomFreq: freq,
+      roomIsHost: isHost,
+    ));
+  }
+
+  /// Drops the user back on Discovery and clears the current-room fields.
+  void leaveRoom() {
+    emit(state.copyWith(
+      stage: SessionStage.discovery,
+      clearRoom: true,
+    ));
+  }
+}

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -1,53 +1,51 @@
 import 'package:equatable/equatable.dart';
 
-/// High-level navigation stages for the Frequency app.
-enum SessionStage { booting, onboarding, discovery, room }
+/// Sealed hierarchy describing the session-level Frequency state. Each
+/// stage carries exactly the fields it needs — the UI exhaustively
+/// switches on the runtime type and the analyzer flags missing branches.
+/// Force-unwraps and "is this field set?" plumbing aren't required.
+sealed class FrequencySessionState extends Equatable {
+  const FrequencySessionState();
+}
 
-/// Single source of truth for session-level Frequency state: which screen
-/// the user is on, who they are, and (when in a room) which frequency they
-/// joined and whether they're the host.
-///
-/// Room-internal state (roster, mute, media playback, output selection) is
-/// still owned by `FrequencyRoomScreen` for now and will migrate here in a
-/// follow-up PR.
-class FrequencySessionState extends Equatable {
-  final SessionStage stage;
-  final String myName;
-  final String? roomFreq;
-  final bool roomIsHost;
-
-  const FrequencySessionState({
-    required this.stage,
-    required this.myName,
-    this.roomFreq,
-    this.roomIsHost = false,
-  });
-
-  /// Initial state: app just launched, identity store hasn't been read yet.
-  const FrequencySessionState.booting()
-      : stage = SessionStage.booting,
-        myName = '',
-        roomFreq = null,
-        roomIsHost = false;
-
-  /// Returns a copy with updated fields. Pass `clearRoom: true` to drop
-  /// `roomFreq` / `roomIsHost` regardless of the corresponding parameters
-  /// (used on `leaveRoom`).
-  FrequencySessionState copyWith({
-    SessionStage? stage,
-    String? myName,
-    String? roomFreq,
-    bool? roomIsHost,
-    bool clearRoom = false,
-  }) {
-    return FrequencySessionState(
-      stage: stage ?? this.stage,
-      myName: myName ?? this.myName,
-      roomFreq: clearRoom ? null : (roomFreq ?? this.roomFreq),
-      roomIsHost: clearRoom ? false : (roomIsHost ?? this.roomIsHost),
-    );
-  }
+/// App just launched; the identity store hasn't been read yet.
+final class SessionBooting extends FrequencySessionState {
+  const SessionBooting();
 
   @override
-  List<Object?> get props => [stage, myName, roomFreq, roomIsHost];
+  List<Object?> get props => const [];
+}
+
+/// No persisted display name; the user is going through onboarding.
+final class SessionOnboarding extends FrequencySessionState {
+  const SessionOnboarding();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// User has a persisted display name and is on Discovery, but hasn't
+/// joined or created a frequency yet.
+final class SessionDiscovery extends FrequencySessionState {
+  final String myName;
+  const SessionDiscovery({required this.myName});
+
+  @override
+  List<Object?> get props => [myName];
+}
+
+/// User is in a room. Both [roomFreq] and [roomIsHost] are non-nullable
+/// by construction, so the UI can read them without force-unwrapping.
+final class SessionRoom extends FrequencySessionState {
+  final String myName;
+  final String roomFreq;
+  final bool roomIsHost;
+  const SessionRoom({
+    required this.myName,
+    required this.roomFreq,
+    required this.roomIsHost,
+  });
+
+  @override
+  List<Object?> get props => [myName, roomFreq, roomIsHost];
 }

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -1,0 +1,53 @@
+import 'package:equatable/equatable.dart';
+
+/// High-level navigation stages for the Frequency app.
+enum SessionStage { booting, onboarding, discovery, room }
+
+/// Single source of truth for session-level Frequency state: which screen
+/// the user is on, who they are, and (when in a room) which frequency they
+/// joined and whether they're the host.
+///
+/// Room-internal state (roster, mute, media playback, output selection) is
+/// still owned by `FrequencyRoomScreen` for now and will migrate here in a
+/// follow-up PR.
+class FrequencySessionState extends Equatable {
+  final SessionStage stage;
+  final String myName;
+  final String? roomFreq;
+  final bool roomIsHost;
+
+  const FrequencySessionState({
+    required this.stage,
+    required this.myName,
+    this.roomFreq,
+    this.roomIsHost = false,
+  });
+
+  /// Initial state: app just launched, identity store hasn't been read yet.
+  const FrequencySessionState.booting()
+      : stage = SessionStage.booting,
+        myName = '',
+        roomFreq = null,
+        roomIsHost = false;
+
+  /// Returns a copy with updated fields. Pass `clearRoom: true` to drop
+  /// `roomFreq` / `roomIsHost` regardless of the corresponding parameters
+  /// (used on `leaveRoom`).
+  FrequencySessionState copyWith({
+    SessionStage? stage,
+    String? myName,
+    String? roomFreq,
+    bool? roomIsHost,
+    bool clearRoom = false,
+  }) {
+    return FrequencySessionState(
+      stage: stage ?? this.stage,
+      myName: myName ?? this.myName,
+      roomFreq: clearRoom ? null : (roomFreq ?? this.roomFreq),
+      roomIsHost: clearRoom ? false : (roomIsHost ?? this.roomIsHost),
+    );
+  }
+
+  @override
+  List<Object?> get props => [stage, myName, roomFreq, roomIsHost];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,9 +46,9 @@ class WalkieTalkieApp extends StatelessWidget {
   }
 }
 
-/// Selects a screen based on the current `SessionStage`. State and the
-/// transitions between stages live in [FrequencySessionCubit]; this widget
-/// is a pure projection of `FrequencySessionState`.
+/// Selects a screen based on the runtime type of `FrequencySessionState`.
+/// State and the transitions between stages live in
+/// [FrequencySessionCubit]; this widget is a pure projection.
 class FrequencyApp extends StatelessWidget {
   const FrequencyApp({super.key});
 
@@ -59,7 +59,7 @@ class FrequencyApp extends StatelessWidget {
         return AnimatedSwitcher(
           duration: const Duration(milliseconds: 280),
           child: KeyedSubtree(
-            key: ValueKey(state.stage),
+            key: ValueKey(state.runtimeType),
             child: _buildStage(context, state),
           ),
         );
@@ -69,31 +69,36 @@ class FrequencyApp extends StatelessWidget {
 
   Widget _buildStage(BuildContext context, FrequencySessionState state) {
     final cubit = context.read<FrequencySessionCubit>();
-    switch (state.stage) {
-      case SessionStage.booting:
-        return const _BootSplash();
-      case SessionStage.onboarding:
-        return FrequencyOnboardingScreen(onDone: cubit.completeOnboarding);
-      case SessionStage.discovery:
-        return FrequencyDiscoveryScreen(
-          myName: state.myName,
-          onRename: cubit.rename,
+    return switch (state) {
+      SessionBooting() => const _BootSplash(),
+      SessionOnboarding() => FrequencyOnboardingScreen(
+          // Wrap in a void closure so the screen's `ValueChanged<String>`
+          // signature isn't asked to absorb the cubit's `Future<void>`.
+          onDone: (name) {
+            cubit.completeOnboarding(name);
+          },
+        ),
+      SessionDiscovery(:final myName) => FrequencyDiscoveryScreen(
+          myName: myName,
+          onRename: (name) {
+            cubit.rename(name);
+          },
           onPick: (result) => cubit.joinRoom(
             freq: result.freq,
             isHost: result.isHost,
           ),
-        );
-      case SessionStage.room:
-        return FrequencyRoomScreen(
-          freq: state.roomFreq!,
-          isHost: state.roomIsHost,
-          myName: state.myName,
+        ),
+      SessionRoom(:final myName, :final roomFreq, :final roomIsHost) =>
+        FrequencyRoomScreen(
+          freq: roomFreq,
+          isHost: roomIsHost,
+          myName: myName,
           groupSize: 5,
           mediaKind: MediaKind.music,
           pttMode: false,
           onLeave: cubit.leaveRoom,
-        );
-    }
+        ),
+    };
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
+import 'bloc/frequency_session_cubit.dart';
+import 'bloc/frequency_session_state.dart';
 import 'data/frequency_mock_data.dart';
 import 'screens/frequency_discovery_screen.dart';
 import 'screens/frequency_onboarding_screen.dart';
@@ -23,145 +26,80 @@ class WalkieTalkieApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Frequency',
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.light(),
-      darkTheme: AppTheme.dark(),
-      themeMode: ThemeMode.system,
-      // Wrap the navigator so toasts stay above pushed routes (modal bottom
-      // sheets, etc.) — a host inside `home` would render below the modal
-      // overlay and get hidden when a sheet is open.
-      builder: (context, child) => FrequencyToastHost(child: child!),
-      home: FrequencyApp(identityStore: identityStore ?? HiveIdentityStore()),
-    );
-  }
-}
-
-/// Root navigator for the prototype: Onboarding → Discovery → Room.
-///
-/// On startup we read a persisted display name from [identityStore]. If one is
-/// present we skip onboarding and land on Discovery; otherwise the user is
-/// taken through the onboarding flow and the chosen name is persisted.
-class FrequencyApp extends StatefulWidget {
-  final IdentityStore identityStore;
-
-  const FrequencyApp({super.key, required this.identityStore});
-
-  @override
-  State<FrequencyApp> createState() => _FrequencyAppState();
-}
-
-enum _Stage { booting, onboarding, discovery, room }
-
-class _FrequencyAppState extends State<FrequencyApp> {
-  _Stage _stage = _Stage.booting;
-  String _myName = '';
-  String _freq = '104.3';
-  bool _isHost = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _bootstrap();
-  }
-
-  Future<void> _bootstrap() async {
-    String? persisted;
-    try {
-      persisted = await widget.identityStore.getDisplayName();
-    } catch (error, stackTrace) {
-      // Hive lives on the filesystem; corruption or disk failure can throw
-      // here. Don't strand the user on the splash — fall back to onboarding,
-      // which will overwrite whatever was on disk on completion.
-      debugPrint('Failed to load persisted display name: $error');
-      debugPrintStack(stackTrace: stackTrace);
-    }
-    if (!mounted) return;
-    setState(() {
-      if (persisted != null) {
-        _myName = persisted;
-        _stage = _Stage.discovery;
-      } else {
-        _stage = _Stage.onboarding;
-      }
-    });
-  }
-
-  Future<void> _onOnboardingDone(String name) async {
-    try {
-      await widget.identityStore.setDisplayName(name);
-    } catch (error, stackTrace) {
-      // Persistence failed — accept the in-memory name so the user isn't
-      // stranded on the name screen. They'll be re-onboarded next launch.
-      debugPrint('Failed to persist display name: $error');
-      debugPrintStack(stackTrace: stackTrace);
-    }
-    if (!mounted) return;
-    setState(() {
-      _myName = name;
-      _stage = _Stage.discovery;
-    });
-  }
-
-  Future<void> _onRenameRequested(String name) async {
-    try {
-      await widget.identityStore.setDisplayName(name);
-    } catch (error, stackTrace) {
-      // Same trade-off as onboarding completion: keep the new name in memory
-      // so the rename UI feels responsive; the failure surfaces next launch
-      // when the previous name is loaded back.
-      debugPrint('Failed to persist display name: $error');
-      debugPrintStack(stackTrace: stackTrace);
-    }
-    if (!mounted) return;
-    setState(() => _myName = name);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 280),
-      child: KeyedSubtree(
-        key: ValueKey(_stage),
-        child: _buildStage(),
+    return BlocProvider(
+      create: (_) => FrequencySessionCubit(
+        identityStore: identityStore ?? HiveIdentityStore(),
+      )..bootstrap(),
+      child: MaterialApp(
+        title: 'Frequency',
+        debugShowCheckedModeBanner: false,
+        theme: AppTheme.light(),
+        darkTheme: AppTheme.dark(),
+        themeMode: ThemeMode.system,
+        // Wrap the navigator so toasts stay above pushed routes (modal bottom
+        // sheets, etc.) — a host inside `home` would render below the modal
+        // overlay and get hidden when a sheet is open.
+        builder: (context, child) => FrequencyToastHost(child: child!),
+        home: const FrequencyApp(),
       ),
     );
   }
+}
 
-  Widget _buildStage() {
-    switch (_stage) {
-      case _Stage.booting:
-        return const _BootSplash();
-      case _Stage.onboarding:
-        return FrequencyOnboardingScreen(onDone: _onOnboardingDone);
-      case _Stage.discovery:
-        return FrequencyDiscoveryScreen(
-          myName: _myName,
-          onRename: _onRenameRequested,
-          onPick: (result) => setState(() {
-            _freq = result.freq;
-            _isHost = result.isHost;
-            _stage = _Stage.room;
-          }),
+/// Selects a screen based on the current `SessionStage`. State and the
+/// transitions between stages live in [FrequencySessionCubit]; this widget
+/// is a pure projection of `FrequencySessionState`.
+class FrequencyApp extends StatelessWidget {
+  const FrequencyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<FrequencySessionCubit, FrequencySessionState>(
+      builder: (context, state) {
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 280),
+          child: KeyedSubtree(
+            key: ValueKey(state.stage),
+            child: _buildStage(context, state),
+          ),
         );
-      case _Stage.room:
+      },
+    );
+  }
+
+  Widget _buildStage(BuildContext context, FrequencySessionState state) {
+    final cubit = context.read<FrequencySessionCubit>();
+    switch (state.stage) {
+      case SessionStage.booting:
+        return const _BootSplash();
+      case SessionStage.onboarding:
+        return FrequencyOnboardingScreen(onDone: cubit.completeOnboarding);
+      case SessionStage.discovery:
+        return FrequencyDiscoveryScreen(
+          myName: state.myName,
+          onRename: cubit.rename,
+          onPick: (result) => cubit.joinRoom(
+            freq: result.freq,
+            isHost: result.isHost,
+          ),
+        );
+      case SessionStage.room:
         return FrequencyRoomScreen(
-          freq: _freq,
-          isHost: _isHost,
-          myName: _myName,
+          freq: state.roomFreq!,
+          isHost: state.roomIsHost,
+          myName: state.myName,
           groupSize: 5,
           mediaKind: MediaKind.music,
           pttMode: false,
-          onLeave: () => setState(() => _stage = _Stage.discovery),
+          onLeave: cubit.leaveRoom,
         );
     }
   }
 }
 
-/// Brief blank splash while we read the persisted identity. We expect Hive's
-/// box open to take a couple frames at most; rendering a stripped-down
-/// background avoids a flash of the wrong screen.
+/// Brief blank splash while the cubit reads the persisted identity. We
+/// expect Hive's box-open to take a couple of frames at most; rendering a
+/// stripped-down background avoids a flash of the wrong screen.
 class _BootSplash extends StatelessWidget {
   const _BootSplash();
 

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1,0 +1,216 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/bloc/frequency_session_cubit.dart';
+import 'package:walkie_talkie/bloc/frequency_session_state.dart';
+import 'package:walkie_talkie/services/identity_store.dart';
+
+class _FakeStore implements IdentityStore {
+  String? _name;
+  bool throwOnGet = false;
+  bool throwOnSet = false;
+  int setCalls = 0;
+
+  _FakeStore({String? initial}) : _name = initial;
+
+  @override
+  Future<String?> getDisplayName() async {
+    if (throwOnGet) throw StateError('boom');
+    return _name;
+  }
+
+  @override
+  Future<void> setDisplayName(String value) async {
+    setCalls++;
+    if (throwOnSet) throw StateError('boom');
+    final trimmed = value.trim();
+    _name = trimmed.isEmpty ? null : trimmed;
+  }
+}
+
+void main() {
+  group('FrequencySessionCubit', () {
+    test('starts in the booting stage with no name', () {
+      final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+      expect(cubit.state.stage, SessionStage.booting);
+      expect(cubit.state.myName, '');
+      expect(cubit.state.roomFreq, isNull);
+      expect(cubit.state.roomIsHost, isFalse);
+    });
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'bootstrap with a persisted name routes to discovery',
+      build: () => FrequencySessionCubit(
+        identityStore: _FakeStore(initial: 'Maya'),
+      ),
+      act: (cubit) => cubit.bootstrap(),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.discovery,
+          myName: 'Maya',
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'bootstrap without a persisted name routes to onboarding',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      act: (cubit) => cubit.bootstrap(),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.onboarding,
+          myName: '',
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'bootstrap falls through to onboarding when the store throws',
+      build: () => FrequencySessionCubit(
+        identityStore: _FakeStore()..throwOnGet = true,
+      ),
+      act: (cubit) => cubit.bootstrap(),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.onboarding,
+          myName: '',
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'completeOnboarding persists and advances to discovery',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      seed: () => const FrequencySessionState(
+        stage: SessionStage.onboarding,
+        myName: '',
+      ),
+      act: (cubit) => cubit.completeOnboarding('Devon'),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.discovery,
+          myName: 'Devon',
+        ),
+      ],
+      verify: (cubit) async {
+        // setDisplayName actually got called.
+        expect((cubit.identityStore as _FakeStore).setCalls, 1);
+        expect(await cubit.identityStore.getDisplayName(), 'Devon');
+      },
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'completeOnboarding still advances when persistence throws',
+      build: () => FrequencySessionCubit(
+        identityStore: _FakeStore()..throwOnSet = true,
+      ),
+      seed: () => const FrequencySessionState(
+        stage: SessionStage.onboarding,
+        myName: '',
+      ),
+      act: (cubit) => cubit.completeOnboarding('Sam'),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.discovery,
+          myName: 'Sam',
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'rename updates the name without changing the stage',
+      build: () => FrequencySessionCubit(
+        identityStore: _FakeStore(initial: 'Maya'),
+      ),
+      seed: () => const FrequencySessionState(
+        stage: SessionStage.discovery,
+        myName: 'Maya',
+      ),
+      act: (cubit) => cubit.rename('Maya R.'),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.discovery,
+          myName: 'Maya R.',
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'joinRoom enters the room stage with the freq and host flag',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      seed: () => const FrequencySessionState(
+        stage: SessionStage.discovery,
+        myName: 'Maya',
+      ),
+      act: (cubit) => cubit.joinRoom(freq: '104.3', isHost: true),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.room,
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: true,
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'leaveRoom drops the room fields and goes back to discovery',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      seed: () => const FrequencySessionState(
+        stage: SessionStage.room,
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: true,
+      ),
+      act: (cubit) => cubit.leaveRoom(),
+      expect: () => [
+        const FrequencySessionState(
+          stage: SessionStage.discovery,
+          myName: 'Maya',
+          roomFreq: null,
+          roomIsHost: false,
+        ),
+      ],
+    );
+  });
+
+  group('FrequencySessionState', () {
+    test('copyWith preserves untouched fields', () {
+      const a = FrequencySessionState(
+        stage: SessionStage.room,
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: true,
+      );
+      final b = a.copyWith(myName: 'Maya R.');
+      expect(b.stage, SessionStage.room);
+      expect(b.myName, 'Maya R.');
+      expect(b.roomFreq, '104.3');
+      expect(b.roomIsHost, isTrue);
+    });
+
+    test('copyWith(clearRoom: true) drops both room fields', () {
+      const a = FrequencySessionState(
+        stage: SessionStage.room,
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: true,
+      );
+      final b = a.copyWith(stage: SessionStage.discovery, clearRoom: true);
+      expect(b.stage, SessionStage.discovery);
+      expect(b.roomFreq, isNull);
+      expect(b.roomIsHost, isFalse);
+    });
+
+    test('equatable equality treats identical fields as equal', () {
+      const a = FrequencySessionState(
+        stage: SessionStage.discovery,
+        myName: 'Maya',
+      );
+      const b = FrequencySessionState(
+        stage: SessionStage.discovery,
+        myName: 'Maya',
+      );
+      expect(a, equals(b));
+    });
+  });
+}

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -29,70 +29,43 @@ class _FakeStore implements IdentityStore {
 
 void main() {
   group('FrequencySessionCubit', () {
-    test('starts in the booting stage with no name', () {
+    test('starts in SessionBooting', () {
       final cubit = FrequencySessionCubit(identityStore: _FakeStore());
-      expect(cubit.state.stage, SessionStage.booting);
-      expect(cubit.state.myName, '');
-      expect(cubit.state.roomFreq, isNull);
-      expect(cubit.state.roomIsHost, isFalse);
+      expect(cubit.state, isA<SessionBooting>());
     });
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'bootstrap with a persisted name routes to discovery',
+      'bootstrap with a persisted name routes to Discovery',
       build: () => FrequencySessionCubit(
         identityStore: _FakeStore(initial: 'Maya'),
       ),
       act: (cubit) => cubit.bootstrap(),
-      expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.discovery,
-          myName: 'Maya',
-        ),
-      ],
+      expect: () => [const SessionDiscovery(myName: 'Maya')],
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'bootstrap without a persisted name routes to onboarding',
+      'bootstrap without a persisted name routes to Onboarding',
       build: () => FrequencySessionCubit(identityStore: _FakeStore()),
       act: (cubit) => cubit.bootstrap(),
-      expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.onboarding,
-          myName: '',
-        ),
-      ],
+      expect: () => [const SessionOnboarding()],
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'bootstrap falls through to onboarding when the store throws',
+      'bootstrap falls through to Onboarding when the store throws',
       build: () => FrequencySessionCubit(
         identityStore: _FakeStore()..throwOnGet = true,
       ),
       act: (cubit) => cubit.bootstrap(),
-      expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.onboarding,
-          myName: '',
-        ),
-      ],
+      expect: () => [const SessionOnboarding()],
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'completeOnboarding persists and advances to discovery',
+      'completeOnboarding persists and advances to Discovery',
       build: () => FrequencySessionCubit(identityStore: _FakeStore()),
-      seed: () => const FrequencySessionState(
-        stage: SessionStage.onboarding,
-        myName: '',
-      ),
+      seed: () => const SessionOnboarding(),
       act: (cubit) => cubit.completeOnboarding('Devon'),
-      expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.discovery,
-          myName: 'Devon',
-        ),
-      ],
+      expect: () => [const SessionDiscovery(myName: 'Devon')],
       verify: (cubit) async {
-        // setDisplayName actually got called.
         expect((cubit.identityStore as _FakeStore).setCalls, 1);
         expect(await cubit.identityStore.getDisplayName(), 'Devon');
       },
@@ -103,48 +76,64 @@ void main() {
       build: () => FrequencySessionCubit(
         identityStore: _FakeStore()..throwOnSet = true,
       ),
-      seed: () => const FrequencySessionState(
-        stage: SessionStage.onboarding,
-        myName: '',
-      ),
+      seed: () => const SessionOnboarding(),
       act: (cubit) => cubit.completeOnboarding('Sam'),
-      expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.discovery,
-          myName: 'Sam',
-        ),
-      ],
+      expect: () => [const SessionDiscovery(myName: 'Sam')],
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'rename updates the name without changing the stage',
+      'rename in Discovery updates the name in place',
       build: () => FrequencySessionCubit(
         identityStore: _FakeStore(initial: 'Maya'),
       ),
-      seed: () => const FrequencySessionState(
-        stage: SessionStage.discovery,
+      seed: () => const SessionDiscovery(myName: 'Maya'),
+      act: (cubit) => cubit.rename('Maya R.'),
+      expect: () => [const SessionDiscovery(myName: 'Maya R.')],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'rename still updates name when persistence throws',
+      build: () => FrequencySessionCubit(
+        identityStore: _FakeStore(initial: 'Maya')..throwOnSet = true,
+      ),
+      seed: () => const SessionDiscovery(myName: 'Maya'),
+      act: (cubit) => cubit.rename('Maya R.'),
+      expect: () => [const SessionDiscovery(myName: 'Maya R.')],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'rename in Room preserves freq + host role',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      seed: () => const SessionRoom(
         myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: true,
       ),
       act: (cubit) => cubit.rename('Maya R.'),
       expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.discovery,
+        const SessionRoom(
           myName: 'Maya R.',
+          roomFreq: '104.3',
+          roomIsHost: true,
         ),
       ],
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'joinRoom enters the room stage with the freq and host flag',
+      'rename in Booting/Onboarding is a no-op on the visible state',
       build: () => FrequencySessionCubit(identityStore: _FakeStore()),
-      seed: () => const FrequencySessionState(
-        stage: SessionStage.discovery,
-        myName: 'Maya',
-      ),
+      seed: () => const SessionOnboarding(),
+      act: (cubit) => cubit.rename('Sam'),
+      expect: () => const <FrequencySessionState>[],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'joinRoom from Discovery enters the Room with freq + host flag',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      seed: () => const SessionDiscovery(myName: 'Maya'),
       act: (cubit) => cubit.joinRoom(freq: '104.3', isHost: true),
       expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.room,
+        const SessionRoom(
           myName: 'Maya',
           roomFreq: '104.3',
           roomIsHost: true,
@@ -153,64 +142,53 @@ void main() {
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'leaveRoom drops the room fields and goes back to discovery',
+      'joinRoom outside Discovery is a no-op',
       build: () => FrequencySessionCubit(identityStore: _FakeStore()),
-      seed: () => const FrequencySessionState(
-        stage: SessionStage.room,
+      seed: () => const SessionOnboarding(),
+      act: (cubit) => cubit.joinRoom(freq: '104.3', isHost: true),
+      expect: () => const <FrequencySessionState>[],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'leaveRoom drops back to Discovery with the prior name',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      seed: () => const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
         roomIsHost: true,
       ),
       act: (cubit) => cubit.leaveRoom(),
-      expect: () => [
-        const FrequencySessionState(
-          stage: SessionStage.discovery,
-          myName: 'Maya',
-          roomFreq: null,
-          roomIsHost: false,
-        ),
-      ],
+      expect: () => [const SessionDiscovery(myName: 'Maya')],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'leaveRoom outside Room is a no-op',
+      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      seed: () => const SessionDiscovery(myName: 'Maya'),
+      act: (cubit) => cubit.leaveRoom(),
+      expect: () => const <FrequencySessionState>[],
     );
   });
 
   group('FrequencySessionState', () {
-    test('copyWith preserves untouched fields', () {
-      const a = FrequencySessionState(
-        stage: SessionStage.room,
-        myName: 'Maya',
-        roomFreq: '104.3',
-        roomIsHost: true,
-      );
-      final b = a.copyWith(myName: 'Maya R.');
-      expect(b.stage, SessionStage.room);
-      expect(b.myName, 'Maya R.');
-      expect(b.roomFreq, '104.3');
-      expect(b.roomIsHost, isTrue);
-    });
-
-    test('copyWith(clearRoom: true) drops both room fields', () {
-      const a = FrequencySessionState(
-        stage: SessionStage.room,
-        myName: 'Maya',
-        roomFreq: '104.3',
-        roomIsHost: true,
-      );
-      final b = a.copyWith(stage: SessionStage.discovery, clearRoom: true);
-      expect(b.stage, SessionStage.discovery);
-      expect(b.roomFreq, isNull);
-      expect(b.roomIsHost, isFalse);
-    });
-
-    test('equatable equality treats identical fields as equal', () {
-      const a = FrequencySessionState(
-        stage: SessionStage.discovery,
-        myName: 'Maya',
-      );
-      const b = FrequencySessionState(
-        stage: SessionStage.discovery,
-        myName: 'Maya',
-      );
+    test('Equatable equality treats identical fields as equal', () {
+      const a = SessionDiscovery(myName: 'Maya');
+      const b = SessionDiscovery(myName: 'Maya');
       expect(a, equals(b));
+    });
+
+    test('Equatable equality distinguishes Booting from Onboarding', () {
+      expect(const SessionBooting(), isNot(equals(const SessionOnboarding())));
+    });
+
+    test('SessionRoom carries non-null freq + host', () {
+      const r = SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: true,
+      );
+      expect(r.roomFreq, '104.3');
+      expect(r.roomIsHost, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes part of [#13](https://github.com/ElodinLaarz/walkie-talkie/issues/13). Replaces `FrequencyApp`'s setState-based state machine with a `FrequencySessionCubit` that owns the navigation stage, the persisted display name, and the current room's frequency + host/guest role. Screens now project state via `BlocBuilder` and dispatch transitions through the cubit.

The slice that **#5 / #6 / #8 / #9** need to plug streams into is in place — those PRs can call `context.read<FrequencySessionCubit>()` and wire `BlocListener`s without re-plumbing the navigation.

## What changed

**New: [`lib/bloc/`](lib/bloc/)**
- [`frequency_session_state.dart`](lib/bloc/frequency_session_state.dart) — immutable `Equatable` state with `SessionStage` enum (`booting` / `onboarding` / `discovery` / `room`), `myName`, `roomFreq`, `roomIsHost`. `copyWith(clearRoom: true)` for `leaveRoom`.
- [`frequency_session_cubit.dart`](lib/bloc/frequency_session_cubit.dart) — methods: `bootstrap()`, `completeOnboarding(name)`, `rename(name)`, `joinRoom(freq, isHost)`, `leaveRoom()`. Filesystem-boundary `try/catch` around `IdentityStore` calls so persistence failures never strand the UI on the splash.

**[`lib/main.dart`](lib/main.dart)**
- `WalkieTalkieApp` wraps the app in a `BlocProvider` that constructs the cubit with `HiveIdentityStore` (or an injected fake for tests) and kicks off `bootstrap()`.
- `FrequencyApp` is now a stateless projection of `FrequencySessionState` — the same `_buildStage` switch as before, just driven by the cubit.

## Scope (intentional)

Session-level state only. **Roster, mute, media playback, talking-peer set, and audio output remain owned by `FrequencyRoomScreen`.** Migrating those is a clean follow-up — together with the existing slice they're substantial enough that landing in one PR would be hard to review. The follow-up will:
- Add a `RoomState` class that the session state holds (or a separate `RoomCubit`)
- Move the room screen's timers, mute state, peer state, and media state into the cubit
- Update the room screen tests to read from the cubit

#5/#6/#8/#9 don't strictly need that follow-up to start — they can fold their stream wiring into the cubit alongside the room-state migration, or land in advance and have the migration plumb their state through later.

## Tests

- **[`test/bloc/frequency_session_cubit_test.dart`](test/bloc/frequency_session_cubit_test.dart)** (new) — 11 unit tests covering:
  - bootstrap with / without a persisted name
  - bootstrap when the store throws (falls through to onboarding)
  - completeOnboarding (and when persistence throws — UI still advances)
  - rename
  - joinRoom / leaveRoom (clearRoom semantics)
  - state `copyWith` and equality
- **Existing tests pass unchanged.** `widget_test.dart`'s `WalkieTalkieApp(identityStore: fake)` pattern still works because the override is now consumed by the cubit instead of `FrequencyApp` directly.

## Reviewer notes

- The state class is `Equatable`-based; `bloc_test`'s `expect:` lists rely on that for equality on emitted states.
- `bootstrap()` is fired via `..bootstrap()` in the `BlocProvider.create` — the splash stage is the initial state, so the user sees a brief blank background while Hive opens its box.
- 95 tests pass locally (was 83 + 12 new cubit tests), 1 skipped (the modal-sheet click-through from #20), `flutter analyze` clean.

## Test plan

- [ ] CI green
- [ ] First launch: splash → onboarding (no persisted name)
- [ ] Subsequent launch: splash → discovery (persisted name shows in chrome)
- [ ] Rename via Discovery chrome chip persists across kill/relaunch
- [ ] Start a Frequency / Tune in / Leave all transition through the cubit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent session state with automatic save/restore of display name, onboarding flow, and explicit room join/leave transitions.
* **Bug Fixes**
  * Resilient startup and persistence: failures are logged but do not block UI flow; renaming and onboarding persist when possible.
* **Refactor**
  * App state moved to a centralized session controller for simpler, predictable screen rendering.
* **Tests**
  * Comprehensive unit tests covering session lifecycle, persistence and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->