### PR TITLE
Delete duplicate com.example.flutter_application_1.MainActivity (#31)

### DIFF
--- a/android/app/src/main/kotlin/com/example/flutter_application_1/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/flutter_application_1/MainActivity.kt
@@ -1,5 +1,0 @@
-package com.example.flutter_application_1
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity : FlutterActivity()


### PR DESCRIPTION
## Summary
- Removes the dead `com/example/flutter_application_1/MainActivity.kt` directory under the Android source tree.
- The active entry point is `com.elodin.walkie_talkie.MainActivity` per `android/app/build.gradle.kts` `applicationId` + `namespace`; `AndroidManifest.xml` declares `.MainActivity` relative to that namespace, so the deleted copy was unreferenced.

Closes #31.

## Notes on issue acceptance criteria
The issue's `grep -r flutter_application_1` acceptance check still has hits in iOS/macOS/Linux/Windows/web scaffolding (untouched here). Those are slated for removal in #36 ("Delete iOS / macOS / Windows / Linux scaffolding (Android-only v1)"), so I'm scoping this PR to the file explicitly listed in #31's "Files" section.

## Test plan
- [x] `flutter analyze` — no issues found
- [x] `flutter test` — 185 tests pass
- [ ] CI green
- [ ] Reviewer (Gemini / Copilot / CodeRabbit) signoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal app initialization structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->