### PR TITLE
Persist recent host frequencies for one-tap resume (#13)

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../protocol/messages.dart';
 import '../services/identity_store.dart';
+import '../services/recent_frequencies_store.dart';
 import 'frequency_session_state.dart';
 
 /// Owns session-level Frequency state and the side-effects that mutate it:
@@ -48,6 +49,7 @@ import 'frequency_session_state.dart';
 ///     the cubit.
 class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   final IdentityStore identityStore;
+  final RecentFrequenciesStore recentFrequenciesStore;
 
   final _mediaCommandsController = StreamController<MediaCommand>.broadcast();
 
@@ -60,8 +62,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
 
   int _seq = 0;
 
-  FrequencySessionCubit({required this.identityStore})
-      : super(const SessionBooting());
+  FrequencySessionCubit({
+    required this.identityStore,
+    required this.recentFrequenciesStore,
+  }) : super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
   /// exists, otherwise into Onboarding. Always exits Booting — even if the
@@ -75,9 +79,16 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       debugPrintStack(stackTrace: stackTrace);
     }
     if (isClosed) return;
-    emit(persisted != null
-        ? SessionDiscovery(myName: persisted)
-        : const SessionOnboarding());
+    if (persisted == null) {
+      emit(const SessionOnboarding());
+      return;
+    }
+    final recent = await _loadRecentFrequencies();
+    if (isClosed) return;
+    emit(SessionDiscovery(
+      myName: persisted,
+      recentHostedFrequencies: recent,
+    ));
   }
 
   /// Persists [name] and advances to Discovery. The state changes even if
@@ -90,7 +101,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       debugPrintStack(stackTrace: stackTrace);
     }
     if (isClosed) return;
-    emit(SessionDiscovery(myName: name));
+    final recent = await _loadRecentFrequencies();
+    if (isClosed) return;
+    emit(SessionDiscovery(
+      myName: name,
+      recentHostedFrequencies: recent,
+    ));
   }
 
   /// Persists the new [name] without changing the current stage. Same
