### PR TITLE
Wire-protocol framing + idempotency, and room Mute/PTT plumbing

### DIFF
--- a/lib/protocol/framing.dart
+++ b/lib/protocol/framing.dart
@@ -1,0 +1,237 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Maximum control-plane MTU the protocol negotiates with Android.
+///
+/// Android caps GATT MTU at 247 bytes; the negotiation lives in the platform
+/// layer (see `docs/protocol.md` § GATT service) and the framing code below
+/// just sees byte buffers sized to that ceiling. Receivers SHOULD honour the
+/// `total_len` and `fragment_idx` header on the wire and not assume any
+/// particular fragment size, but every encoder in this codebase splits at
+/// [kMaxFragmentSize].
+const int kMaxFragmentSize = 247;
+
+/// Fragment header in front of every chunk on the wire.
+///
+/// ```text
+/// [ flags=0x00  total_len_hi  total_len_lo  fragment_idx ]  <up-to-243 bytes>
+/// ```
+const int kFragmentHeaderSize = 4;
+
+/// Maximum payload bytes carried by a single fragment.
+const int kMaxFragmentPayloadSize = kMaxFragmentSize - kFragmentHeaderSize;
+
+/// Hard cap on the size of any one logical message — 4 KiB / 17 fragments at
+/// the negotiated MTU. Anything larger is a protocol error: the roster's
+/// worst-case shape (12 peers, padded names, BT device strings) sits well
+/// inside this margin.
+const int kMaxMessageSize = 4096;
+
+/// `total_len` is encoded as a big-endian uint16; an 0xFFFF cap is the
+/// implicit ceiling of that field. A receiver computing
+/// `(hi << 8) | lo` will mask anything wider, so the encoder fails fast
+/// instead of letting a length overflow silently.
+const int kMaxEncodableLength = 0xFFFF;
+
+/// Reserved flag byte at offset 0 of every fragment header. v1 always emits
+/// `0x00`; receivers MUST drop fragments whose flag byte they don't
+/// recognize so a future bit (e.g. compression, signing) doesn't get
+/// silently misinterpreted by an older guest.
+const int kFragmentFlagsV1 = 0x00;
+
+/// A length-prefixed JSON message split into one or more fragments suitable
+/// for writing to the GATT REQUEST/RESPONSE characteristic.
+///
+/// Each fragment is an independent BLE write — the receiver reassembles them
+/// using the `total_len` + `fragment_idx` header carried on every fragment.
+List<Uint8List> encodeFragments(String json) {
+  final bytes = utf8.encode(json);
+  if (bytes.length > kMaxMessageSize) {
+    throw FormatException(
+      'Message too large for v1 framing: ${bytes.length} bytes '
+      '(cap: $kMaxMessageSize)',
+    );
+  }
+  // Defensive: kMaxMessageSize is well below the wire's uint16 ceiling, but
+  // the check at the wire boundary protects us if a future patch raises
+  // the v1 cap and forgets to widen `total_len`.
+  if (bytes.length > kMaxEncodableLength) {
+    throw FormatException(
+      'Message length exceeds 16-bit wire encoding: ${bytes.length}',
+    );
+  }
+
+  final totalLen = bytes.length;
+  final fragmentCount = totalLen == 0
+      ? 1
+      : (totalLen + kMaxFragmentPayloadSize - 1) ~/ kMaxFragmentPayloadSize;
+
+  final fragments = <Uint8List>[];
+  for (int i = 0; i < fragmentCount; i++) {
+    final start = i * kMaxFragmentPayloadSize;
+    final end =
+        (start + kMaxFragmentPayloadSize) < totalLen
+            ? start + kMaxFragmentPayloadSize
+            : totalLen;
+    final payloadLen = end - start;
+
+    final fragment = Uint8List(kFragmentHeaderSize + payloadLen)
+      ..[0] = kFragmentFlagsV1
+      ..[1] = (totalLen >> 8) & 0xFF
+      ..[2] = totalLen & 0xFF
+      ..[3] = i & 0xFF;
+    if (payloadLen > 0) {
+      fragment.setRange(
+        kFragmentHeaderSize,
+        kFragmentHeaderSize + payloadLen,
+        bytes,
+        start,
+      );
+    }
+    fragments.add(fragment);
+  }
+  return fragments;
+}
+
+/// Errors emitted by the [FragmentReassembler]. These are recoverable at
+/// the link level — the protocol's policy is to drop the offending fragment
+/// (and the in-flight buffer for that message) and keep the connection up.
+sealed class FragmentError implements Exception {
+  final String message;
+  const FragmentError(this.message);
+  @override
+  String toString() => 'FragmentError: $message';
+}
+
+/// Fragment was shorter than the 4-byte header, or its flags byte isn't
+/// recognized in this protocol version.
+class MalformedFragment extends FragmentError {
+  const MalformedFragment(super.message);
+}
+
+/// `total_len` exceeded the v1 message cap, or contradicted a previously
+/// seen fragment from the same in-flight message.
+class InconsistentFragment extends FragmentError {
+  const InconsistentFragment(super.message);
+}
+
+/// Fragment arrived out of order, or `fragment_idx` exceeded what
+/// `total_len` requires.
+class UnexpectedFragmentIndex extends FragmentError {
+  const UnexpectedFragmentIndex(super.message);
+}
+
+/// Reassembles fragments into complete JSON messages.
+///
+/// Single-producer, single-consumer: each instance tracks the in-flight
+/// message for one logical sender (one GATT characteristic on one
+/// connection). v1 fragments arrive in order — every reassembler reset
+/// throws [UnexpectedFragmentIndex] rather than silently buffering
+/// out-of-order data, so a misbehaving peer surfaces loudly instead of
+/// poisoning the next message.
+///
+/// Usage:
+///
+/// ```dart
+/// final r = FragmentReassembler();
+/// for (final frag in incomingFragments) {
+///   final complete = r.feed(frag);
+///   if (complete != null) handleMessage(complete);
+/// }
+/// ```
+class FragmentReassembler {
+  int? _expectedTotalLen;
+  int _nextIdx = 0;
+  final BytesBuilder _buffer = BytesBuilder(copy: false);
+
+  /// Reset to an empty in-flight message. Useful when the underlying link
+  /// drops mid-message and the receiver needs to discard the partial buffer
+  /// before the next fragment arrives.
+  void reset() {
+    _expectedTotalLen = null;
+    _nextIdx = 0;
+    _buffer.clear();
+  }
+
+  /// Feed one fragment. Returns the complete UTF-8 JSON string when the
+  /// fragment closes a message, or `null` while the message is still
+  /// in-flight.
+  ///
+  /// Throws [FragmentError] subtypes on protocol violations. The caller
+  /// catches and drops; the reassembler is internally reset so the next
+  /// `feed` starts a fresh message.
+  String? feed(Uint8List fragment) {
+    if (fragment.length < kFragmentHeaderSize) {
+      reset();
+      throw MalformedFragment(
+        'Fragment shorter than header: ${fragment.length} bytes',
+      );
+    }
+    final flags = fragment[0];
+    if (flags != kFragmentFlagsV1) {
+      reset();
+      throw MalformedFragment(
+        'Unknown fragment flags byte: 0x${flags.toRadixString(16)}',
+      );
+    }
+    final totalLen = (fragment[1] << 8) | fragment[2];
+    final idx = fragment[3];
+
+    if (totalLen > kMaxMessageSize) {
+      reset();
+      throw InconsistentFragment(
+        'Declared total_len $totalLen exceeds cap $kMaxMessageSize',
+      );
+    }
+
+    final expected = _expectedTotalLen;
+    if (expected == null) {
+      // First fragment — index must be zero, total_len anchors the buffer.
+      if (idx != 0) {
+        reset();
+        throw UnexpectedFragmentIndex(
+          'Expected fragment_idx 0 to start a message, got $idx',
+        );
+      }
+      _expectedTotalLen = totalLen;
+    } else {
+      if (totalLen != expected) {
+        reset();
+        throw InconsistentFragment(
+          'total_len $totalLen contradicts in-flight $expected',
+        );
+      }
+      if (idx != _nextIdx) {
+        reset();
+        throw UnexpectedFragmentIndex(
+          'Expected fragment_idx $_nextIdx, got $idx',
+        );
+      }
+    }
+
+    final payloadLen = fragment.length - kFragmentHeaderSize;
+    final remaining = totalLen - _buffer.length;
+    if (payloadLen > remaining) {
+      reset();
+      throw InconsistentFragment(
+        'Fragment payload $payloadLen bytes exceeds remaining $remaining',
+      );
+    }
+    if (payloadLen > 0) {
+      _buffer.add(
+        Uint8List.sublistView(fragment, kFragmentHeaderSize),
+      );
+    }
+    _nextIdx++;
+
+    if (_buffer.length == totalLen) {
+      final out = _buffer.toBytes();
+      reset();
+      // utf8.decode throws FormatException on bad bytes; let it propagate
+      // — the caller treats invalid UTF-8 the same as any other dropped
+      // message.
+      return utf8.decode(out);
+    }
+    return null;
+  }
+}

