### PR TITLE
Carry sessionUuid + BT MAC end-to-end through discovery (#37)

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -145,6 +145,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// the user isn't on Discovery (shouldn't happen — Discovery is the
   /// only screen that triggers it).
   ///
+  /// On the guest side, the caller passes [macAddress] and
+  /// [sessionUuidLow8] from the discovered advertisement. Both are stored
+  /// on `SessionRoom` so the GATT-client transport can dial the host
+  /// later (the actual `connectToHost` call lands in the GATT-client
+  /// issue). On the host side both are null — the local user *is* the
+  /// host, so there's no remote to dial.
+  ///
   /// Resets the per-link sequence counter to 0 so the next sent message
   /// starts at `seq = 1` per the protocol's reconnect rule.
   ///
@@ -153,7 +160,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// failure or slow disk shouldn't block the transition into the room.
   /// The updated list shows up the next time the user lands on
   /// Discovery (via [leaveRoom]'s re-read).
-  Future<void> joinRoom({required String freq, required bool isHost}) async {
+  Future<void> joinRoom({
+    required String freq,
+    required bool isHost,
+    String? macAddress,
+    String? sessionUuidLow8,
+  }) async {
     final current = state;
     if (current is! SessionDiscovery) return;
     _seq = 0;
@@ -168,6 +180,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       myName: current.myName,
       roomFreq: freq,
       roomIsHost: isHost,
+      // Guest path threads MAC + session UUID through to the room state so
+      // the GATT-client transport can dial the host. Host path leaves them
+      // null — the local user is the host.
+      macAddress: isHost ? null : macAddress,
+      sessionUuidLow8: isHost ? null : sessionUuidLow8,
     ));
   }
 

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -86,6 +86,19 @@ final class SessionRoom extends FrequencySessionState {
   /// rationale.
   final MediaState? mediaState;
 
+  /// BT MAC of the host this guest is connected to, carried through from
+  /// Discovery. Null on the host side (the local user *is* the host, so
+  /// there's no remote to dial) and on Recent / cosmetic-only entries before
+  /// BLE is wired. The GATT-client transport reads this to dial the host.
+  final String? macAddress;
+
+  /// Low 8 bytes of the host's session UUID, in hex (16 chars). Carried
+  /// alongside [macAddress] so the BLE control plane can correlate the room
+  /// with the advertised session — multiple hosts on different sessions can
+  /// share a MAC if the same physical device hops sessions, so MAC alone
+  /// isn't a stable session key. Null in the same cases as [macAddress].
+  final String? sessionUuidLow8;
+
   const SessionRoom({
     required this.myName,
     required this.roomFreq,
@@ -93,6 +106,8 @@ final class SessionRoom extends FrequencySessionState {
     this.hostPeerId,
     this.roster = const [],
     this.mediaState,
+    this.macAddress,
+    this.sessionUuidLow8,
   });
 
   /// `??` would conflate "argument omitted" with "argument explicitly set
@@ -116,6 +131,8 @@ final class SessionRoom extends FrequencySessionState {
     Object? hostPeerId = _unset,
     List<ProtocolPeer>? roster,
     Object? mediaState = _unset,
+    Object? macAddress = _unset,
+    Object? sessionUuidLow8 = _unset,
   }) =>
       SessionRoom(
         myName: myName ?? this.myName,
@@ -130,9 +147,23 @@ final class SessionRoom extends FrequencySessionState {
         mediaState: identical(mediaState, _unset)
             ? this.mediaState
             : mediaState as MediaState?,
+        macAddress: identical(macAddress, _unset)
+            ? this.macAddress
+            : macAddress as String?,
+        sessionUuidLow8: identical(sessionUuidLow8, _unset)
+            ? this.sessionUuidLow8
+            : sessionUuidLow8 as String?,
       );
 
   @override
-  List<Object?> get props =>
-      [myName, roomFreq, roomIsHost, hostPeerId, roster, mediaState];
+  List<Object?> get props => [
+        myName,
+        roomFreq,
+        roomIsHost,
+        hostPeerId,
+        roster,
+        mediaState,
+        macAddress,
+        sessionUuidLow8,
+      ];
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -135,7 +135,12 @@ class FrequencyApp extends StatelessWidget {
           // committed to entering the room).
           onPick: (result) {
             unawaited(
-              cubit.joinRoom(freq: result.freq, isHost: result.isHost),
+              cubit.joinRoom(
+                freq: result.freq,
+                isHost: result.isHost,
+                macAddress: result.macAddress,
+                sessionUuidLow8: result.sessionUuidLow8,
+              ),
             );
           },
         ),

--- a/lib/protocol/discovery.dart
+++ b/lib/protocol/discovery.dart
@@ -13,6 +13,10 @@ class DiscoveredSession {
   final int rssi;
   final String mhzDisplay;
 
+  /// BT MAC of the advertising host. The guest hands this to the GATT client
+  /// on tap-to-join — without it there's nothing to dial.
+  final String macAddress;
+
   DiscoveredSession({
     required this.protocolVersion,
     required this.isHost,
@@ -20,6 +24,7 @@ class DiscoveredSession {
     required this.flags,
     required this.hostName,
     required this.rssi,
+    required this.macAddress,
   }) : mhzDisplay = _deriveMhz(sessionUuidLow8);
 
   /// Derives the cosmetic MHz display string from the session UUID.
@@ -63,6 +68,7 @@ class DiscoveredSession {
     Uint8List data, {
     required String hostName,
     required int rssi,
+    required String macAddress,
   }) {
     if (data.length < 16) return null;
 
@@ -88,6 +94,7 @@ class DiscoveredSession {
       flags: flags,
       hostName: hostName,
       rssi: rssi,
+      macAddress: macAddress,
     );
   }
 }

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -13,7 +13,23 @@ import '../widgets/frequency_atoms.dart';
 class DiscoveryResult {
   final String freq;
   final bool isHost;
-  const DiscoveryResult({required this.freq, required this.isHost});
+
+  /// BT MAC of the host the user tapped. Null when the user is creating a new
+  /// frequency (host path) or resuming a recent — there's no remote host
+  /// device to dial in those cases. Populated only when joining as a guest.
+  final String? macAddress;
+
+  /// Low 8 bytes of the host's session UUID (hex). Same shape as
+  /// [macAddress]: null on the host / Recent paths, populated when tuning in
+  /// to a discovered session so the guest can identify the host's room.
+  final String? sessionUuidLow8;
+
+  const DiscoveryResult({
+    required this.freq,
+    required this.isHost,
+    this.macAddress,
+    this.sessionUuidLow8,
+  });
 }
 
 /// Discovery — find & join a Frequency.
@@ -321,6 +337,8 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                     widget.onPick(DiscoveryResult(
                       freq: session.mhzDisplay,
                       isHost: false,
+                      macAddress: session.macAddress,
+                      sessionUuidLow8: session.sessionUuidLow8,
                     ));
                   },
                 ),

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -29,7 +29,16 @@ class DiscoveryResult {
     required this.isHost,
     this.macAddress,
     this.sessionUuidLow8,
-  });
+  })  : assert(
+          !isHost || (macAddress == null && sessionUuidLow8 == null),
+          'host DiscoveryResult must have null macAddress + sessionUuidLow8 — '
+          'the local user IS the host, there is no remote to dial',
+        ),
+        assert(
+          isHost || (macAddress != null && sessionUuidLow8 != null),
+          'guest DiscoveryResult must carry both macAddress and sessionUuidLow8 — '
+          'the GATT-client transport reads both off the room state to dial the host',
+        );
 }
 
 /// Discovery — find & join a Frequency.

