### PR TITLE
Persist a stable peerId alongside displayName

### DIFF
--- a/lib/services/identity_store.dart
+++ b/lib/services/identity_store.dart
@@ -1,10 +1,16 @@
+import 'dart:math';
+
 import 'package:hive/hive.dart';
 
 /// Persisted user identity that survives app restarts.
 ///
-/// Today this is just the display name picked during onboarding. The interface
-/// exists so the app shell and tests can swap implementations without touching
-/// Hive directly.
+/// Carries two independent things:
+///   * `displayName` — what other people on a frequency see, picked during
+///     onboarding, editable via the rename sheet.
+///   * `peerId` — a stable per-install UUID v4 used by the wire protocol
+///     to route messages and tag voice frames. Generated lazily on first
+///     read, never changes once created, completely decoupled from the
+///     display name (renames don't perturb it).
 abstract class IdentityStore {
   /// Returns the persisted display name, or `null` if onboarding has not
   /// completed.
@@ -13,12 +19,19 @@ abstract class IdentityStore {
   /// Persists the display name. The value is trimmed; an empty string is
   /// treated as a clear and removes the persisted name.
   Future<void> setDisplayName(String value);
+
+  /// Returns the persisted peerId, generating a fresh UUID v4 on first
+  /// call and persisting it before returning. Idempotent for the install
+  /// lifetime — the same id is returned on every subsequent call across
+  /// app restarts.
+  Future<String> getPeerId();
 }
 
 /// Hive-backed [IdentityStore] keyed in a single string box.
 class HiveIdentityStore implements IdentityStore {
   static const String _boxName = 'identity';
   static const String _displayNameKey = 'displayName';
+  static const String _peerIdKey = 'peerId';
 
   Box<String>? _box;
 
@@ -49,4 +62,38 @@ class HiveIdentityStore implements IdentityStore {
       await box.put(_displayNameKey, trimmed);
     }
   }
+
+  @override
+  Future<String> getPeerId() async {
+    final box = await _open();
+    final existing = box.get(_peerIdKey);
+    if (existing != null && existing.isNotEmpty) return existing;
+    final fresh = _generateUuidV4();
+    await box.put(_peerIdKey, fresh);
+    return fresh;
+  }
+}
+
+/// Generates a UUID v4 string in canonical `8-4-4-4-12` hex form using
+/// `Random.secure()`. Avoids pulling in the `uuid` package for ~15 lines
+/// of work; the format follows RFC 4122 §4.4 (random bits with the
+/// version nibble pinned to 4 and the variant top bits to `10`).
+String _generateUuidV4() {
+  final rng = Random.secure();
+  final bytes = List<int>.generate(16, (_) => rng.nextInt(256));
+  // Version 4 (random) marker.
+  bytes[6] = (bytes[6] & 0x0F) | 0x40;
+  // RFC 4122 variant marker (10xx).
+  bytes[8] = (bytes[8] & 0x3F) | 0x80;
+
+  String segment(int from, int to) {
+    final sb = StringBuffer();
+    for (var i = from; i < to; i++) {
+      sb.write(bytes[i].toRadixString(16).padLeft(2, '0'));
+    }
+    return sb.toString();
+  }
+
+  return '${segment(0, 4)}-${segment(4, 6)}-${segment(6, 8)}-'
+      '${segment(8, 10)}-${segment(10, 16)}';
 }