--- a/lib/protocol/framing.dart
+++ b/lib/protocol/framing.dart
@@ -142,7 +142,10 @@ class UnexpectedFragmentIndex extends FragmentError {
 class FragmentReassembler {
   int? _expectedTotalLen;
   int _nextIdx = 0;
-  final BytesBuilder _buffer = BytesBuilder(copy: false);
+  // Default-mode (copying) BytesBuilder: BLE callers commonly reuse
+  // packet buffers, so a non-copying view would corrupt our reassembly
+  // state out from under us. The copy is ≤4 KiB per message — cheap.
+  final BytesBuilder _buffer = BytesBuilder();
 
   /// Reset to an empty in-flight message. Useful when the underlying link
   /// drops mid-message and the receiver needs to discard the partial buffer

--- a/lib/protocol/framing.dart
+++ b/lib/protocol/framing.dart
@@ -33,6 +33,13 @@ const int kMaxMessageSize = 4096;
 /// instead of letting a length overflow silently.
 const int kMaxEncodableLength = 0xFFFF;
 
+/// `fragment_idx` is a uint8 on the wire (offset 3 of every fragment
+/// header); 256 fragments is the absolute ceiling regardless of any
+/// other cap. With the v1 [kMaxMessageSize] of 4 KiB and 243-byte
+/// payloads we land at ~17 fragments — well below this — but a future
+/// cap raise must not silently wrap to a 1-byte index.
+const int kMaxFragmentCount = 256;
+
 /// Reserved flag byte at offset 0 of every fragment header. v1 always emits
 /// `0x00`; receivers MUST drop fragments whose flag byte they don't
 /// recognize so a future bit (e.g. compression, signing) doesn't get
@@ -65,6 +72,16 @@ List<Uint8List> encodeFragments(String json) {
   final fragmentCount = totalLen == 0
       ? 1
       : (totalLen + kMaxFragmentPayloadSize - 1) ~/ kMaxFragmentPayloadSize;
+  // Unreachable with the v1 4 KiB message cap (max ~17 fragments) but
+  // guards against a future cap raise: silently masking `i` to 8 bits
+  // would produce duplicate fragment indices on the wire and a
+  // reassembler that confidently stitches together garbage.
+  if (fragmentCount > kMaxFragmentCount) {
+    throw FormatException(
+      'Message requires $fragmentCount fragments; fragment_idx is uint8 '
+      '(cap: $kMaxFragmentCount)',
+    );
+  }
 
   final fragments = <Uint8List>[];
   for (int i = 0; i < fragmentCount; i++) {
@@ -79,7 +96,7 @@ List<Uint8List> encodeFragments(String json) {
       ..[0] = kFragmentFlagsV1
       ..[1] = (totalLen >> 8) & 0xFF
       ..[2] = totalLen & 0xFF
-      ..[3] = i & 0xFF;
+      ..[3] = i;
     if (payloadLen > 0) {
       fragment.setRange(
         kFragmentHeaderSize,

--- a/lib/protocol/sequence_filter.dart
+++ b/lib/protocol/sequence_filter.dart
@@ -1,0 +1,67 @@
+/// Idempotency filter for the control plane.
+///
+/// BLE writes are at-least-once: a guest can reconnect mid-flight, the
+/// platform layer can retry a notification, or two retransmissions can race
+/// up the stack. The protocol's contract (see `docs/protocol.md` §
+/// "Sequence numbers and idempotency") is that **receivers** drop messages
+/// whose `seq` is `<=` the highest `seq` already accepted from the same
+/// peer. This class is the per-receiver state for that rule.
+///
+/// Lifetime: one [SequenceFilter] per logical receive endpoint. Hosts hold
+/// one keyed by `peerId` covering all guests; a guest holds one for the
+/// host. After a clean disconnect the receiver MUST [forget] the peer's
+/// entry — both sides reset their own outgoing counter on reconnect, and a
+/// stale `lastSeq[peerId]` from the previous session would silently swallow
+/// the new session's `seq=1`.
+class SequenceFilter {
+  final Map<String, int> _lastSeq = {};
+
+  /// Read-only view of the highest accepted seq per peer. Useful for
+  /// diagnostics and tests; the filter doesn't expose mutation here on
+  /// purpose so calling code can't accidentally raise the watermark and
+  /// suppress a legitimate message.
+  Map<String, int> get watermarks => Map.unmodifiable(_lastSeq);
+
+  /// Whether this is the first message we've ever seen from [peerId].
+  /// Mostly for tests; in production code prefer [accept], which both
+  /// answers the question and updates the watermark in one call.
+  bool isFirstFrom(String peerId) => !_lastSeq.containsKey(peerId);
+
+  /// Returns true and advances the watermark when [seq] from [peerId] is
+  /// strictly greater than every prior seq from that peer. Returns false
+  /// (without mutating state) for duplicates, out-of-order arrivals, or
+  /// non-positive seqs. Receivers route an `accept == true` to message
+  /// dispatch and silently drop the rest.
+  ///
+  /// The protocol requires `seq >= 1` and strictly monotonic increments —
+  /// this filter is more permissive: it accepts any `seq > lastSeq` to
+  /// stay robust against benign producer gaps (a peer that increments its
+  /// counter on send-attempt rather than wire-success can skip values
+  /// without breaking the receiver's view of "later than what we've
+  /// seen"). The protocol's stricter "no gaps" guarantee is enforced by
+  /// senders, not receivers.
+  bool accept({required String peerId, required int seq}) {
+    if (seq < 1) return false;
+    final last = _lastSeq[peerId];
+    if (last != null && seq <= last) return false;
+    _lastSeq[peerId] = seq;
+    return true;
+  }
+
+  /// Drop the watermark for [peerId]. Callers MUST invoke this on clean
+  /// disconnect (the `Leave`/`RemovePeer` flow in `docs/protocol.md` §
+  /// Lifecycle) and on dirty-disconnect detection (heartbeat timeout). A
+  /// reconnecting peer resets its own counter to 0 and starts the fresh
+  /// session at `seq=1`; a stale watermark of, say, 7 from the previous
+  /// session would swallow seq 1–7 of the new one.
+  void forget(String peerId) {
+    _lastSeq.remove(peerId);
+  }
+
+  /// Wipe all watermarks. Useful when entering a fresh room, where the
+  /// previous room's roster is gone and any held-over watermarks would be
+  /// noise at best, silent message loss at worst.
+  void clear() {
+    _lastSeq.clear();
+  }
+}

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -151,8 +151,14 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // sequence matters: pushing `setMuted` before `startVoice` finishes
     // would race the encoder init on slower devices and the first toggle
     // would silently no-op.
+    //
+    // The `mounted` check guards against the user leaving the room before
+    // startVoice resolves — without it, the trailing setMuted would land
+    // after dispose has fired stopVoice and tell a torn-down engine to
+    // mute itself.
     final initialMuted = _meEffectivelyMuted;
     unawaited(_audio.startVoice().then((_) {
+      if (!mounted) return;
       _audio.setMuted(initialMuted);
     }));
 

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -8,6 +8,7 @@ import '../bloc/frequency_session_cubit.dart';
 import '../bloc/frequency_session_state.dart';
 import '../data/frequency_mock_data.dart';
 import '../protocol/messages.dart';
+import '../services/audio_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
 import '../widgets/frequency_toast_host.dart';
@@ -44,6 +45,13 @@ class FrequencyRoomScreen extends StatefulWidget {
   final String myName;
   final VoidCallback onLeave;
 
+  /// Native audio bridge. Optional so widget tests that don't care about the
+  /// MethodChannel can omit it (the catch-blocks inside [AudioService]
+  /// swallow `MissingPluginException`); production wiring constructs the
+  /// default instance. Tests that *do* assert on audio engine calls can
+  /// pass an instance whose channel handler they've registered.
+  final AudioService? audioService;
+
   const FrequencyRoomScreen({
     super.key,
     required this.freq,
@@ -53,6 +61,7 @@ class FrequencyRoomScreen extends StatefulWidget {
     required this.isHost,
     required this.myName,
     required this.onLeave,
+    this.audioService,
   });
 
   @override
@@ -115,6 +124,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
 
   bool get _meEffectivelyMuted => widget.pttMode ? !_holdingPtt : _meMuted;
 
+  late final AudioService _audio;
+
   @override
   void initState() {
     super.initState();
@@ -134,6 +145,16 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     _source = widget.mediaKind == MediaKind.podcast ? 'Podcasts' : 'YouTube Music';
     _lib = kMedia[_source]!;
     _lastAction = const _LastAction(by: 'Devon', action: 'started playback', when: '12s ago');
+
+    _audio = widget.audioService ?? AudioService();
+    // Spin up the capture engine, then push the initial mute state. The
+    // sequence matters: pushing `setMuted` before `startVoice` finishes
+    // would race the encoder init on slower devices and the first toggle
+    // would silently no-op.
+    final initialMuted = _meEffectivelyMuted;
+    unawaited(_audio.startVoice().then((_) {
+      _audio.setMuted(initialMuted);
+    }));
 
     _resolveMyPeerId();
     _startTalkSimulation();
@@ -252,6 +273,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         _meMuted = widget.pttMode;
         _holdingPtt = false;
       });
+      // Switching pttMode resets effective mute (open mic ⇒ unmuted,
+      // PTT ⇒ muted-until-held), so the engine needs the new state.
+      unawaited(_audio.setMuted(_meEffectivelyMuted));
     }
   }
 
@@ -262,7 +286,23 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     _hostJoinDemoTimer?.cancel();
     _weakSignalDemoTimer?.cancel();
     _mediaSub?.cancel();
+    unawaited(_audio.stopVoice());
     super.dispose();
+  }
+
+  /// Open-mic mute toggle. Updates the local UI state and pushes the new
+  /// mute flag to the native audio engine in one step so they can't drift.
+  void _setOpenMicMuted(bool muted) {
+    setState(() => _meMuted = muted);
+    unawaited(_audio.setMuted(muted));
+  }
+
+  /// PTT press/release. While held the mic is unmuted; on release we
+  /// re-mute so a stuck pointer or a missed `onPointerCancel` can't leave
+  /// the user open-mic'd against their intent.
+  void _setPttHolding(bool holding) {
+    setState(() => _holdingPtt = holding);
+    unawaited(_audio.setMuted(!holding));
   }
 
   void _onMediaCommand(MediaCommand cmd) {
@@ -620,7 +660,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           if (widget.pttMode)
             _PushToTalkButton(
               holding: _holdingPtt,
-              onChange: (h) => setState(() => _holdingPtt = h),
+              onChange: _setPttHolding,
             )
           else
             SizedBox(
@@ -631,14 +671,14 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                       label: 'Unmute',
                       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                       fontSize: 13,
-                      onPressed: () => setState(() => _meMuted = false),
+                      onPressed: () => _setOpenMicMuted(false),
                     )
                   : PrimaryButton(
                       icon: Icons.mic,
                       label: 'Mute',
                       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                       fontSize: 13,
-                      onPressed: () => setState(() => _meMuted = true),
+                      onPressed: () => _setOpenMicMuted(true),
                     ),
             ),
         ],

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -92,12 +92,13 @@ class AudioService {
   /// down between toggles.
   ///
   /// Returns false if the native side rejects the request (permissions
-  /// denied, no L2CAP link, AudioRecord init failure). The Dart side logs
-  /// and surfaces the failure to the UI; it doesn't retry.
+  /// denied, no L2CAP link, AudioRecord init failure) or if the platform
+  /// call throws. Logs the failure; callers are responsible for any
+  /// user-visible error handling. Does not retry.
   Future<bool> startVoice() async {
     try {
       final result = await _methodChannel.invokeMethod('startVoice');
-      return result as bool;
+      return result == true;
     } catch (e) {
       debugPrint('Error starting voice: $e');
       return false;
@@ -110,7 +111,7 @@ class AudioService {
   Future<bool> stopVoice() async {
     try {
       final result = await _methodChannel.invokeMethod('stopVoice');
-      return result as bool;
+      return result == true;
     } catch (e) {
       debugPrint('Error stopping voice: $e');
       return false;
@@ -132,7 +133,7 @@ class AudioService {
       final result = await _methodChannel.invokeMethod('setMuted', {
         'muted': muted,
       });
-      return result as bool;
+      return result == true;
     } catch (e) {
       debugPrint('Error setting mute state: $e');
       return false;

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -81,6 +81,64 @@ class AudioService {
     }
   }
 
+  /// Begin voice capture and streaming. Wires the mic into the L2CAP CoC
+  /// the host advertised in `JoinAccepted` (or the host's own
+  /// AudioRecord → mix-minus loop when the local user *is* the host).
+  ///
+  /// Idempotent at the native layer — repeated calls while voice is up
+  /// resolve to the existing capture session. Called from the room screen
+  /// when the user enters the room or releases mute, so a quick
+  /// mute → unmute → mute doesn't have to wait for the engine to spin
+  /// down between toggles.
+  ///
+  /// Returns false if the native side rejects the request (permissions
+  /// denied, no L2CAP link, AudioRecord init failure). The Dart side logs
+  /// and surfaces the failure to the UI; it doesn't retry.
+  Future<bool> startVoice() async {
+    try {
+      final result = await _methodChannel.invokeMethod('startVoice');
+      return result as bool;
+    } catch (e) {
+      debugPrint('Error starting voice: $e');
+      return false;
+    }
+  }
+
+  /// Tear down voice capture and streaming. Counterpart to [startVoice];
+  /// safe to call when voice isn't running (the native side resolves it as
+  /// a no-op rather than throwing).
+  Future<bool> stopVoice() async {
+    try {
+      final result = await _methodChannel.invokeMethod('stopVoice');
+      return result as bool;
+    } catch (e) {
+      debugPrint('Error stopping voice: $e');
+      return false;
+    }
+  }
+
+  /// Set the local mic mute flag at the native layer. Mute does **not**
+  /// tear down the L2CAP CoC or the AudioRecord — it just gates whether
+  /// captured frames are encoded and sent. Keeping the engine warm makes
+  /// unmute instant; tearing it down would round-trip through codec init
+  /// every time the user taps the button.
+  ///
+  /// Wire-protocol implication: emitting a `mute` control message on the
+  /// REQUEST characteristic is the *cubit's* job (so the host can echo it
+  /// to the rest of the roster); this method only affects the local audio
+  /// path. They're called together from the room screen.
+  Future<bool> setMuted(bool muted) async {
+    try {
+      final result = await _methodChannel.invokeMethod('setMuted', {
+        'muted': muted,
+      });
+      return result as bool;
+    } catch (e) {
+      debugPrint('Error setting mute state: $e');
+      return false;
+    }
+  }
+
   /// Get list of connected devices
   Future<List<Map<String, String>>> getConnectedDevices() async {
     try {

--- a/test/protocol/framing_test.dart
+++ b/test/protocol/framing_test.dart
@@ -1,0 +1,201 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/protocol/framing.dart';
+
+void main() {
+  group('encodeFragments', () {
+    test('a small message fits in one fragment', () {
+      final fragments = encodeFragments('{"k":"v"}');
+      expect(fragments, hasLength(1));
+      final f = fragments.single;
+      expect(f[0], 0x00);
+      expect(f[1], 0); // total_len_hi
+      expect(f[2], 9); // total_len_lo
+      expect(f[3], 0); // fragment_idx
+      expect(utf8.decode(f.sublist(kFragmentHeaderSize)), '{"k":"v"}');
+    });
+
+    test('a message exactly one payload long produces a single fragment', () {
+      final json = 'a' * kMaxFragmentPayloadSize;
+      final fragments = encodeFragments(json);
+      expect(fragments, hasLength(1));
+      expect(fragments.single.length, kMaxFragmentSize);
+    });
+
+    test('a message one byte over fragment payload spills to a second fragment',
+        () {
+      final json = 'a' * (kMaxFragmentPayloadSize + 1);
+      final fragments = encodeFragments(json);
+      expect(fragments, hasLength(2));
+      // First fragment full, second carries one byte of payload.
+      expect(fragments[0].length, kMaxFragmentSize);
+      expect(fragments[1].length, kFragmentHeaderSize + 1);
+      // total_len header is identical across fragments and matches the input.
+      expect((fragments[0][1] << 8) | fragments[0][2], json.length);
+      expect((fragments[1][1] << 8) | fragments[1][2], json.length);
+      // fragment_idx increments.
+      expect(fragments[0][3], 0);
+      expect(fragments[1][3], 1);
+    });
+
+    test('a 2 KiB message fragments and reassembles to bytes-identical JSON',
+        () {
+      final json = jsonEncode({
+        'kind': 'roster_update',
+        'roster': List.generate(
+          12,
+          (i) => {
+            'peerId': 'p$i' * 8,
+            'displayName': 'Person $i with a longish handle',
+            'btDevice': 'AirPods Max #$i',
+            'muted': false,
+            'talking': false,
+          },
+        ),
+      });
+      final fragments = encodeFragments(json);
+      // ~2 KiB at 243 bytes/fragment ≈ 9 fragments.
+      expect(fragments.length, greaterThan(1));
+      final r = FragmentReassembler();
+      String? out;
+      for (final f in fragments) {
+        out = r.feed(f);
+      }
+      expect(out, json);
+    });
+
+    test('the empty string still emits one (header-only) fragment', () {
+      final fragments = encodeFragments('');
+      expect(fragments, hasLength(1));
+      expect(fragments.single.length, kFragmentHeaderSize);
+    });
+
+    test('messages over the v1 cap are rejected', () {
+      final tooBig = 'a' * (kMaxMessageSize + 1);
+      expect(() => encodeFragments(tooBig), throwsFormatException);
+    });
+
+    test('multibyte UTF-8 sequences are not split mid-codepoint', () {
+      // Build a message that puts a 2-byte UTF-8 sequence ('é' = 0xC3 0xA9)
+      // straddling a fragment boundary in JSON-byte space. The reassembler's
+      // utf8.decode at the end ties the bytes back together — this just
+      // proves we don't accidentally chunk by characters and corrupt the
+      // sequence count.
+      final junk = 'a' * (kMaxFragmentPayloadSize - 1);
+      final json = '$junké$junk';
+      final fragments = encodeFragments(json);
+      expect(fragments.length, greaterThan(1));
+      final r = FragmentReassembler();
+      String? out;
+      for (final f in fragments) {
+        out = r.feed(f);
+      }
+      expect(out, json);
+    });
+  });
+
+  group('FragmentReassembler', () {
+    test('returns null on intermediate fragments and the message on the last',
+        () {
+      final json = 'x' * (kMaxFragmentPayloadSize * 2 + 5);
+      final fragments = encodeFragments(json);
+      expect(fragments, hasLength(3));
+      final r = FragmentReassembler();
+      expect(r.feed(fragments[0]), isNull);
+      expect(r.feed(fragments[1]), isNull);
+      expect(r.feed(fragments[2]), json);
+    });
+
+    test('reassembler is reusable across messages', () {
+      final r = FragmentReassembler();
+      final a = encodeFragments('{"k":"a"}');
+      final b = encodeFragments('{"k":"b"}');
+      expect(r.feed(a.single), '{"k":"a"}');
+      expect(r.feed(b.single), '{"k":"b"}');
+    });
+
+    test('a fragment shorter than the header is rejected', () {
+      final r = FragmentReassembler();
+      expect(
+        () => r.feed(Uint8List.fromList([0x00, 0x00])),
+        throwsA(isA<MalformedFragment>()),
+      );
+    });
+
+    test('an unknown flags byte is rejected', () {
+      final r = FragmentReassembler();
+      final bad = Uint8List.fromList([0x42, 0x00, 0x01, 0x00, 0x61]);
+      expect(() => r.feed(bad), throwsA(isA<MalformedFragment>()));
+    });
+
+    test('a non-zero starting fragment_idx is rejected', () {
+      final r = FragmentReassembler();
+      // total_len=10, idx=1, payload='abc' — but the buffer is empty so
+      // idx must be 0.
+      final bad = Uint8List.fromList([0x00, 0x00, 0x0A, 0x01, 0x61, 0x62, 0x63]);
+      expect(() => r.feed(bad), throwsA(isA<UnexpectedFragmentIndex>()));
+    });
+
+    test('an out-of-order continuation fragment is rejected', () {
+      final json = 'x' * (kMaxFragmentPayloadSize + 5);
+      final fragments = encodeFragments(json);
+      final r = FragmentReassembler();
+      expect(r.feed(fragments[0]), isNull);
+      // Synthesize a fragment with idx=2 instead of idx=1.
+      final tampered = Uint8List.fromList(fragments[1])..[3] = 0x02;
+      expect(() => r.feed(tampered), throwsA(isA<UnexpectedFragmentIndex>()));
+    });
+
+    test('a continuation with a different total_len is rejected', () {
+      final json = 'x' * (kMaxFragmentPayloadSize + 5);
+      final fragments = encodeFragments(json);
+      final r = FragmentReassembler();
+      expect(r.feed(fragments[0]), isNull);
+      // Bump total_len_lo from N to N+1 on the continuation.
+      final tampered = Uint8List.fromList(fragments[1]);
+      tampered[2] = (tampered[2] + 1) & 0xFF;
+      expect(() => r.feed(tampered), throwsA(isA<InconsistentFragment>()));
+    });
+
+    test('a declared total_len above the v1 cap is rejected', () {
+      // total_len = 0x1FFF (8191) > 4096 cap.
+      final bad = Uint8List.fromList([0x00, 0x1F, 0xFF, 0x00, 0x61]);
+      final r = FragmentReassembler();
+      expect(() => r.feed(bad), throwsA(isA<InconsistentFragment>()));
+    });
+
+    test('fragment payload that overshoots the declared length is rejected',
+        () {
+      // total_len declared as 2, but payload is 3 bytes.
+      final bad = Uint8List.fromList([0x00, 0x00, 0x02, 0x00, 0x61, 0x62, 0x63]);
+      final r = FragmentReassembler();
+      expect(() => r.feed(bad), throwsA(isA<InconsistentFragment>()));
+    });
+
+    test('after a violation, the reassembler is reset and accepts a new message',
+        () {
+      final r = FragmentReassembler();
+      try {
+        r.feed(Uint8List.fromList([0x00, 0x00]));
+      } on MalformedFragment {
+        // expected
+      }
+      // Fresh, well-formed message lands cleanly.
+      final fragments = encodeFragments('{"k":"v"}');
+      expect(r.feed(fragments.single), '{"k":"v"}');
+    });
+
+    test('reset() drops in-flight buffer without surfacing an error', () {
+      final json = 'x' * (kMaxFragmentPayloadSize + 5);
+      final fragments = encodeFragments(json);
+      final r = FragmentReassembler();
+      expect(r.feed(fragments[0]), isNull);
+      r.reset();
+      // Re-feeding the original message starts fresh and completes.
+      expect(r.feed(fragments[0]), isNull);
+      expect(r.feed(fragments[1]), json);
+    });
+  });
+}

--- a/test/protocol/framing_test.dart
+++ b/test/protocol/framing_test.dart
@@ -27,14 +27,19 @@ void main() {
     test('a message one byte over fragment payload spills to a second fragment',
         () {
       final json = 'a' * (kMaxFragmentPayloadSize + 1);
+      // total_len is wire bytes (UTF-8), not Dart's UTF-16 code-unit count.
+      // For the all-ASCII fixture they happen to coincide, but the assertion
+      // should compare against bytes so it stays correct if the fixture
+      // ever grows non-ASCII.
+      final totalLen = utf8.encode(json).length;
       final fragments = encodeFragments(json);
       expect(fragments, hasLength(2));
       // First fragment full, second carries one byte of payload.
       expect(fragments[0].length, kMaxFragmentSize);
       expect(fragments[1].length, kFragmentHeaderSize + 1);
       // total_len header is identical across fragments and matches the input.
-      expect((fragments[0][1] << 8) | fragments[0][2], json.length);
-      expect((fragments[1][1] << 8) | fragments[1][2], json.length);
+      expect((fragments[0][1] << 8) | fragments[0][2], totalLen);
+      expect((fragments[1][1] << 8) | fragments[1][2], totalLen);
       // fragment_idx increments.
       expect(fragments[0][3], 0);
       expect(fragments[1][3], 1);
@@ -77,12 +82,14 @@ void main() {
       expect(() => encodeFragments(tooBig), throwsFormatException);
     });
 
-    test('multibyte UTF-8 sequences are not split mid-codepoint', () {
+    test('multibyte UTF-8 sequences reassemble correctly across fragment boundaries',
+        () {
       // Build a message that puts a 2-byte UTF-8 sequence ('é' = 0xC3 0xA9)
-      // straddling a fragment boundary in JSON-byte space. The reassembler's
-      // utf8.decode at the end ties the bytes back together — this just
-      // proves we don't accidentally chunk by characters and corrupt the
-      // sequence count.
+      // straddling a fragment boundary in JSON-byte space. Fragmentation
+      // operates on bytes (it must — we can't peek at codepoint structure
+      // through the GATT MTU) and the reassembler's utf8.decode at the
+      // end stitches the codepoint back together. Regression guard
+      // against anyone "fixing" the splitter to be character-aware.
       final junk = 'a' * (kMaxFragmentPayloadSize - 1);
       final json = '$junké$junk';
       final fragments = encodeFragments(json);

--- a/test/protocol/sequence_filter_test.dart
+++ b/test/protocol/sequence_filter_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/protocol/sequence_filter.dart';
+
+void main() {
+  group('SequenceFilter', () {
+    test('accepts the first message from a peer', () {
+      final f = SequenceFilter();
+      expect(f.isFirstFrom('a'), isTrue);
+      expect(f.accept(peerId: 'a', seq: 1), isTrue);
+      expect(f.isFirstFrom('a'), isFalse);
+    });
+
+    test('accepts strictly increasing seqs', () {
+      final f = SequenceFilter();
+      expect(f.accept(peerId: 'a', seq: 1), isTrue);
+      expect(f.accept(peerId: 'a', seq: 2), isTrue);
+      expect(f.accept(peerId: 'a', seq: 3), isTrue);
+    });
+
+    test('rejects a duplicate seq', () {
+      final f = SequenceFilter();
+      expect(f.accept(peerId: 'a', seq: 5), isTrue);
+      expect(f.accept(peerId: 'a', seq: 5), isFalse);
+    });
+
+    test('rejects an out-of-order seq', () {
+      final f = SequenceFilter();
+      expect(f.accept(peerId: 'a', seq: 5), isTrue);
+      expect(f.accept(peerId: 'a', seq: 3), isFalse);
+      // The watermark didn't move backwards.
+      expect(f.watermarks['a'], 5);
+    });
+
+    test('rejects non-positive seqs', () {
+      final f = SequenceFilter();
+      expect(f.accept(peerId: 'a', seq: 0), isFalse);
+      expect(f.accept(peerId: 'a', seq: -1), isFalse);
+      // No watermark established yet.
+      expect(f.watermarks.containsKey('a'), isFalse);
+    });
+
+    test('tolerates gaps from senders that skip seqs', () {
+      // The protocol requires monotonic +1 increments at the sender, but the
+      // receiver-side filter accepts any strictly-increasing seq so a
+      // misbehaving sender doesn't poison the link.
+      final f = SequenceFilter();
+      expect(f.accept(peerId: 'a', seq: 1), isTrue);
+      expect(f.accept(peerId: 'a', seq: 5), isTrue);
+      expect(f.accept(peerId: 'a', seq: 6), isTrue);
+      expect(f.accept(peerId: 'a', seq: 5), isFalse);
+    });
+
+    test('per-peer watermarks are independent', () {
+      final f = SequenceFilter();
+      expect(f.accept(peerId: 'a', seq: 7), isTrue);
+      // 'b' has its own counter; seq=1 from b is fresh.
+      expect(f.accept(peerId: 'b', seq: 1), isTrue);
+      expect(f.watermarks, {'a': 7, 'b': 1});
+    });
+
+    test('forget() drops just the named peer', () {
+      final f = SequenceFilter();
+      f.accept(peerId: 'a', seq: 7);
+      f.accept(peerId: 'b', seq: 3);
+      f.forget('a');
+      // a's counter is gone; b's is intact.
+      expect(f.isFirstFrom('a'), isTrue);
+      expect(f.isFirstFrom('b'), isFalse);
+      // a can now accept seq=1 (the protocol's reconnect rule).
+      expect(f.accept(peerId: 'a', seq: 1), isTrue);
+    });
+
+    test('clear() wipes all watermarks', () {
+      final f = SequenceFilter();
+      f.accept(peerId: 'a', seq: 7);
+      f.accept(peerId: 'b', seq: 3);
+      f.clear();
+      expect(f.watermarks, isEmpty);
+      expect(f.accept(peerId: 'a', seq: 1), isTrue);
+      expect(f.accept(peerId: 'b', seq: 1), isTrue);
+    });
+
+    test('watermarks are an unmodifiable view', () {
+      final f = SequenceFilter();
+      f.accept(peerId: 'a', seq: 7);
+      final view = f.watermarks;
+      expect(() => view['a'] = 99, throwsUnsupportedError);
+      expect(() => view.remove('a'), throwsUnsupportedError);
+      // Internal state intact.
+      expect(f.accept(peerId: 'a', seq: 7), isFalse);
+      expect(f.accept(peerId: 'a', seq: 8), isTrue);
+    });
+  });
+}

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -12,6 +13,10 @@ import 'package:walkie_talkie/screens/frequency_room_screen.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/frequency_toast_host.dart';
+
+/// MethodChannel name the audio service uses to talk to the native engine.
+/// Must match the constant in `lib/services/audio_service.dart`.
+const _audioChannel = MethodChannel('com.elodin.walkie_talkie/audio');
 
 class MockFrequencySessionCubit extends Mock implements FrequencySessionCubit {}
 class MockIdentityStore extends Mock implements IdentityStore {}
@@ -102,6 +107,10 @@ Widget _room({
     );
 
 void main() {
+  /// Captures every audio MethodChannel call the room screen makes during a
+  /// single test. Reset in `setUp` so cross-test bleed is impossible.
+  final audioCalls = <MethodCall>[];
+
   setUpAll(() {
     registerFallbackValue(MediaOp.play);
   });
@@ -111,6 +120,20 @@ void main() {
     binding.platformDispatcher.implicitView!
       ..physicalSize = _viewport
       ..devicePixelRatio = 1.0;
+
+    // Stub the audio MethodChannel so `AudioService` calls land on the test
+    // recorder instead of throwing `MissingPluginException`. The screen's
+    // initState fires startVoice + setMuted before the first pump, so the
+    // handler must be in place before pumpWidget.
+    audioCalls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_audioChannel, (call) async {
+      audioCalls.add(call);
+      // All audio methods this screen calls return bool today; returning
+      // true keeps the await chain happy without forcing per-method
+      // dispatch.
+      return true;
+    });
   });
 
   tearDown(() {
@@ -118,6 +141,8 @@ void main() {
     binding.platformDispatcher.implicitView!
       ..resetPhysicalSize()
       ..resetDevicePixelRatio();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_audioChannel, null);
   });
 
   group('FrequencyRoomScreen', () {
@@ -414,6 +439,96 @@ void main() {
         // and `_source` hasn't been corrupted.
         expect(find.text('Nightsong'), findsOneWidget);
         expect(find.text('LISTENING TOGETHER · YOUTUBE MUSIC'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'startVoice fires on entry, stopVoice fires on dispose',
+      (tester) async {
+        await tester.pumpWidget(_wrap(_room()));
+        // Drain the post-frame microtask that resolves startVoice's then().
+        await tester.pump();
+
+        expect(
+          audioCalls.where((c) => c.method == 'startVoice').length,
+          1,
+          reason: 'startVoice must be called once on entry',
+        );
+
+        // Pump an empty widget tree to dispose the room.
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+
+        expect(
+          audioCalls.where((c) => c.method == 'stopVoice').length,
+          1,
+          reason: 'stopVoice must be called on dispose',
+        );
+      },
+    );
+
+    testWidgets(
+      'open-mic mute toggle pushes setMuted to the audio engine',
+      (tester) async {
+        await tester.pumpWidget(_wrap(_room()));
+        await tester.pump();
+
+        // Initial: not muted (open-mic default).
+        // Tap Mute → setMuted(true) on the engine.
+        await tester.tap(find.text('Mute'));
+        await tester.pump();
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': true}),
+        );
+
+        // Tap Unmute → setMuted(false).
+        await tester.tap(find.text('Unmute'));
+        await tester.pump();
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': false}),
+        );
+      },
+    );
+
+    testWidgets(
+      'PTT hold/release pushes setMuted(false) and setMuted(true)',
+      (tester) async {
+        await tester.pumpWidget(_wrap(_room(pttMode: true)));
+        await tester.pump();
+
+        // Press the PTT button — engine unmutes.
+        final ptt = find.text('Hold to talk');
+        final pttCenter = tester.getCenter(ptt);
+        final gesture = await tester.startGesture(pttCenter);
+        await tester.pump();
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': false}),
+        );
+
+        // Release — engine re-mutes.
+        await gesture.up();
+        await tester.pump();
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': true}),
+        );
+      },
+    );
+
+    testWidgets(
+      'PTT mode start emits setMuted(true) — push-to-talk default is muted',
+      (tester) async {
+        await tester.pumpWidget(_wrap(_room(pttMode: true)));
+        await tester.pump();
+
+        // The very first setMuted after startVoice resolves must reflect
+        // the PTT default (muted-until-held), not the open-mic default.
+        final firstSetMuted =
+            audioCalls.firstWhere((c) => c.method == 'setMuted');
+        expect(firstSetMuted.arguments, {'muted': true});
       },
     );
 

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -23,6 +23,9 @@ void main() {
                 case 'scanDevices':
                 case 'connectDevice':
                 case 'disconnectDevice':
+                case 'startVoice':
+                case 'stopVoice':
+                case 'setMuted':
                   return true;
                 case 'stopScan':
                   return null;
@@ -87,6 +90,29 @@ void main() {
           'disconnectDevice',
           arguments: {'macAddress': '00:00:00:00:00:00'},
         ),
+      ]);
+    });
+
+    test('startVoice calls correct method', () async {
+      final result = await audioService.startVoice();
+      expect(result, true);
+      expect(log, <Matcher>[isMethodCall('startVoice', arguments: null)]);
+    });
+
+    test('stopVoice calls correct method', () async {
+      final result = await audioService.stopVoice();
+      expect(result, true);
+      expect(log, <Matcher>[isMethodCall('stopVoice', arguments: null)]);
+    });
+
+    test('setMuted forwards the muted flag in the args', () async {
+      final muted = await audioService.setMuted(true);
+      final unmuted = await audioService.setMuted(false);
+      expect(muted, true);
+      expect(unmuted, true);
+      expect(log, <Matcher>[
+        isMethodCall('setMuted', arguments: {'muted': true}),
+        isMethodCall('setMuted', arguments: {'muted': false}),
       ]);
     });
 


### PR DESCRIPTION
## Summary

Land the pure-Dart pieces of the protocol implementation work flagged in the v1 spec, plus the room-screen plumbing for mute and push-to-talk. Native BLE / L2CAP / Oboe stays untouched — that's the next PR.

- **`lib/protocol/framing.dart`** — `encodeFragments` and `FragmentReassembler` for the GATT control plane. 4-byte header (flags, big-endian uint16 `total_len`, `fragment_idx`), 247-byte fragments, 4 KiB message cap. Typed `FragmentError` subclasses (`MalformedFragment`, `InconsistentFragment`, `UnexpectedFragmentIndex`) so callers can distinguish "drop and continue" from "drop and disconnect" without parsing strings.
- **`lib/protocol/sequence_filter.dart`** — per-peer `lastSeq` watermark with `accept` / `forget` / `clear`. Honours the protocol's reconnect rule (a fresh session restarts at `seq = 1`) by exposing `forget(peerId)` for the dirty-disconnect path. `watermarks` is unmodifiable so callers can't accidentally raise the bar and silently swallow a real message.
- **`lib/services/audio_service.dart`** — adds `startVoice()`, `stopVoice()`, `setMuted(bool)`. Same defensive pattern as the existing methods: catch native errors, log, return `false`. Native side will start handling these in the BLE/L2CAP PR.
- **`lib/screens/frequency_room_screen.dart`** — accepts an optional `AudioService` (defaults to a real instance), calls `startVoice` on entry / `stopVoice` on dispose, and pushes `setMuted` alongside every Mute toggle and PTT hold/release. PTT release re-mutes defensively in case `onPointerCancel` is missed.

The "settings affordance for renaming" ask is already met by the identity chip in the Discovery chrome — it opens the existing `_RenameSheet` which routes through `cubit.rename()`. No change needed.

## Why this PR is pure Dart

The full TODO list (BLE advertising, GATT server, L2CAP CoC, Oboe mic capture, Opus, mix-minus) needs ~2000 lines of native Kotlin that can't be verified without two real Android devices in the same room. Splitting that out into its own PR keeps this one fully testable today (`flutter analyze` clean, all 168 tests passing in WSL) and gives the native PR a concrete Dart-side seam to plug into.

## Test plan

- [x] `flutter analyze` — no issues.
- [x] `flutter test` — 168 passing, 1 pre-existing skip (modal-sheet integration test deferred to real device).
- [x] New tests cover the encoder, the reassembler (every error branch), the sequence filter (duplicates, out-of-order, per-peer independence, reconnect via `forget`), and the room-screen audio plumbing (startVoice/stopVoice lifecycle, setMuted on every Mute toggle and PTT press/release).
- [ ] Smoke-test on a device once the native BLE/L2CAP PR lands — this PR's behavior is invisible to the user until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated native voice capture with start/stop and mute controls.
  * Added a robust JSON message fragmentation and reassembly protocol for large payloads.

* **Improvements**
  * Receiver-side sequence filtering to avoid duplicates and out-of-order processing.
  * Better synchronization of UI mute (PTT/open‑mic) with the audio engine.

* **Tests**
  * New unit and widget tests for fragmentation, sequencing, and audio interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->