--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -75,6 +75,7 @@ class DiscoveryService {
         data,
         hostName: r.advertisementData.advName,
         rssi: r.rssi,
+        macAddress: r.device.remoteId.str,
       );
       if (session != null) return session;
     }

--- a/test/bloc/discovery_cubit_test.dart
+++ b/test/bloc/discovery_cubit_test.dart
@@ -46,6 +46,7 @@ void main() {
         flags: 0,
         hostName: 'Host',
         rssi: -50,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
       ),
     ];
 
@@ -71,6 +72,7 @@ void main() {
         flags: 0,
         hostName: 'Host',
         rssi: -50,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
       ),
     ];
     resultsController.add(sessions);

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -211,6 +211,53 @@ void main() {
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'joinRoom as guest threads MAC + sessionUuidLow8 onto SessionRoom',
+      // The GATT-client transport (issue #43) reads these off SessionRoom
+      // to dial the host. They have to survive the Discovery → Room
+      // transition or the guest has nothing to connect to.
+      build: () => _makeCubit(),
+      seed: () => const SessionDiscovery(myName: 'Maya'),
+      act: (cubit) => cubit.joinRoom(
+        freq: '104.3',
+        isHost: false,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+        sessionUuidLow8: '0011223344556677',
+      ),
+      expect: () => [
+        const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: false,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          sessionUuidLow8: '0011223344556677',
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'joinRoom as host drops MAC + sessionUuidLow8 even if accidentally passed',
+      // The local user IS the host on this path, so a remote MAC would be
+      // meaningless. We strip it defensively rather than trusting callers
+      // to omit it — keeps SessionRoom's invariant clean for the
+      // GATT-client issue's "if mac != null, dial it" branch.
+      build: () => _makeCubit(),
+      seed: () => const SessionDiscovery(myName: 'Maya'),
+      act: (cubit) => cubit.joinRoom(
+        freq: '104.3',
+        isHost: true,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+        sessionUuidLow8: '0011223344556677',
+      ),
+      expect: () => [
+        const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: true,
+        ),
+      ],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
       'leaveRoom drops back to Discovery with the prior name',
       build: () => _makeCubit(),
       seed: () => const SessionRoom(

--- a/test/protocol/discovery_test.dart
+++ b/test/protocol/discovery_test.dart
@@ -12,11 +12,12 @@ void main() {
         0x00, 0x00, // flags
         0x00, 0x00, 0x00, 0x00, // reserved
       ]);
-      
+
       final session = DiscoveredSession.fromManufacturerData(
         data,
         hostName: "Maya's Pixel",
         rssi: -45,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
       );
 
       expect(session, isNotNull);
@@ -25,6 +26,31 @@ void main() {
       expect(session.sessionUuidLow8, '0011223344556677');
       expect(session.hostName, "Maya's Pixel");
       expect(session.rssi, -45);
+      expect(session.macAddress, 'AA:BB:CC:DD:EE:FF');
+    });
+
+    test('round-trips the macAddress through fromManufacturerData', () {
+      // The MAC isn't encoded in the advertisement payload — it comes from
+      // the BLE scan record on the device side. fromManufacturerData has
+      // to thread it through to DiscoveredSession unchanged so the guest's
+      // GATT-connect call can dial the right host.
+      final data = Uint8List.fromList([
+        0x01, 0x01,
+        0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE,
+        0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+      ]);
+      const mac = '11:22:33:44:55:66';
+
+      final session = DiscoveredSession.fromManufacturerData(
+        data,
+        hostName: 'Devon',
+        rssi: -60,
+        macAddress: mac,
+      );
+
+      expect(session, isNotNull);
+      expect(session!.macAddress, mac);
     });
 
     test('rejects advertisement with wrong version', () {
@@ -32,13 +58,23 @@ void main() {
         0x02, // Version 2 (unsupported)
         0x01, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
       ]);
-      final session = DiscoveredSession.fromManufacturerData(data, hostName: 'X', rssi: 0);
+      final session = DiscoveredSession.fromManufacturerData(
+        data,
+        hostName: 'X',
+        rssi: 0,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+      );
       expect(session, isNull);
     });
 
     test('rejects truncated advertisement', () {
       final data = Uint8List.fromList([0x01, 0x01, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x00, 0x00, 0x00]);
-      final session = DiscoveredSession.fromManufacturerData(data, hostName: 'X', rssi: 0);
+      final session = DiscoveredSession.fromManufacturerData(
+        data,
+        hostName: 'X',
+        rssi: 0,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+      );
       expect(session, isNull);
     });
 
