### PR TITLE
Add release signing config with debug fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ app.*.symbols
 **/android/local.properties
 **/android/generated/
 **/android/key.properties
+**/android/keystore.jks
 
 # iOS/XCode related
 **/ios/**/*.mode1v3

--- a/android/SIGNING.md
+++ b/android/SIGNING.md
@@ -1,0 +1,53 @@
+# Release Signing Configuration
+
+This app uses a signing configuration that falls back to debug keys when no release keystore is configured. This allows `flutter run --release` to work in development while supporting proper release signing for distribution.
+
+## Setup for Release Builds
+
+To sign release builds with your own keystore:
+
+### 1. Generate a keystore
+
+```bash
+keytool -genkey -v -keystore android/keystore.jks -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+```
+
+Follow the prompts to set:
+- Keystore password
+- Key password
+- Your name, organization, etc.
+
+### 2. Create key.properties
+
+Create `android/key.properties` with the following content:
+
+```properties
+storeFile=keystore.jks
+storePassword=<your keystore password>
+keyAlias=upload
+keyPassword=<your key password>
+```
+
+**Important:** Both `keystore.jks` and `key.properties` are already in `.gitignore` and should **never** be committed to version control.
+
+### 3. Build the release APK
+
+```bash
+flutter build apk --release
+```
+
+The APK will be signed with your release keystore.
+
+## Fallback Behavior
+
+If `key.properties` doesn't exist:
+- Release builds fall back to debug signing
+- This is fine for local testing with `flutter run --release`
+- CI builds without a keystore configured will use debug signing
+
+## CI/CD
+
+For automated builds, you can:
+1. Store the keystore and credentials as secrets in your CI system
+2. Generate `key.properties` from those secrets before building
+3. Or continue using debug signing for internal test builds

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -52,11 +52,11 @@ android {
             val keyPropsFile = rootProject.file("key.properties")
             if (keyPropsFile.exists()) {
                 val keyProps = java.util.Properties()
-                keyProps.load(java.io.FileInputStream(keyPropsFile))
-                keyAlias = keyProps["keyAlias"] as String?
-                keyPassword = keyProps["keyPassword"] as String?
-                storeFile = keyProps["storeFile"]?.let { file(it as String) }
-                storePassword = keyProps["storePassword"] as String?
+                keyPropsFile.inputStream().use { keyProps.load(it) }
+                keyAlias = keyProps.getProperty("keyAlias")
+                keyPassword = keyProps.getProperty("keyPassword")
+                storeFile = keyProps.getProperty("storeFile")?.let { rootProject.file(it) }
+                storePassword = keyProps.getProperty("storePassword")
             }
         }
     }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -47,11 +47,25 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            val keyPropsFile = rootProject.file("key.properties")
+            if (keyPropsFile.exists()) {
+                val keyProps = java.util.Properties()
+                keyProps.load(java.io.FileInputStream(keyPropsFile))
+                keyAlias = keyProps["keyAlias"] as String?
+                keyPassword = keyProps["keyPassword"] as String?
+                storeFile = keyProps["storeFile"]?.let { file(it as String) }
+                storePassword = keyProps["storePassword"] as String?
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName(
+                if (rootProject.file("key.properties").exists()) "release" else "debug"
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Land the release signing configuration that was TODO'd in `build.gradle.kts`. Hosts can now ship properly-signed release APKs while preserving the debug-key fallback so `flutter run --release` and CI builds keep working without secret configuration.

- **`android/app/build.gradle.kts`** — add `signingConfigs.release` block that loads credentials from `key.properties` when present; update `buildTypes.release` to use the release config when `key.properties` exists, falling back to debug signing otherwise. Removed the TODO comment.
- **`.gitignore`** — add `**/android/keystore.jks` (the `key.properties` entry was already present).
- **`android/SIGNING.md`** — documentation for keystore generation, `key.properties` format, and fallback behavior.

## Why this approach

The debug-key fallback was explicitly requested in the issue — it allows local dev (`flutter run --release`) to work without requiring every developer to generate a keystore, and lets CI builds proceed without secrets. When `key.properties` is configured, release builds use it; when absent, they fall back to debug signing.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 168 passing, 1 pre-existing skip
- [x] Verified build.gradle.kts syntax (no Gradle errors)
- [ ] Manual: generate a keystore per `SIGNING.md` instructions, confirm release APK is signed with it
- [ ] Manual: delete `key.properties`, confirm release build falls back to debug signing

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native audio capture integration for voice functionality with start, stop, and mute controls.

* **Documentation**
  * Added Android release signing documentation with step-by-step keystore configuration instructions for secure app releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->