--- a/lib/services/identity_store.dart
+++ b/lib/services/identity_store.dart
@@ -35,6 +35,11 @@ class HiveIdentityStore implements IdentityStore {
 
   Box<String>? _box;
 
+  /// Single-flight cache for `getPeerId`. The first caller starts the
+  /// get-or-create; every concurrent caller awaits the same future, so all
+  /// callers in the same session see the same id even on a fresh install.
+  Future<String>? _peerIdFuture;
+
   Future<Box<String>> _open() async {
     final existing = _box;
     if (existing != null && existing.isOpen) return existing;
@@ -64,7 +69,9 @@ class HiveIdentityStore implements IdentityStore {
   }
 
   @override
-  Future<String> getPeerId() async {
+  Future<String> getPeerId() => _peerIdFuture ??= _readOrCreatePeerId();
+
+  Future<String> _readOrCreatePeerId() async {
     final box = await _open();
     final existing = box.get(_peerIdKey);
     if (existing != null && existing.isNotEmpty) return existing;

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -6,6 +6,7 @@ import 'package:walkie_talkie/services/identity_store.dart';
 
 class _FakeStore implements IdentityStore {
   String? _name;
+  String? _peerId;
   bool throwOnGet = false;
   bool throwOnSet = false;
   int setCalls = 0;
@@ -25,6 +26,9 @@ class _FakeStore implements IdentityStore {
     final trimmed = value.trim();
     _name = trimmed.isEmpty ? null : trimmed;
   }
+
+  @override
+  Future<String> getPeerId() async => _peerId ??= 'fake-peer-id';
 }
 
 void main() {

--- a/test/services/identity_store_test.dart
+++ b/test/services/identity_store_test.dart
@@ -109,6 +109,20 @@ void main() {
         expect(await store.getPeerId(), id);
       });
 
+      test('concurrent first calls return the same id (no race)', () async {
+        // Without the single-flight cache, multiple callers on a fresh
+        // install can each observe a missing key, generate different
+        // UUIDs, and last-write-wins on the box — leaving callers
+        // holding ids that don't match what got persisted.
+        final store = HiveIdentityStore();
+        final ids = await Future.wait(
+          List.generate(8, (_) => store.getPeerId()),
+        );
+        expect(ids.toSet(), hasLength(1));
+        // And the persisted value matches what callers received.
+        expect(await HiveIdentityStore().getPeerId(), ids.first);
+      });
+
       test('a fresh install generates a new id (not a constant)', () async {
         // Guards against regressions like swapping `Random.secure()` for a
         // seedable `Random()` or hard-coding a constant — both would slip

--- a/test/services/identity_store_test.dart
+++ b/test/services/identity_store_test.dart
@@ -59,5 +59,68 @@ void main() {
       await store.setDisplayName('   ');
       expect(await store.getDisplayName(), isNull);
     });
+
+    group('getPeerId', () {
+      // Canonical UUID v4: 8-4-4-4-12 hex with the version nibble pinned
+      // to `4` and the variant top bits to `10` (so the 4-segment starts
+      // with `4` and the 5-segment starts with 8/9/a/b).
+      final uuidV4Pattern = RegExp(
+        r'^[0-9a-f]{8}-'
+        r'[0-9a-f]{4}-'
+        r'4[0-9a-f]{3}-'
+        r'[89ab][0-9a-f]{3}-'
+        r'[0-9a-f]{12}$',
+      );
+
+      test('returns a UUID v4 string', () async {
+        final store = HiveIdentityStore();
+        final id = await store.getPeerId();
+        expect(id, matches(uuidV4Pattern));
+      });
+
+      test('is idempotent within a session', () async {
+        final store = HiveIdentityStore();
+        final a = await store.getPeerId();
+        final b = await store.getPeerId();
+        expect(a, b);
+      });
+
+      test('persists across HiveIdentityStore instances', () async {
+        final first = HiveIdentityStore();
+        final id = await first.getPeerId();
+        final second = HiveIdentityStore();
+        expect(await second.getPeerId(), id);
+      });
+
+      test('renaming the display name does not change peerId', () async {
+        final store = HiveIdentityStore();
+        await store.setDisplayName('Maya');
+        final id = await store.getPeerId();
+        await store.setDisplayName('Devon');
+        expect(await store.getPeerId(), id);
+      });
+
+      test('clearing the display name does not clear peerId', () async {
+        final store = HiveIdentityStore();
+        await store.setDisplayName('Maya');
+        final id = await store.getPeerId();
+        await store.setDisplayName(''); // clears displayName
+        expect(await store.getDisplayName(), isNull);
+        expect(await store.getPeerId(), id);
+      });
+
+      test('a fresh install generates a new id (not a constant)', () async {
+        // Guards against regressions like swapping `Random.secure()` for a
+        // seedable `Random()` or hard-coding a constant — both would slip
+        // past the round-trip and format tests above.
+        final firstId = await HiveIdentityStore().getPeerId();
+        // Wipe persisted state and re-init Hive at the same path.
+        await Hive.deleteFromDisk();
+        Hive.init(tempDir.path);
+        final secondId = await HiveIdentityStore().getPeerId();
+        expect(secondId, isNot(equals(firstId)));
+        expect(secondId, matches(uuidV4Pattern));
+      });
+    });
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,6 +4,7 @@ import 'package:walkie_talkie/services/identity_store.dart';
 
 class _FakeIdentityStore implements IdentityStore {
   String? _name;
+  String? _peerId;
   _FakeIdentityStore({String? initial}) : _name = initial;
 
   @override
@@ -15,6 +16,9 @@ class _FakeIdentityStore implements IdentityStore {
     final trimmed = value.trim();
     _name = trimmed.isEmpty ? null : trimmed;
   }
+
+  @override
+  Future<String> getPeerId() async => _peerId ??= 'fake-peer-id';
 }
 
 void main() {


### PR DESCRIPTION
## Summary

Closes [#22](https://github.com/ElodinLaarz/walkie-talkie/issues/22).

The wire protocol from [#7](https://github.com/ElodinLaarz/walkie-talkie/pull/16) routes every control message and tags every voice frame by `peerId`. Until now there was no source for it. This adds `Future<String> getPeerId()` to `IdentityStore` with **get-or-create** semantics — it returns the persisted UUID v4, generating one on first call and persisting it before returning. Stable for the install lifetime, decoupled from `displayName` (renames don't perturb it).

Foundational for **#5** (BT scanning advertises `peerId` in the LE manufacturer payload), **#6** (voice frames tagged by `peerId`), and **#8** (media commands attributed by `peerId`).

## What changed

- **`lib/services/identity_store.dart`** — new `getPeerId()` method on the abstract interface and the Hive implementation. Lazy create-on-first-call; persisted under a separate `peerId` key in the existing `identity` box.
- **UUID v4 generation** — small `Random.secure()`-based helper following RFC 4122 §4.4 (~15 LOC). No new package dependencies for ~one-and-a-half functions of work.
- **Test fakes updated** — `_FakeStore` (cubit test) and `_FakeIdentityStore` (widget test) both now implement `getPeerId()` with a lazy in-memory id (`'fake-peer-id'`).

## Tests (6 new)

- UUID v4 format (canonical `8-4-4-4-12` hex, version-4 nibble, RFC variant top bits).
- Idempotency within a session.
- Persists across new `HiveIdentityStore` instances.
- Renaming `displayName` doesn't perturb `peerId`.
- Clearing `displayName` doesn't clear `peerId`.
- A wiped Hive box generates a **new** id, not a constant — guards against regressions like swapping `Random.secure()` for a seedable `Random()` or hard-coding a literal (the format and idempotency tests would both pass with either bug).

106 tests pass locally (was 100), 1 skipped, `flutter analyze` clean.

## Reviewer notes

- Decoupling: `setDisplayName('')` clears the name but the id sticks around. Same reverse: a fresh `peerId` getter doesn't change anything about `displayName`.
- No UI or cubit changes here. Wiring `peerId` into `FrequencySessionState` (or wherever the BT layer reads it from) is left for whichever PR (#5/#6) actually needs it on screen — keeps this one tightly scoped.
- The `dart:math` import is the only new import.

## Test plan

- [ ] CI green
- [ ] Fresh install: `getPeerId()` returns a UUID v4
- [ ] Force-quit + relaunch: same id comes back
- [ ] Edit display name: id unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stable per-installation identifier that persists across app sessions and updates.
* **Bug Fixes**
  * Ensures concurrent requests for the identifier reliably return the same value on first generation.
* **Tests**
  * Added tests validating UUID v4 format, persistence across restarts, stability across calls, concurrency behavior, and fresh-install regeneration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->