@@ -55,6 +91,7 @@ void main() {
         flags: 0,
         hostName: 'H1',
         rssi: -50,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
       );
       // low12 = 0, tenths = 880 + 0 = 880, mhz = 88.0
       expect(s1.mhzDisplay, '88.0');
@@ -71,6 +108,7 @@ void main() {
         flags: 0,
         hostName: 'H2',
         rssi: -50,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
       );
       // low12 = 163, tenths = 880 + (163 % 200) = 880 + 163 = 1043, mhz = 104.3
       expect(s2.mhzDisplay, '104.3');
@@ -84,6 +122,7 @@ void main() {
         flags: 0,
         hostName: 'H3',
         rssi: -50,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
       );
       // low12 = 250, tenths = 880 + (250 % 200) = 880 + 50 = 930, mhz = 93.0
       expect(s3.mhzDisplay, '93.0');

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -243,4 +243,51 @@ void main() {
       },
     );
   });
+
+  group('DiscoveryResult invariants', () {
+    test('host DiscoveryResult with non-null MAC fails the host assert', () {
+      // The Start-a-new-Frequency and Resume-recent paths are local-only
+      // hosts — there's no remote to dial, so MAC + sessionUuidLow8 must
+      // stay null. Catch the bad state at construction.
+      expect(
+        () => DiscoveryResult(
+          freq: '104.3',
+          isHost: true,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('guest DiscoveryResult with null MAC fails the guest assert', () {
+      // The Nearby tap-to-join path always has both fields by construction
+      // (we just carried them off the discovered advertisement). A null
+      // here would mean the screen forgot to thread them — fail fast
+      // rather than letting #43 dial nothing.
+      expect(
+        () => DiscoveryResult(
+          freq: '104.3',
+          isHost: false,
+          sessionUuidLow8: '0011223344556677',
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('valid host and guest DiscoveryResults construct cleanly', () {
+      expect(
+        () => const DiscoveryResult(freq: '104.3', isHost: true),
+        returnsNormally,
+      );
+      expect(
+        () => const DiscoveryResult(
+          freq: '104.3',
+          isHost: false,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          sessionUuidLow8: '0011223344556677',
+        ),
+        returnsNormally,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Closes #37. Threads the BT MAC and `sessionUuidLow8` from a discovered advertisement all the way to `SessionRoom`, which is the seam the GATT-client work (#43) reads off to dial the host. Today the guest's tap on a Nearby row drops `r.device.remoteId.str` on the floor — without it, the GATT-client work has nothing to call `connectToHost(...)` with.

- **`lib/protocol/discovery.dart`** — `DiscoveredSession` gains a required `macAddress` field. `fromManufacturerData` requires it as a named arg; the MAC isn't in the advertisement payload, it comes from the BLE scan record on the device side.
- **`lib/services/bluetooth_discovery_service.dart`** — `_parseResult` passes `r.device.remoteId.str` as the MAC.
- **`lib/screens/frequency_discovery_screen.dart`** — `DiscoveryResult` gains optional `macAddress` and `sessionUuidLow8`. `_NearbyRow.onJoin` populates them from the tapped row; the host (Start a new Frequency) and Recent (Resume) paths leave them null because there's no remote host to dial in those cases.
- **`lib/bloc/frequency_session_state.dart`** — `SessionRoom` gains optional `macAddress` and `sessionUuidLow8`. `copyWith` uses the same `_unset`-sentinel pattern already established for `hostPeerId`/`mediaState` so a future explicit-null is distinguishable from "argument omitted."
- **`lib/bloc/frequency_session_cubit.dart`** — `joinRoom` accepts the two new optional named params and threads them onto `SessionRoom` on the guest path. Host path defensively strips them even if accidentally passed, keeping `SessionRoom`'s "non-null MAC means there's a remote to dial" invariant clean for #43's branch.
- **`lib/main.dart`** — top-level `onPick` callback forwards the new fields.

`sessionUuidLow8` is plumbed alongside MAC because MAC alone isn't a stable session key — the same physical device can host multiple sessions in succession — and the BLE control plane will need both halves to correlate the room with the advertised session.

## Deviation from the issue

The issue proposed renaming `joinRoom`'s `freq` parameter to `mhzDisplay` and making it optional. I left it as `required String freq` in this PR: every current caller still provides it, and the rename has no payoff until #39 (host-side bootstrap) lets the host derive freq from a minted UUID. Doing it now would be churn across `main.dart`, both cubit-state-using widget tests, and all the existing `joinRoom` test cases for no behavioral change.

## Test plan

- [x] `flutter analyze` — no issues.
- [x] `flutter test` — 215 passing, 1 pre-existing skip (modal-sheet integration deferred to a real device).
- [x] New: round-trip the MAC through `DiscoveredSession.fromManufacturerData`.
- [x] New: guest `joinRoom` puts MAC + `sessionUuidLow8` onto `SessionRoom`.
- [x] New: host `joinRoom` drops MAC + `sessionUuidLow8` even if accidentally passed.
- [x] Updated: every existing `DiscoveredSession` constructor call across the test suite (the constructor change is the breakage point).
- [ ] Smoke-test on a device once the GATT-client PR (#43) lands and starts reading `SessionRoom.macAddress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added device identification support when joining existing frequency sessions as a guest, capturing host device information for enhanced connection tracking.

* **Tests**
  * Updated test coverage for device identifier handling in session discovery and joining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->