### PR TITLE
feat(#45): parameterize encodeFragments with maxFragmentSize

### DIFF
--- a/lib/protocol/framing.dart
+++ b/lib/protocol/framing.dart
@@ -1,19 +1,22 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-/// Maximum control-plane MTU the protocol negotiates with Android.
-///
-/// Android caps GATT MTU at 247 bytes; the negotiation lives in the platform
-/// layer (see `docs/protocol.md` § GATT service) and the framing code below
-/// just sees byte buffers sized to that ceiling. Receivers SHOULD honour the
-/// `total_len` and `fragment_idx` header on the wire and not assume any
-/// particular fragment size, but encoders in this codebase default to
-/// splitting at [kMaxFragmentSize] when no negotiated MTU is supplied.
+/// Maximum bytes per wire fragment (full header + payload) that the v1
+/// protocol emits. This is the *fragment-size* ceiling, not an ATT MTU:
+/// callers with a negotiated ATT MTU of N should pass `min(N - 3, 247)` to
+/// [encodeFragments] (3 bytes go to the ATT write/notify opcode + handle).
+/// The negotiation itself lives in the platform layer (see
+/// `docs/protocol.md` § GATT service); the framing code only sees byte
+/// buffers sized at or below this ceiling. Receivers honour each
+/// fragment's `total_len` + `fragment_idx` header and never assume a
+/// particular per-fragment size.
 const int kMaxFragmentSize = 247;
 
-/// BLE default ATT MTU floor (23 bytes — BLE 4.0 spec). Two devices that
-/// fail to negotiate a higher MTU still guarantee at least this much per
-/// write, so the encoder rejects anything smaller as a caller bug rather
+/// Smallest fragment-size budget the encoder will honour, matching the
+/// BLE default GATT MTU of 23 bytes that two devices are guaranteed to
+/// support before any negotiation (see `docs/protocol.md` § GATT
+/// service). At that floor the payload budget is `23 - 4 = 19` bytes per
+/// fragment. The encoder rejects anything smaller as a caller bug rather
 /// than silently producing fragments the link can't carry.
 const int kMinFragmentSize = 23;
 
@@ -58,10 +61,11 @@ const int kFragmentFlagsV1 = 0x00;
 /// Each fragment is an independent BLE write — the receiver reassembles them
 /// using the `total_len` + `fragment_idx` header carried on every fragment.
 ///
-/// [maxFragmentSize] is the per-write byte ceiling (header + payload) and
-/// defaults to [kMaxFragmentSize]. Callers with access to a negotiated GATT
-/// MTU should pass it here so the encoder doesn't emit fragments the link
-/// will fragment again unpredictably. Must be in the closed range
+/// [maxFragmentSize] is the per-write byte ceiling (full fragment buffer
+/// = 4-byte header + payload) and defaults to [kMaxFragmentSize]. Callers
+/// with a negotiated ATT MTU should pass `min(mtu - 3, kMaxFragmentSize)`
+/// here so the encoder doesn't emit fragments the link will refragment
+/// unpredictably. Must be in the closed range
 /// `[kMinFragmentSize, kMaxFragmentSize]`; values outside throw
 /// `ArgumentError`.
 List<Uint8List> encodeFragments(

--- a/lib/protocol/framing.dart
+++ b/lib/protocol/framing.dart
@@ -7,9 +7,15 @@ import 'dart:typed_data';
 /// layer (see `docs/protocol.md` § GATT service) and the framing code below
 /// just sees byte buffers sized to that ceiling. Receivers SHOULD honour the
 /// `total_len` and `fragment_idx` header on the wire and not assume any
-/// particular fragment size, but every encoder in this codebase splits at
-/// [kMaxFragmentSize].
+/// particular fragment size, but encoders in this codebase default to
+/// splitting at [kMaxFragmentSize] when no negotiated MTU is supplied.
 const int kMaxFragmentSize = 247;
+
+/// BLE default ATT MTU floor (23 bytes — BLE 4.0 spec). Two devices that
+/// fail to negotiate a higher MTU still guarantee at least this much per
+/// write, so the encoder rejects anything smaller as a caller bug rather
+/// than silently producing fragments the link can't carry.
+const int kMinFragmentSize = 23;
 
 /// Fragment header in front of every chunk on the wire.
 ///
@@ -51,7 +57,27 @@ const int kFragmentFlagsV1 = 0x00;
 ///
 /// Each fragment is an independent BLE write — the receiver reassembles them
 /// using the `total_len` + `fragment_idx` header carried on every fragment.
-List<Uint8List> encodeFragments(String json) {
+///
+/// [maxFragmentSize] is the per-write byte ceiling (header + payload) and
+/// defaults to [kMaxFragmentSize]. Callers with access to a negotiated GATT
+/// MTU should pass it here so the encoder doesn't emit fragments the link
+/// will fragment again unpredictably. Must be in the closed range
+/// `[kMinFragmentSize, kMaxFragmentSize]`; values outside throw
+/// `ArgumentError`.
+List<Uint8List> encodeFragments(
+  String json, {
+  int maxFragmentSize = kMaxFragmentSize,
+}) {
+  if (maxFragmentSize < kMinFragmentSize ||
+      maxFragmentSize > kMaxFragmentSize) {
+    throw ArgumentError.value(
+      maxFragmentSize,
+      'maxFragmentSize',
+      'must be in [$kMinFragmentSize, $kMaxFragmentSize]',
+    );
+  }
+  final fragmentPayloadSize = maxFragmentSize - kFragmentHeaderSize;
+
   final bytes = utf8.encode(json);
   if (bytes.length > kMaxMessageSize) {
     throw FormatException(
@@ -71,9 +97,10 @@ List<Uint8List> encodeFragments(String json) {
   final totalLen = bytes.length;
   final fragmentCount = totalLen == 0
       ? 1
-      : (totalLen + kMaxFragmentPayloadSize - 1) ~/ kMaxFragmentPayloadSize;
-  // Unreachable with the v1 4 KiB message cap (max ~17 fragments) but
-  // guards against a future cap raise: silently masking `i` to 8 bits
+      : (totalLen + fragmentPayloadSize - 1) ~/ fragmentPayloadSize;
+  // With the smallest legal MTU (23 → 19-byte payload) and the v1 4 KiB
+  // message cap, the worst case is ~216 fragments — under the uint8
+  // `fragment_idx` ceiling. Recheck anyway: silently masking `i` to 8 bits
   // would produce duplicate fragment indices on the wire and a
   // reassembler that confidently stitches together garbage.
   if (fragmentCount > kMaxFragmentCount) {
@@ -85,10 +112,10 @@ List<Uint8List> encodeFragments(String json) {
 
   final fragments = <Uint8List>[];
   for (int i = 0; i < fragmentCount; i++) {
-    final start = i * kMaxFragmentPayloadSize;
+    final start = i * fragmentPayloadSize;
     final end =
-        (start + kMaxFragmentPayloadSize) < totalLen
-            ? start + kMaxFragmentPayloadSize
+        (start + fragmentPayloadSize) < totalLen
+            ? start + fragmentPayloadSize
             : totalLen;
     final payloadLen = end - start;
 

--- a/test/protocol/framing_test.dart
+++ b/test/protocol/framing_test.dart
@@ -83,15 +83,18 @@ void main() {
     });
 
     test('a custom maxFragmentSize splits at that boundary and reassembles', () {
-      // 96-byte payload per fragment (header is 4 bytes).
-      const mtu = 100;
-      const payloadPerFragment = mtu - kFragmentHeaderSize;
+      // 96-byte payload per fragment (header is 4 bytes). Naming this
+      // `maxFragmentSize` rather than `mtu` keeps the test honest: the
+      // encoder takes a per-fragment buffer ceiling, not an ATT MTU.
+      const maxFragmentSize = 100;
+      const payloadPerFragment = maxFragmentSize - kFragmentHeaderSize;
       // 250 bytes → ceil(250/96) = 3 fragments: 96 + 96 + 58.
       final json = 'a' * 250;
-      final fragments = encodeFragments(json, maxFragmentSize: mtu);
+      final fragments =
+          encodeFragments(json, maxFragmentSize: maxFragmentSize);
       expect(fragments, hasLength(3));
-      expect(fragments[0].length, mtu);
-      expect(fragments[1].length, mtu);
+      expect(fragments[0].length, maxFragmentSize);
+      expect(fragments[1].length, maxFragmentSize);
       expect(fragments[2].length, kFragmentHeaderSize + 58);
       // total_len header is identical across fragments and matches the input.
       for (var i = 0; i < fragments.length; i++) {

--- a/test/protocol/framing_test.dart
+++ b/test/protocol/framing_test.dart
@@ -82,6 +82,66 @@ void main() {
       expect(() => encodeFragments(tooBig), throwsFormatException);
     });
 
+    test('a custom maxFragmentSize splits at that boundary and reassembles', () {
+      // 96-byte payload per fragment (header is 4 bytes).
+      const mtu = 100;
+      const payloadPerFragment = mtu - kFragmentHeaderSize;
+      // 250 bytes → ceil(250/96) = 3 fragments: 96 + 96 + 58.
+      final json = 'a' * 250;
+      final fragments = encodeFragments(json, maxFragmentSize: mtu);
+      expect(fragments, hasLength(3));
+      expect(fragments[0].length, mtu);
+      expect(fragments[1].length, mtu);
+      expect(fragments[2].length, kFragmentHeaderSize + 58);
+      // total_len header is identical across fragments and matches the input.
+      for (var i = 0; i < fragments.length; i++) {
+        expect(fragments[i][0], kFragmentFlagsV1);
+        expect((fragments[i][1] << 8) | fragments[i][2], 250);
+        expect(fragments[i][3], i);
+      }
+      // The reassembler doesn't care about the encoder's MTU — it stitches
+      // fragments back together from the headers alone, so a sender can
+      // honour a small negotiated MTU without breaking the receiver.
+      final r = FragmentReassembler();
+      String? out;
+      for (final f in fragments) {
+        out = r.feed(f);
+      }
+      expect(out, json);
+      // Sanity: the constants we relied on for the math above.
+      expect(payloadPerFragment, 96);
+    });
+
+    test('maxFragmentSize below the BLE floor is rejected', () {
+      expect(
+        () => encodeFragments('hi', maxFragmentSize: kMinFragmentSize - 1),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('maxFragmentSize above the v1 ceiling is rejected', () {
+      expect(
+        () => encodeFragments('hi', maxFragmentSize: kMaxFragmentSize + 1),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('maxFragmentSize at the BLE floor still produces well-formed fragments',
+        () {
+      // 19-byte payload per fragment at the 23-byte floor; verify a small
+      // message still assembles correctly at the most pessimistic MTU.
+      final json = 'a' * 50;
+      final fragments = encodeFragments(json, maxFragmentSize: kMinFragmentSize);
+      // ceil(50 / 19) = 3 fragments.
+      expect(fragments, hasLength(3));
+      final r = FragmentReassembler();
+      String? out;
+      for (final f in fragments) {
+        out = r.feed(f);
+      }
+      expect(out, json);
+    });
+
     test('multibyte UTF-8 sequences reassemble correctly across fragment boundaries',
         () {
       // Build a message that puts a 2-byte UTF-8 sequence ('é' = 0xC3 0xA9)


### PR DESCRIPTION
## Summary

Land the Dart-side half of [#45](https://github.com/ElodinLaarz/walkie-talkie/issues/45) — `encodeFragments` now takes an optional `maxFragmentSize` so callers with access to a negotiated GATT MTU can split at that boundary instead of always emitting 247-byte fragments the platform may refragment.

- **`lib/protocol/framing.dart`** — `encodeFragments(String json, {int maxFragmentSize = kMaxFragmentSize})`. Range-checked against the new `kMinFragmentSize = 23` (BLE 4.0 ATT MTU floor) and the existing `kMaxFragmentSize = 247`; out-of-range values throw `ArgumentError`. The fragment-count math now uses `maxFragmentSize - kFragmentHeaderSize` instead of the hard-coded payload constant.
- **`test/protocol/framing_test.dart`** — new tests cover `maxFragmentSize: 100` (issue's acceptance criterion), the BLE-floor and v1-ceiling rejections, and a `kMinFragmentSize` round-trip through the reassembler so we know the worst-case MTU still produces fragments the receiver can stitch back together.

## Why this is split from the native side

The full issue scope also wants per-connection MTU caching in the native layer plus a `getNegotiatedMtu(endpointId)` MethodChannel that `BleControlTransport.send` queries before each write. Both depend on the GATT-client manager from [#43](https://github.com/ElodinLaarz/walkie-talkie/issues/43), which is still open. The Dart parameterization is the first dependency for that wiring and ships clean on its own — `BleControlTransport.send` keeps the default 247 until #43 lands and gives it a real per-connection MTU to thread through.

The reassembler intentionally doesn't enforce a max fragment size (it only cares about the `total_len` header), so a sender honouring a smaller MTU works against any v1 receiver — including the existing one — without further changes.

## Test plan

- [x] `flutter analyze` — no issues.
- [x] `flutter test` — 232 passing, 1 pre-existing skip (modal-sheet integration test).
- [x] New tests cover the encoder at `maxFragmentSize: 100` (count, header values, reassembler round-trip), at the BLE floor (`kMinFragmentSize` round-trip), and the two `ArgumentError` boundaries.
- [ ] Smoke-test on a device once #43 lands and `BleControlTransport.send` starts threading a real negotiated MTU through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message fragmentation now accepts an optional parameter to configure maximum fragment size, with automatic validation against platform constraints.

* **Tests**
  * Added test coverage for custom fragment sizes, including boundary conditions, validation limits, and reassembly verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->