@@ -108,8 +124,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     }
     if (isClosed) return;
     switch (state) {
-      case SessionDiscovery():
-        emit(SessionDiscovery(myName: name));
+      case final SessionDiscovery discovery:
+        // Preserve the loaded recent-frequencies list across renames —
+        // re-reading would be a wasted disk hit and would briefly flicker
+        // the Recent section if persistence is slow.
+        emit(SessionDiscovery(
+          myName: name,
+          recentHostedFrequencies: discovery.recentHostedFrequencies,
+        ));
       case final SessionRoom room:
         emit(room.copyWith(myName: name));
       case SessionBooting():
@@ -125,10 +147,23 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   ///
   /// Resets the per-link sequence counter to 0 so the next sent message
   /// starts at `seq = 1` per the protocol's reconnect rule.
-  void joinRoom({required String freq, required bool isHost}) {
+  ///
+  /// When [isHost] is true, the freq is recorded to the recent-hosted
+  /// list as a side-effect. Persistence runs in the background — a
+  /// failure or slow disk shouldn't block the transition into the room.
+  /// The updated list shows up the next time the user lands on
+  /// Discovery (via [leaveRoom]'s re-read).
+  Future<void> joinRoom({required String freq, required bool isHost}) async {
     final current = state;
     if (current is! SessionDiscovery) return;
     _seq = 0;
+    if (isHost) {
+      // Fire-and-forget: the user has already committed to entering the
+      // room, so we shouldn't await disk I/O before emitting. Errors are
+      // logged on the future and surfaced on next launch as a missing
+      // entry; nothing else depends on success here.
+      unawaited(_recordRecentFrequency(freq));
+    }
     emit(SessionRoom(
       myName: current.myName,
       roomFreq: freq,
@@ -139,11 +174,39 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// Drops back to Discovery and forgets the room. No-op if not in a
   /// room (e.g. duplicate leave triggered during a transition). Resets
   /// the sequence counter so the next room starts fresh.
-  void leaveRoom() {
+  ///
+  /// Re-reads the recent-frequencies list so a freq the user just
+  /// hosted appears at the top of the Recent section as soon as they
+  /// return to Discovery.
+  Future<void> leaveRoom() async {
     final current = state;
     if (current is! SessionRoom) return;
     _seq = 0;
-    emit(SessionDiscovery(myName: current.myName));
+    final recent = await _loadRecentFrequencies();
+    if (isClosed) return;
+    emit(SessionDiscovery(
+      myName: current.myName,
+      recentHostedFrequencies: recent,
+    ));
+  }
+
+  Future<List<String>> _loadRecentFrequencies() async {
+    try {
+      return await recentFrequenciesStore.getRecent();
+    } catch (error, stackTrace) {
+      debugPrint('Failed to load recent frequencies: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      return const [];
+    }
+  }
+
+  Future<void> _recordRecentFrequency(String freq) async {
+    try {
+      await recentFrequenciesStore.record(freq);
+    } catch (error, stackTrace) {
+      debugPrint('Failed to record recent frequency: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
   }
 
   /// Apply a `JoinAccepted` from the host. Replaces the room's snapshot

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -34,12 +34,24 @@ final class SessionOnboarding extends FrequencySessionState {
 
 /// User has a persisted display name and is on Discovery, but hasn't
 /// joined or created a frequency yet.
+///
+/// [recentHostedFrequencies] is the most-recent-first list of channels
+/// the local user has hosted on this device, sourced from
+/// `RecentFrequenciesStore`. Empty when the user hasn't hosted before
+/// or the persisted store couldn't be read. The list is expected to
+/// already be unmodifiable (Equatable diffs it element-wise, so a
+/// caller mutating it in place would silently break state-change
+/// detection).
 final class SessionDiscovery extends FrequencySessionState {
   final String myName;
-  const SessionDiscovery({required this.myName});
+  final List<String> recentHostedFrequencies;
+  const SessionDiscovery({
+    required this.myName,
+    this.recentHostedFrequencies = const [],
+  });
 
   @override
-  List<Object?> get props => [myName];
+  List<Object?> get props => [myName, recentHostedFrequencies];
 }
 
 /// User is in a room. Both [roomFreq] and [roomIsHost] are non-nullable

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'screens/frequency_onboarding_screen.dart';
 import 'screens/frequency_room_screen.dart';
 import 'services/bluetooth_discovery_service.dart';
 import 'services/identity_store.dart';
+import 'services/recent_frequencies_store.dart';
 import 'theme/app_theme.dart';
 import 'widgets/frequency_toast_host.dart';
 
@@ -24,10 +25,18 @@ class WalkieTalkieApp extends StatelessWidget {
   /// Override for tests; defaults to the Hive-backed implementation.
   final IdentityStore? identityStore;
 
+  /// Override for tests; defaults to the Hive-backed implementation.
+  final RecentFrequenciesStore? recentFrequenciesStore;
+
   /// Override for tests; defaults to the real Bluetooth-LE implementation.
   final DiscoveryService? discoveryService;
 
-  const WalkieTalkieApp({super.key, this.identityStore, this.discoveryService});
+  const WalkieTalkieApp({
+    super.key,
+    this.identityStore,
+    this.recentFrequenciesStore,
+    this.discoveryService,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +49,10 @@ class WalkieTalkieApp extends StatelessWidget {
         RepositoryProvider<IdentityStore>(
           create: (_) => identityStore ?? HiveIdentityStore(),
         ),
+        RepositoryProvider<RecentFrequenciesStore>(
+          create: (_) =>
+              recentFrequenciesStore ?? HiveRecentFrequenciesStore(),
+        ),
         RepositoryProvider<DiscoveryService>(
           create: (_) => discoveryService ?? DiscoveryService(),
         ),
@@ -49,6 +62,8 @@ class WalkieTalkieApp extends StatelessWidget {
           BlocProvider(
             create: (context) => FrequencySessionCubit(
               identityStore: context.read<IdentityStore>(),
+              recentFrequenciesStore:
+                  context.read<RecentFrequenciesStore>(),
             )..bootstrap(),
           ),
           BlocProvider(
@@ -106,15 +121,19 @@ class FrequencyApp extends StatelessWidget {
             cubit.completeOnboarding(name);
           },
         ),
-      SessionDiscovery(:final myName) => FrequencyDiscoveryScreen(
+      SessionDiscovery(:final myName, :final recentHostedFrequencies) =>
+        FrequencyDiscoveryScreen(
           myName: myName,
+          recentHostedFrequencies: recentHostedFrequencies,
           onRename: (name) {
             cubit.rename(name);
           },
-          onPick: (result) => cubit.joinRoom(
-            freq: result.freq,
-            isHost: result.isHost,
-          ),
+          // joinRoom is a Future<void> now that it persists; the cubit
+          // tolerates a fire-and-forget call (the user has already
+          // committed to entering the room).
+          onPick: (result) {
+            cubit.joinRoom(freq: result.freq, isHost: result.isHost);
+          },
         ),
       SessionRoom(:final myName, :final roomFreq, :final roomIsHost) =>
         FrequencyRoomScreen(
@@ -124,7 +143,13 @@ class FrequencyApp extends StatelessWidget {
           groupSize: 5,
           mediaKind: MediaKind.music,
           pttMode: false,
-          onLeave: cubit.leaveRoom,
+          // `leaveRoom` is async (re-reads recent frequencies before
+          // emitting), but `onLeave` is a sync VoidCallback — wrap
+          // explicitly so the discarded future is intentional rather
+          // than a tear-off lint.
+          onLeave: () {
+            cubit.leaveRoom();
+          },
         ),
     };
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -132,7 +134,9 @@ class FrequencyApp extends StatelessWidget {
           // tolerates a fire-and-forget call (the user has already
           // committed to entering the room).
           onPick: (result) {
-            cubit.joinRoom(freq: result.freq, isHost: result.isHost);
+            unawaited(
+              cubit.joinRoom(freq: result.freq, isHost: result.isHost),
+            );
           },
         ),
       SessionRoom(:final myName, :final roomFreq, :final roomIsHost) =>
@@ -148,7 +152,7 @@ class FrequencyApp extends StatelessWidget {
           // explicitly so the discarded future is intentional rather
           // than a tear-off lint.
           onLeave: () {
-            cubit.leaveRoom();
+            unawaited(cubit.leaveRoom());
           },
         ),
     };

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -28,11 +28,19 @@ class FrequencyDiscoveryScreen extends StatefulWidget {
   /// confirms an edit in the rename sheet.
   final ValueChanged<String> onRename;
 
+  /// Most-recent-first list of frequencies the local user has hosted on
+  /// this device. Surfaced as a "Recent" section so the user can re-host
+  /// a personal channel with one tap instead of accepting whichever
+  /// random frequency the create card happens to have minted this visit.
+  /// Empty (the default) hides the section entirely.
+  final List<String> recentHostedFrequencies;
+
   const FrequencyDiscoveryScreen({
     super.key,
     required this.onPick,
     required this.myName,
     required this.onRename,
+    this.recentHostedFrequencies = const [],
   });
 
   @override
@@ -100,6 +108,10 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                   _buildHero(context),
                   const SizedBox(height: 24),
                   _buildCreateCard(context),
+                  if (widget.recentHostedFrequencies.isNotEmpty) ...[
+                    const SectionLabel(text: 'Recent'),
+                    _buildRecentList(context),
+                  ],
                   SectionLabel(
                     text: 'Nearby',
                     trailing: _buildScanIndicator(context),
@@ -259,6 +271,29 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
     }
   }
 
+  Widget _buildRecentList(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return FreqCard(
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: [
+          for (int i = 0; i < widget.recentHostedFrequencies.length; i++)
+            _RecentRow(
+              key: ValueKey('recent-${widget.recentHostedFrequencies[i]}'),
+              freq: widget.recentHostedFrequencies[i],
+              first: i == 0,
+              accent: c.accentSoft,
+              accentInk: c.accentInk,
+              onResume: () => widget.onPick(DiscoveryResult(
+                freq: widget.recentHostedFrequencies[i],
+                isHost: true,
+              )),
+            ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildNearbyList(BuildContext context) {
     return BlocBuilder<DiscoveryCubit, DiscoveryState>(
       builder: (context, state) {
@@ -397,6 +432,110 @@ class _NearbyRow extends StatelessWidget {
   }
 }
 
+
+/// One row in the "Recent" card — a single tappable hit-target that
+/// re-hosts the freq when activated. Mirrors `_NearbyRow`'s visual
+/// language (icon disc + title + freq mono), but the trailing affordance
+/// is a "Resume" hint instead of signal bars + selection state since
+/// recents are a one-tap action with no per-row sub-selection.
+class _RecentRow extends StatelessWidget {
+  final String freq;
+  final bool first;
+  final Color accent;
+  final Color accentInk;
+  final VoidCallback onResume;
+
+  const _RecentRow({
+    super.key,
+    required this.freq,
+    required this.first,
+    required this.accent,
+    required this.accentInk,
+    required this.onResume,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Material(
+      color: c.surface,
+      child: InkWell(
+        onTap: onResume,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            border: Border(
+              top: first ? BorderSide.none : BorderSide(color: c.line),
+            ),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: accent,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                alignment: Alignment.center,
+                child: Icon(Icons.history, size: 16, color: accentInk),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Your channel',
+                      style: TextStyle(
+                        fontFamily: 'Inter',
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: c.ink,
+                      ),
+                    ),
+                    // Text.rich (rather than a Row of Texts) so the
+                    // freq + unit string can ellipsize gracefully when
+                    // the row is squeezed by a wide Resume button on
+                    // narrower phones — a Row would overflow instead.
+                    Text.rich(
+                      TextSpan(
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 12,
+                          color: c.ink3,
+                        ),
+                        children: [
+                          const TextSpan(text: 'Host on '),
+                          TextSpan(
+                            text: freq,
+                            style: kMonoStyle.copyWith(fontSize: 12),
+                          ),
+                          const TextSpan(text: ' MHz'),
+                        ],
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              FreqButton(
+                accent: true,
+                label: 'Resume',
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+                fontSize: 13,
+                onPressed: onResume,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
 
 /// Tappable circular chip in the chrome that shows the user's initials and
 /// opens the rename sheet when tapped.

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -1,0 +1,88 @@
+import 'package:hive/hive.dart';
+
+/// Persisted "frequencies the local user has hosted" list, most-recent
+/// first, capped at [HiveRecentFrequenciesStore.maxEntries]. Lets the
+/// Discovery screen offer one-tap resume of recent personal channels
+/// without redialling a fresh random freq each visit.
+///
+/// Decoupled from [IdentityStore] on purpose: identity carries who the
+/// user is (display name + peerId); recent frequencies are a UX
+/// convenience the user can clear without losing their identity. Mixing
+/// them in one box would conflate "rename me" with "forget my channel
+/// history".
+abstract class RecentFrequenciesStore {
+  /// Returns the persisted list, most-recent first. Empty when nothing
+  /// has been recorded yet. The returned list is unmodifiable; callers
+  /// that need to mutate must copy.
+  Future<List<String>> getRecent();
+
+  /// Records [freq] as the most-recent host frequency. Trims; an empty
+  /// or whitespace-only value is ignored. Existing entries equal to the
+  /// trimmed value are de-duplicated (the entry moves to the front
+  /// rather than being added a second time). The list is capped at
+  /// [HiveRecentFrequenciesStore.maxEntries] — older entries roll off
+  /// the end.
+  Future<void> record(String freq);
+
+  /// Drops every persisted entry. The next [getRecent] returns empty.
+  Future<void> clear();
+}
+
+/// Hive-backed [RecentFrequenciesStore] keyed in a single dynamic box.
+///
+/// The list is stored under a single key (rather than one entry per
+/// indexed key) so reordering on `record` is a single put — the cap is
+/// small enough that the cost of rewriting the whole list is negligible
+/// and the bounded size keeps the box compact.
+class HiveRecentFrequenciesStore implements RecentFrequenciesStore {
+  static const String _boxName = 'recent_frequencies';
+  static const String _key = 'list';
+
+  /// Cap on retained entries. The Discovery screen renders all of them
+  /// inline, so the bound is a UX choice rather than a storage one.
+  static const int maxEntries = 5;
+
+  // `Box<dynamic>` because Hive's typed boxes don't model `List<String>`
+  // cleanly without a custom adapter — the value-type parameter is the
+  // *element* type, but a list value would need the box's element type
+  // to be the list itself. Casting on read keeps the call sites typed.
+  Box<dynamic>? _box;
+
+  Future<Box<dynamic>> _open() async {
+    final existing = _box;
+    if (existing != null && existing.isOpen) return existing;
+    final box = await Hive.openBox<dynamic>(_boxName);
+    _box = box;
+    return box;
+  }
+
+  @override
+  Future<List<String>> getRecent() async {
+    final box = await _open();
+    final raw = box.get(_key);
+    if (raw is! List) return const [];
+    return List<String>.unmodifiable(raw.cast<String>());
+  }
+
+  @override
+  Future<void> record(String freq) async {
+    final trimmed = freq.trim();
+    if (trimmed.isEmpty) return;
+    final box = await _open();
+    final raw = box.get(_key);
+    final current = raw is List ? raw.cast<String>() : const <String>[];
+    final updated = <String>[trimmed];
+    for (final entry in current) {
+      if (entry == trimmed) continue;
+      updated.add(entry);
+      if (updated.length >= maxEntries) break;
+    }
+    await box.put(_key, updated);
+  }
+
+  @override
+  Future<void> clear() async {
+    final box = await _open();
+    await box.delete(_key);
+  }
+}

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -84,7 +84,12 @@ class HiveRecentFrequenciesStore implements RecentFrequenciesStore {
     final box = await _open();
     final raw = box.get(_key);
     if (raw is! List) return const [];
-    return List<String>.unmodifiable(raw.cast<String>());
+    // `whereType<String>()` rather than `cast<String>()`: cast returns a
+    // lazy view that throws on the first non-String element when the
+    // unmodifiable wrapper iterates it, which would blow up bootstrap
+    // for a corrupted or schema-migrated payload. Filtering surfaces
+    // any still-valid entries and treats junk as empty.
+    return List<String>.unmodifiable(raw.whereType<String>().toList());
   }
 
   @override
@@ -99,7 +104,11 @@ class HiveRecentFrequenciesStore implements RecentFrequenciesStore {
     if (trimmed.isEmpty) return;
     final box = await _open();
     final raw = box.get(_key);
-    final current = raw is List ? raw.cast<String>() : const <String>[];
+    // Same safe-filter rationale as getRecent — a malformed payload
+    // (non-String entry) shouldn't throw mid-record and leak the
+    // exception up through the cubit's fire-and-forget boundary.
+    final current =
+        raw is List ? raw.whereType<String>().toList() : const <String>[];
     final updated = <String>[trimmed];
     for (final entry in current) {
       if (entry == trimmed) continue;

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -48,12 +48,35 @@ class HiveRecentFrequenciesStore implements RecentFrequenciesStore {
   // to be the list itself. Casting on read keeps the call sites typed.
   Box<dynamic>? _box;
 
+  /// In-flight `Hive.openBox` call. Cached so concurrent first-callers
+  /// share a single open instead of each issuing their own request to
+  /// Hive's internals. Cleared after the open settles so a later cycle
+  /// (e.g. a test calling `Hive.deleteFromDisk` + re-init) re-opens
+  /// against the new path instead of returning the old closed box.
+  Future<Box<dynamic>>? _openFuture;
+
+  /// Serializes `record` against itself. Each call chains onto the
+  /// previous, so two concurrent records can't both observe the same
+  /// pre-write state and last-write-wins one of them out of the list.
+  /// Errors on the chain are swallowed for the purpose of *chaining*
+  /// only — the original future still surfaces the failure to its
+  /// caller (and the cubit logs + drops it).
+  Future<void> _writeChain = Future.value();
+
   Future<Box<dynamic>> _open() async {
     final existing = _box;
     if (existing != null && existing.isOpen) return existing;
-    final box = await Hive.openBox<dynamic>(_boxName);
-    _box = box;
-    return box;
+    final pending = _openFuture;
+    if (pending != null) return pending;
+    final future = Hive.openBox<dynamic>(_boxName);
+    _openFuture = future;
+    try {
+      final box = await future;
+      _box = box;
+      return box;
+    } finally {
+      _openFuture = null;
+    }
   }
 
   @override
@@ -65,7 +88,13 @@ class HiveRecentFrequenciesStore implements RecentFrequenciesStore {
   }
 
   @override
-  Future<void> record(String freq) async {
+  Future<void> record(String freq) {
+    final next = _writeChain.then((_) => _doRecord(freq));
+    _writeChain = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _doRecord(String freq) async {
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
     final box = await _open();

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -7,6 +7,7 @@ import 'package:walkie_talkie/bloc/frequency_session_state.dart';
 import 'package:walkie_talkie/protocol/messages.dart';
 import 'package:walkie_talkie/protocol/peer.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
+import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 
 class _FakeStore implements IdentityStore {
   String? _name;
@@ -39,16 +40,56 @@ class _FakeStore implements IdentityStore {
   }
 }
 
+class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
+  final List<String> _entries;
+  bool throwOnGet = false;
+  bool throwOnRecord = false;
+  int recordCalls = 0;
+
+  _FakeRecentFrequenciesStore({List<String>? initial})
+      : _entries = List<String>.of(initial ?? const []);
+
+  @override
+  Future<List<String>> getRecent() async {
+    if (throwOnGet) throw StateError('boom');
+    return List<String>.unmodifiable(_entries);
+  }
+
+  @override
+  Future<void> record(String freq) async {
+    recordCalls++;
+    if (throwOnRecord) throw StateError('boom');
+    final trimmed = freq.trim();
+    if (trimmed.isEmpty) return;
+    _entries
+      ..remove(trimmed)
+      ..insert(0, trimmed);
+  }
+
+  @override
+  Future<void> clear() async => _entries.clear();
+}
+
+FrequencySessionCubit _makeCubit({
+  IdentityStore? identityStore,
+  RecentFrequenciesStore? recentFrequenciesStore,
+}) =>
+    FrequencySessionCubit(
+      identityStore: identityStore ?? _FakeStore(),
+      recentFrequenciesStore:
+          recentFrequenciesStore ?? _FakeRecentFrequenciesStore(),
+    );
+
 void main() {
   group('FrequencySessionCubit', () {
     test('starts in SessionBooting', () {
-      final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+      final cubit = _makeCubit();
       expect(cubit.state, isA<SessionBooting>());
     });
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'bootstrap with a persisted name routes to Discovery',
-      build: () => FrequencySessionCubit(
+      build: () => _makeCubit(
         identityStore: _FakeStore(initial: 'Maya'),
       ),
       act: (cubit) => cubit.bootstrap(),
@@ -57,14 +98,14 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'bootstrap without a persisted name routes to Onboarding',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       act: (cubit) => cubit.bootstrap(),
       expect: () => [const SessionOnboarding()],
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'bootstrap falls through to Onboarding when the store throws',
-      build: () => FrequencySessionCubit(
+      build: () => _makeCubit(
         identityStore: _FakeStore()..throwOnGet = true,
       ),
       act: (cubit) => cubit.bootstrap(),
@@ -73,7 +114,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'completeOnboarding persists and advances to Discovery',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionOnboarding(),
       act: (cubit) => cubit.completeOnboarding('Devon'),
       expect: () => [const SessionDiscovery(myName: 'Devon')],
@@ -85,7 +126,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'completeOnboarding still advances when persistence throws',
-      build: () => FrequencySessionCubit(
+      build: () => _makeCubit(
         identityStore: _FakeStore()..throwOnSet = true,
       ),
       seed: () => const SessionOnboarding(),
@@ -95,7 +136,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'rename in Discovery updates the name in place',
-      build: () => FrequencySessionCubit(
+      build: () => _makeCubit(
         identityStore: _FakeStore(initial: 'Maya'),
       ),
       seed: () => const SessionDiscovery(myName: 'Maya'),
@@ -105,7 +146,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'rename still updates name when persistence throws',
-      build: () => FrequencySessionCubit(
+      build: () => _makeCubit(
         identityStore: _FakeStore(initial: 'Maya')..throwOnSet = true,
       ),
       seed: () => const SessionDiscovery(myName: 'Maya'),
@@ -115,7 +156,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'rename in Room preserves freq + host role',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -133,7 +174,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'rename in Booting/Onboarding is a no-op on the visible state',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionOnboarding(),
       act: (cubit) => cubit.rename('Sam'),
       expect: () => const <FrequencySessionState>[],
@@ -141,7 +182,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'joinRoom from Discovery enters the Room with freq + host flag',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionDiscovery(myName: 'Maya'),
       act: (cubit) => cubit.joinRoom(freq: '104.3', isHost: true),
       expect: () => [
@@ -155,7 +196,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'joinRoom outside Discovery is a no-op',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionOnboarding(),
       act: (cubit) => cubit.joinRoom(freq: '104.3', isHost: true),
       expect: () => const <FrequencySessionState>[],
@@ -163,7 +204,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'leaveRoom drops back to Discovery with the prior name',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -175,17 +216,180 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'leaveRoom outside Room is a no-op',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionDiscovery(myName: 'Maya'),
       act: (cubit) => cubit.leaveRoom(),
       expect: () => const <FrequencySessionState>[],
+    );
+
+    // ── Recent-frequencies persistence ─────────────────────────────────
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'bootstrap surfaces the persisted recent-frequencies list on Discovery',
+      build: () => _makeCubit(
+        identityStore: _FakeStore(initial: 'Maya'),
+        recentFrequenciesStore: _FakeRecentFrequenciesStore(
+          initial: const ['100.1', '92.4'],
+        ),
+      ),
+      act: (cubit) => cubit.bootstrap(),
+      expect: () => [
+        const SessionDiscovery(
+          myName: 'Maya',
+          recentHostedFrequencies: ['100.1', '92.4'],
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'bootstrap with no persisted name does not read recent frequencies',
+      // No name → Onboarding; the store hasn't been used by the user yet,
+      // so reading it would just be wasted I/O on a fresh install.
+      build: () => _makeCubit(
+        recentFrequenciesStore: _FakeRecentFrequenciesStore()..throwOnGet = true,
+      ),
+      act: (cubit) => cubit.bootstrap(),
+      expect: () => [const SessionOnboarding()],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'bootstrap tolerates a recent-frequencies read failure',
+      // Name reads fine, recent-freqs read throws — Discovery should
+      // still land, with an empty list, instead of stranding the user
+      // in Booting.
+      build: () => _makeCubit(
+        identityStore: _FakeStore(initial: 'Maya'),
+        recentFrequenciesStore: _FakeRecentFrequenciesStore()..throwOnGet = true,
+      ),
+      act: (cubit) => cubit.bootstrap(),
+      expect: () => [const SessionDiscovery(myName: 'Maya')],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'completeOnboarding loads recent frequencies into Discovery',
+      build: () => _makeCubit(
+        recentFrequenciesStore: _FakeRecentFrequenciesStore(
+          initial: const ['92.4'],
+        ),
+      ),
+      seed: () => const SessionOnboarding(),
+      act: (cubit) => cubit.completeOnboarding('Devon'),
+      expect: () => [
+        const SessionDiscovery(
+          myName: 'Devon',
+          recentHostedFrequencies: ['92.4'],
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'rename in Discovery preserves the recent-frequencies list',
+      // Re-reading on every rename would be wasted I/O and would briefly
+      // flicker the section if persistence is slow — the loaded list
+      // should pass through unchanged.
+      build: () => _makeCubit(
+        identityStore: _FakeStore(initial: 'Maya'),
+      ),
+      seed: () => const SessionDiscovery(
+        myName: 'Maya',
+        recentHostedFrequencies: ['100.1', '92.4'],
+      ),
+      act: (cubit) => cubit.rename('Maya R.'),
+      expect: () => [
+        const SessionDiscovery(
+          myName: 'Maya R.',
+          recentHostedFrequencies: ['100.1', '92.4'],
+        ),
+      ],
+    );
+
+    test(
+      'joinRoom as host records the freq in the recent-frequencies store',
+      () async {
+        final recent = _FakeRecentFrequenciesStore();
+        final cubit = _makeCubit(recentFrequenciesStore: recent);
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        // Let the fire-and-forget record() complete.
+        await Future<void>.delayed(Duration.zero);
+
+        expect(recent.recordCalls, 1);
+        expect(await recent.getRecent(), ['104.3']);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'joinRoom as guest does NOT record the freq',
+      () async {
+        // Guest-side joins reflect "I tuned in to someone else's channel"
+        // — those don't belong in *my* recent-hosted list.
+        final recent = _FakeRecentFrequenciesStore();
+        final cubit = _makeCubit(recentFrequenciesStore: recent);
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(freq: '104.3', isHost: false);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(recent.recordCalls, 0);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'joinRoom as host swallows record() failures',
+      () async {
+        // The user has already committed to entering the room; a disk
+        // hiccup must not bubble up as an unhandled async error or
+        // block the state transition.
+        final recent = _FakeRecentFrequenciesStore()..throwOnRecord = true;
+        final cubit = _makeCubit(recentFrequenciesStore: recent);
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await expectLater(
+          cubit.joinRoom(freq: '104.3', isHost: true),
+          completes,
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(cubit.state, isA<SessionRoom>());
+
+        await cubit.close();
+      },
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'leaveRoom re-reads recent frequencies so a just-hosted freq is at the top',
+      build: () {
+        // Pre-seed the store with '104.3' to model the freq the user
+        // just hosted having been recorded during joinRoom.
+        return _makeCubit(
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(
+            initial: const ['104.3', '92.4'],
+          ),
+        );
+      },
+      seed: () => const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: true,
+      ),
+      act: (cubit) => cubit.leaveRoom(),
+      expect: () => [
+        const SessionDiscovery(
+          myName: 'Maya',
+          recentHostedFrequencies: ['104.3', '92.4'],
+        ),
+      ],
     );
 
     // ── Wire-protocol surface ──────────────────────────────────────────
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'applyJoinAccepted lands roster + hostPeerId + mediaState on the room',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -255,7 +459,7 @@ void main() {
       // The host-has-nothing-playing case: copyWith must distinguish
       // "argument omitted" from "argument explicitly null", or the stale
       // mediaState from the last connection survives the rejoin.
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -289,7 +493,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'applyJoinAccepted outside SessionRoom is a no-op',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => const SessionDiscovery(myName: 'Maya'),
       act: (cubit) => cubit.applyJoinAccepted(JoinAccepted(
         peerId: 'p-host',
@@ -305,7 +509,7 @@ void main() {
       // Per the protocol: a fresh JoinAccepted (initial join or reconnect)
       // resets seq counters on both ends — receivers clear lastSeq[peer]
       // and senders restart at 1. We exercise the sender side here.
-      final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+      final cubit = _makeCubit();
       cubit.emit(const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -333,7 +537,7 @@ void main() {
     });
 
     test('sendMediaCommand emits the originator command on the stream', () async {
-      final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+      final cubit = _makeCubit();
       cubit.emit(const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -366,7 +570,7 @@ void main() {
       'applyHostMediaEcho re-emits the host-echoed command for non-originator UI '
       'reaction',
       () async {
-        final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+        final cubit = _makeCubit();
         cubit.emit(const SessionRoom(
           myName: 'Maya',
           roomFreq: '104.3',
@@ -400,7 +604,7 @@ void main() {
     test('applyJoinAccepted after close is a silent no-op', () async {
       // BLE callbacks can fire after the user navigates away and the
       // cubit closes; we shouldn't throw on a post-dispose emit.
-      final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+      final cubit = _makeCubit();
       cubit.emit(const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -425,7 +629,7 @@ void main() {
       // unhandled async errors — room-screen callers fire-and-forget,
       // so an unhandled rethrow would crash the zone.
       final store = _FakeStore()..throwOnGetPeerId = true;
-      final cubit = FrequencySessionCubit(identityStore: store);
+      final cubit = _makeCubit(identityStore: store);
       cubit.emit(const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -446,7 +650,7 @@ void main() {
       // `Bad state: Cannot add new events after calling close`.
       final completer = Completer<String>();
       final store = _GatedPeerIdStore(completer.future);
-      final cubit = FrequencySessionCubit(identityStore: store);
+      final cubit = _makeCubit(identityStore: store);
       cubit.emit(const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -471,7 +675,7 @@ void main() {
     test('applyHostMediaEcho after close is a silent no-op', () async {
       // Same shape: a late RESPONSE-notify shouldn't throw
       // `Bad state: Cannot add new events after calling close`.
-      final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+      final cubit = _makeCubit();
       cubit.emit(const SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',
@@ -492,7 +696,7 @@ void main() {
     });
 
     test('applyHostMediaEcho outside SessionRoom is a no-op', () async {
-      final cubit = FrequencySessionCubit(identityStore: _FakeStore());
+      final cubit = _makeCubit();
       // No room emitted; we're sitting in Booting.
       final emissions = <MediaCommand>[];
       final sub = cubit.mediaCommands.listen(emissions.add);
@@ -514,7 +718,7 @@ void main() {
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'rename in Room preserves the JoinAccepted snapshot fields',
-      build: () => FrequencySessionCubit(identityStore: _FakeStore()),
+      build: () => _makeCubit(),
       seed: () => SessionRoom(
         myName: 'Maya',
         roomFreq: '104.3',

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -64,6 +64,14 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
     _entries
       ..remove(trimmed)
       ..insert(0, trimmed);
+    // Mirror the production cap so the fake doesn't silently let tests
+    // drift past behavior the real store enforces.
+    if (_entries.length > HiveRecentFrequenciesStore.maxEntries) {
+      _entries.removeRange(
+        HiveRecentFrequenciesStore.maxEntries,
+        _entries.length,
+      );
+    }
   }
 
   @override

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -177,5 +177,70 @@ void main() {
       expect(picked!.isHost, isTrue);
       expect(picked!.freq, isNotEmpty);
     });
+
+    testWidgets(
+      'omits the Recent section when there are no persisted frequencies',
+      (tester) async {
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            // recentHostedFrequencies defaults to empty.
+          ),
+        ));
+        await tester.pump();
+
+        expect(find.text('RECENT'), findsNothing);
+        expect(find.text('Resume'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'renders a Resume row per persisted recent frequency',
+      (tester) async {
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const ['100.1', '92.4'],
+          ),
+        ));
+        await tester.pump();
+
+        expect(find.text('RECENT'), findsOneWidget);
+        // One Resume button per row.
+        expect(find.text('Resume'), findsNWidgets(2));
+        // Each row's freq is rendered inside a Text.rich span, so match
+        // by substring rather than exact text.
+        expect(find.textContaining('100.1'), findsOneWidget);
+        expect(find.textContaining('92.4'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping a Resume row fires onPick with isHost: true and that freq',
+      (tester) async {
+        DiscoveryResult? picked;
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (r) => picked = r,
+            onRename: (_) {},
+            recentHostedFrequencies: const ['100.1', '92.4'],
+          ),
+        ));
+        await tester.pump();
+
+        // Tap the second row's Resume button.
+        await tester.tap(find.text('Resume').last);
+        await tester.pump();
+
+        expect(picked, isNotNull);
+        expect(picked!.isHost, isTrue);
+        expect(picked!.freq, '92.4');
+      },
+    );
   });
 }

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:walkie_talkie/data/frequency_mock_data.dart';
 import 'package:walkie_talkie/protocol/messages.dart';
 import 'package:walkie_talkie/screens/frequency_room_screen.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
+import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/frequency_toast_host.dart';
 
@@ -361,7 +362,10 @@ void main() {
       'rejoin with no mediaState resets the transport instead of stranding '
       'on the prior snapshot',
       (tester) async {
-        final cubit = FrequencySessionCubit(identityStore: _MemoryStore());
+        final cubit = FrequencySessionCubit(
+          identityStore: _MemoryStore(),
+          recentFrequenciesStore: _NullRecentFrequenciesStore(),
+        );
         addTearDown(cubit.close);
 
         cubit
@@ -406,7 +410,10 @@ void main() {
     testWidgets(
       'snapshot for an unknown source is dropped — UI keeps the prior queue',
       (tester) async {
-        final cubit = FrequencySessionCubit(identityStore: _MemoryStore());
+        final cubit = FrequencySessionCubit(
+          identityStore: _MemoryStore(),
+          recentFrequenciesStore: _NullRecentFrequenciesStore(),
+        );
         addTearDown(cubit.close);
 
         cubit
@@ -536,7 +543,10 @@ void main() {
       'applyJoinAccepted snapshot seeds the local player on rejoin',
       (tester) async {
         // Real cubit so the BlocListener actually reacts to state changes.
-        final cubit = FrequencySessionCubit(identityStore: _MemoryStore());
+        final cubit = FrequencySessionCubit(
+          identityStore: _MemoryStore(),
+          recentFrequenciesStore: _NullRecentFrequenciesStore(),
+        );
         addTearDown(cubit.close);
 
         // Pretend the user already tuned in to a music room.
@@ -593,4 +603,15 @@ class _MemoryStore implements IdentityStore {
 
   @override
   Future<String> getPeerId() async => _peerId ??= 'me-peer-id';
+}
+
+/// Inert RecentFrequenciesStore — these tests don't exercise the
+/// recent-frequencies path, but the cubit constructor now requires one.
+class _NullRecentFrequenciesStore implements RecentFrequenciesStore {
+  @override
+  Future<List<String>> getRecent() async => const [];
+  @override
+  Future<void> record(String freq) async {}
+  @override
+  Future<void> clear() async {}
 }

--- a/test/services/recent_frequencies_store_test.dart
+++ b/test/services/recent_frequencies_store_test.dart
@@ -1,0 +1,110 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:walkie_talkie/services/recent_frequencies_store.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('recent_freqs_test_');
+    Hive.init(tempDir.path);
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('HiveRecentFrequenciesStore', () {
+    test('returns an empty list before any record', () async {
+      final store = HiveRecentFrequenciesStore();
+      expect(await store.getRecent(), isEmpty);
+    });
+
+    test('record + getRecent round-trips a single entry', () async {
+      final store = HiveRecentFrequenciesStore();
+      await store.record('92.4');
+      expect(await store.getRecent(), ['92.4']);
+    });
+
+    test('most recent entry comes first', () async {
+      final store = HiveRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.record('100.1');
+      await store.record('88.7');
+      expect(await store.getRecent(), ['88.7', '100.1', '92.4']);
+    });
+
+    test('re-recording an existing freq de-dupes and moves it to the front',
+        () async {
+      // Without dedupe, hosting the same channel twice would crowd out
+      // older entries with copies of itself.
+      final store = HiveRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.record('100.1');
+      await store.record('92.4');
+      expect(await store.getRecent(), ['92.4', '100.1']);
+    });
+
+    test('caps the list at maxEntries (older entries roll off)', () async {
+      final store = HiveRecentFrequenciesStore();
+      // Record one more than the cap.
+      for (var i = 0; i <= HiveRecentFrequenciesStore.maxEntries; i++) {
+        await store.record('${88 + i}.0');
+      }
+      final recent = await store.getRecent();
+      expect(recent, hasLength(HiveRecentFrequenciesStore.maxEntries));
+      // The very first record (88.0) should have rolled off.
+      expect(recent, isNot(contains('88.0')));
+      // Most recent is at the front.
+      expect(recent.first,
+          '${88 + HiveRecentFrequenciesStore.maxEntries}.0');
+    });
+
+    test('record trims whitespace', () async {
+      final store = HiveRecentFrequenciesStore();
+      await store.record('   92.4   ');
+      expect(await store.getRecent(), ['92.4']);
+    });
+
+    test('record with empty / whitespace-only is a no-op', () async {
+      final store = HiveRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.record('');
+      await store.record('   ');
+      expect(await store.getRecent(), ['92.4']);
+    });
+
+    test('persists across new HiveRecentFrequenciesStore instances', () async {
+      final first = HiveRecentFrequenciesStore();
+      await first.record('92.4');
+      await first.record('100.1');
+
+      final second = HiveRecentFrequenciesStore();
+      expect(await second.getRecent(), ['100.1', '92.4']);
+    });
+
+    test('clear empties the list', () async {
+      final store = HiveRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.record('100.1');
+      await store.clear();
+      expect(await store.getRecent(), isEmpty);
+    });
+
+    test('getRecent returns an unmodifiable list', () async {
+      // Callers shouldn't be able to mutate the returned list and have
+      // their changes observed by anyone else (or, worse, accidentally
+      // mutate cached state inside Hive's box).
+      final store = HiveRecentFrequenciesStore();
+      await store.record('92.4');
+      final recent = await store.getRecent();
+      expect(() => recent.add('100.1'), throwsUnsupportedError);
+    });
+  });
+}

--- a/test/services/recent_frequencies_store_test.dart
+++ b/test/services/recent_frequencies_store_test.dart
@@ -97,6 +97,22 @@ void main() {
       expect(await store.getRecent(), isEmpty);
     });
 
+    test('concurrent record calls do not lose entries', () async {
+      // Without serialization, the read-modify-write inside `record`
+      // races: two callers can both read the same pre-write state and
+      // last-write-wins one of them out of the list. Fire several in
+      // parallel — every freq should survive.
+      final store = HiveRecentFrequenciesStore();
+      await Future.wait([
+        store.record('92.4'),
+        store.record('100.1'),
+        store.record('88.7'),
+        store.record('104.3'),
+      ]);
+      final recent = await store.getRecent();
+      expect(recent.toSet(), {'92.4', '100.1', '88.7', '104.3'});
+    });
+
     test('getRecent returns an unmodifiable list', () async {
       // Callers shouldn't be able to mutate the returned list and have
       // their changes observed by anyone else (or, worse, accidentally

--- a/test/services/recent_frequencies_store_test.dart
+++ b/test/services/recent_frequencies_store_test.dart
@@ -113,6 +113,33 @@ void main() {
       expect(recent.toSet(), {'92.4', '100.1', '88.7', '104.3'});
     });
 
+    test(
+      'getRecent treats a List<dynamic> with mixed types as a filtered '
+      'String list (no throw)',
+      () async {
+        // Simulate a Hive payload from a future schema migration / a
+        // direct write. `cast<String>()` would throw on the first
+        // non-String when the unmodifiable wrapper iterates it,
+        // blowing up bootstrap. `whereType<String>` filters silently.
+        final box = await Hive.openBox<dynamic>('recent_frequencies');
+        await box.put('list', <dynamic>['92.4', 42, '100.1', null, '88.7']);
+        await box.close();
+
+        final store = HiveRecentFrequenciesStore();
+        expect(await store.getRecent(), ['92.4', '100.1', '88.7']);
+      },
+    );
+
+    test('record over a malformed payload rebuilds a clean list', () async {
+      final box = await Hive.openBox<dynamic>('recent_frequencies');
+      await box.put('list', <dynamic>['92.4', 42, '100.1']);
+      await box.close();
+
+      final store = HiveRecentFrequenciesStore();
+      await store.record('104.3');
+      expect(await store.getRecent(), ['104.3', '92.4', '100.1']);
+    });
+
     test('getRecent returns an unmodifiable list', () async {
       // Callers shouldn't be able to mutate the returned list and have
       // their changes observed by anyone else (or, worse, accidentally

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -39,6 +39,14 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
     _entries
       ..remove(trimmed)
       ..insert(0, trimmed);
+    // Mirror the production cap so the fake doesn't silently let tests
+    // drift past behavior the real store enforces.
+    if (_entries.length > HiveRecentFrequenciesStore.maxEntries) {
+      _entries.removeRange(
+        HiveRecentFrequenciesStore.maxEntries,
+        _entries.length,
+      );
+    }
   }
 
   @override

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'package:walkie_talkie/main.dart';
 import 'package:walkie_talkie/protocol/discovery.dart';
 import 'package:walkie_talkie/services/bluetooth_discovery_service.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
+import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 
 class _FakeIdentityStore implements IdentityStore {
   String? _name;
@@ -23,6 +24,27 @@ class _FakeIdentityStore implements IdentityStore {
   Future<String> getPeerId() async => _peerId ??= 'fake-peer-id';
 }
 
+class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
+  final List<String> _entries;
+  _FakeRecentFrequenciesStore({List<String>? initial})
+      : _entries = List<String>.of(initial ?? const []);
+
+  @override
+  Future<List<String>> getRecent() async => List<String>.unmodifiable(_entries);
+
+  @override
+  Future<void> record(String freq) async {
+    final trimmed = freq.trim();
+    if (trimmed.isEmpty) return;
+    _entries
+      ..remove(trimmed)
+      ..insert(0, trimmed);
+  }
+
+  @override
+  Future<void> clear() async => _entries.clear();
+}
+
 class _FakeDiscoveryService implements DiscoveryService {
   @override
   Stream<List<DiscoveredSession>> get results => const Stream.empty();
@@ -41,6 +63,7 @@ void main() {
   testWidgets('first launch routes through onboarding', (tester) async {
     await tester.pumpWidget(WalkieTalkieApp(
       identityStore: _FakeIdentityStore(),
+      recentFrequenciesStore: _FakeRecentFrequenciesStore(),
       discoveryService: _FakeDiscoveryService(),
     ));
     // Boot splash → microtask flush → onboarding welcome.
@@ -57,6 +80,7 @@ void main() {
       await tester.pumpWidget(
         WalkieTalkieApp(
           identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
           discoveryService: _FakeDiscoveryService(),
         ),
       );
@@ -69,6 +93,31 @@ void main() {
           findsOneWidget);
       expect(find.text('Get started'), findsNothing);
       expect(find.text('MA'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'persisted recent frequencies appear in the Recent section on launch',
+    (tester) async {
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore:
+              _FakeRecentFrequenciesStore(initial: const ['100.1', '92.4']),
+          discoveryService: _FakeDiscoveryService(),
+        ),
+      );
+      // bootstrap awaits two reads (display name, recent frequencies); pump
+      // a few frames to clear them before asserting.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('RECENT'), findsOneWidget);
+      // Each row's freq is rendered inside a Text.rich span ("Host on X
+      // MHz"), so match by substring rather than exact text.
+      expect(find.textContaining('100.1'), findsOneWidget);
+      expect(find.textContaining('92.4'), findsOneWidget);
     },
   );
 }


### PR DESCRIPTION
## Summary

Closes the optional half of [#13](https://github.com/ElodinLaarz/walkie-talkie/issues/13). The first three acceptance criteria — persist display name, skip onboarding when one exists, and an in-app rename affordance — were already wired up by `HiveIdentityStore` + the cubit's `bootstrap` / `rename` paths. Only the recent-frequencies item was outstanding.

- **New `lib/services/recent_frequencies_store.dart`** — abstract `RecentFrequenciesStore` + `HiveRecentFrequenciesStore` backed by a single `recent_frequencies` box. Capped at 5 entries; re-recording an existing freq dedupes (moves it to the front rather than crowding out older history); empty / whitespace-only input is a no-op; clear() drops everything. Returned lists are `unmodifiable`.
- **`FrequencySessionCubit`** takes the store as a second required dep. Loads on `bootstrap` / `completeOnboarding` / `leaveRoom` so the Discovery state always carries the fresh list; records on `joinRoom(isHost: true)` **fire-and-forget** because the user has already committed to entering the room and disk I/O must not block the state transition. Recent-store failures are logged + swallowed — same defensive shape as the existing identity-store paths. Reads are skipped on the no-name → Onboarding branch so a fresh install doesn't pay an extra disk hit.
- **`SessionDiscovery`** carries the loaded list. Discovery stays a pure projection of state (no extra cubit / repository hop in the screen). Renames preserve the list rather than re-reading.
- **Discovery screen** surfaces a "Recent" card between Create and Nearby (only when non-empty). Each row mirrors the Nearby row's visual language — disc icon + title + freq subtitle + accent "Resume" button — but the freq subtitle uses `Text.rich` with `TextOverflow.ellipsis` so a wide trailing button can't blow out the layout on narrower phones. Tapping `Resume` calls `onPick` with `isHost: true` and that freq.

## Acceptance criteria (from #13)

- [x] Persist the display name to Hive after onboarding finishes — already in place (`HiveIdentityStore.setDisplayName`).
- [x] On app start, if a name exists, skip onboarding and go to Discovery — already in place (cubit `bootstrap`).
- [x] Edit the display name later — already in place (identity chip in Discovery chrome → `_RenameSheet` → `cubit.rename`).
- [x] **Optional**: persist the last few frequencies hosted, surface for resume — done in this PR.

## Test plan

- [x] `flutter analyze` — clean.
- [x] `flutter test` — 208 passing, 1 pre-existing skip (modal-sheet integration test deferred to real device); ran on WSL Debian.
- [x] Native `mixer_test` — still compiles + passes.
- [x] New tests cover:
  - **Store** (9): empty initial state, round-trip, ordering, dedupe-and-move-to-front, cap rollover, whitespace handling, persistence across instances, `clear`, returned-list immutability.
  - **Cubit** (7): bootstrap surfaces the list, no-name skips the recent read, recent-read failure falls through to an empty list, `completeOnboarding` loads recents, rename preserves the list, `joinRoom(isHost: true/false)` records / doesn't record, record failures are swallowed, `leaveRoom` re-reads.
  - **Discovery screen** (3): Recent section is omitted when empty, renders one Resume row per freq, tapping a Resume row fires `onPick(freq, isHost: true)`.
  - **Widget end-to-end** (1): persisted recent frequencies show up on launch through `WalkieTalkieApp`.
- [ ] Smoke-test on a real device once a follow-up lands — the existing widget tests already cover the visible behavior, this is a Hive-only feature with no native side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Frequency discovery screen now displays a "Recent" section above nearby frequencies, showing the 5 most recently hosted frequencies ordered by most recent first
  * Quick "Resume" action allows users to instantly rejoin any previously hosted frequency with a single tap, improving accessibility to familiar channels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->