### PR TITLE
feat(#56): ReconnectController + ConnectionPhase — guest auto-reconnect on BLE drop

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -364,7 +364,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       if (postAttempt is SessionRoom) {
         emit(postAttempt.copyWith(connectionPhase: ConnectionPhase.lost));
       }
-      unawaited(leaveRoom());
+      await leaveRoom();
     }
     // On success: wait for the transport's JoinAccepted to call
     // applyJoinAccepted, which cancels the controller and resets to online.

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -274,6 +274,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Future<void> leaveRoom() async {
     final current = state;
     if (current is! SessionRoom) return;
+    // Stop any in-progress reconnect so BLE retries halt promptly when
+    // the user manually leaves rather than waiting for the next delay tick.
+    _reconnectController?.cancel();
+    _reconnectController = null;
     _seq = 0;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
@@ -357,13 +361,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     final reconnected = await controller.attempt(macAddress: macAddress);
 
     if (isClosed) return;
+    // Guard: if the room state has already moved on (applyJoinAccepted fired
+    // and set connectionPhase back to online, or the user manually left), do
+    // not overwrite that state with a failure-path transition.
+    final postAttempt = state;
+    if (postAttempt is! SessionRoom ||
+        postAttempt.connectionPhase != ConnectionPhase.reconnecting) {
+      return;
+    }
     if (!reconnected) {
       // All retries exhausted — surface the lost phase briefly so the UI
       // can show a "Lost connection" indicator, then drop to Discovery.
-      final postAttempt = state;
-      if (postAttempt is SessionRoom) {
-        emit(postAttempt.copyWith(connectionPhase: ConnectionPhase.lost));
-      }
+      emit(postAttempt.copyWith(connectionPhase: ConnectionPhase.lost));
       await leaveRoom();
     }
     // On success: wait for the transport's JoinAccepted to call

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -4,9 +4,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../protocol/messages.dart';
+import '../services/audio_service.dart';
 import '../services/ble_control_transport.dart';
 import '../services/identity_store.dart';
 import '../services/recent_frequencies_store.dart';
+import '../services/reconnect_controller.dart';
 import 'frequency_session_state.dart';
 
 /// Owns session-level Frequency state and the side-effects that mutate it:
@@ -57,7 +59,17 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// for tests and early development builds.
   final BleControlTransport? _transport;
 
+  /// Optional audio service. Required to drive [notifyDrop] — without it,
+  /// reconnect attempts are silently skipped and the room stays in whatever
+  /// [ConnectionPhase] was last emitted.
+  final AudioService? _audio;
+
+  /// Delay schedule injected into [ReconnectController]. Defaults to the
+  /// production schedule; tests pass short delays to avoid slow test runs.
+  final List<Duration>? _reconnectDelays;
+
   StreamSubscription<FrequencyMessage>? _transportSubscription;
+  ReconnectController? _reconnectController;
 
   final _mediaCommandsController = StreamController<MediaCommand>.broadcast();
 
@@ -74,7 +86,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     required this.identityStore,
     required this.recentFrequenciesStore,
     BleControlTransport? transport,
+    AudioService? audio,
+    List<Duration>? reconnectDelays,
   })  : _transport = transport,
+        _audio = audio,
+        _reconnectDelays = reconnectDelays,
         super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
@@ -300,11 +316,58 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     final current = state;
     if (current is! SessionRoom) return;
     _seq = 0;
+    // Clear any in-progress reconnect and return to online — the handshake
+    // completing is the authoritative "connection is healthy" signal.
+    _reconnectController?.cancel();
+    _reconnectController = null;
     emit(current.copyWith(
       hostPeerId: msg.hostPeerId,
       roster: msg.roster,
       mediaState: msg.mediaState,
+      connectionPhase: ConnectionPhase.online,
     ));
+  }
+
+  /// Called by heartbeat detection when the guest hasn't heard from the host
+  /// for the heartbeat timeout. Transitions the room to
+  /// [ConnectionPhase.reconnecting] and starts the exponential-backoff retry
+  /// loop.
+  ///
+  /// No-op if the local user is the host, if [_audio] was not injected, or if
+  /// a reconnect is already in progress. On success the transport will deliver
+  /// a [JoinAccepted] that calls [applyJoinAccepted] and transitions back to
+  /// [ConnectionPhase.online]. On failure the room drops to Discovery.
+  Future<void> notifyDrop({required String macAddress}) async {
+    final current = state;
+    if (isClosed || current is! SessionRoom) return;
+    if (current.roomIsHost) return;
+    if (current.connectionPhase == ConnectionPhase.reconnecting) return;
+
+    final audio = _audio;
+    if (audio == null) return;
+
+    emit(current.copyWith(connectionPhase: ConnectionPhase.reconnecting));
+
+    _reconnectController?.cancel();
+    final controller = ReconnectController(
+      audio: audio,
+      delays: _reconnectDelays,
+    );
+    _reconnectController = controller;
+    final reconnected = await controller.attempt(macAddress: macAddress);
+
+    if (isClosed) return;
+    if (!reconnected) {
+      // All retries exhausted — surface the lost phase briefly so the UI
+      // can show a "Lost connection" indicator, then drop to Discovery.
+      final postAttempt = state;
+      if (postAttempt is SessionRoom) {
+        emit(postAttempt.copyWith(connectionPhase: ConnectionPhase.lost));
+      }
+      unawaited(leaveRoom());
+    }
+    // On success: wait for the transport's JoinAccepted to call
+    // applyJoinAccepted, which cancels the controller and resets to online.
   }
 
   /// Broadcasts a media command originated by the local peer.
@@ -422,6 +485,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
 
   @override
   Future<void> close() async {
+    // Cancel an in-progress reconnect before closing so the attempt loop
+    // won't call emit() or leaveRoom() after the cubit is disposed.
+    _reconnectController?.cancel();
     // Order matters. `super.close()` flips the cubit's `isClosed`; the
     // suspended `await` in `sendMediaCommand` resumes after it sees
     // `isClosed == true` and bails before touching the controller. If

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -54,6 +54,16 @@ final class SessionDiscovery extends FrequencySessionState {
   List<Object?> get props => [myName, recentHostedFrequencies];
 }
 
+/// Tracks whether the guest's BLE link to the host is healthy.
+///
+/// [online] — established and receiving heartbeats (default for hosts, whose
+///   link is always considered healthy since they *are* the host).
+/// [reconnecting] — a transient drop was detected; [ReconnectController] is
+///   retrying in the background and the UI shows a "Reconnecting…" pill.
+/// [lost] — all retries exhausted; [FrequencySessionCubit.leaveRoom] is
+///   called immediately after emitting this phase.
+enum ConnectionPhase { online, reconnecting, lost }
+
 /// User is in a room. Both [roomFreq] and [roomIsHost] are non-nullable
 /// by construction, so the UI can read them without force-unwrapping.
 ///
@@ -99,6 +109,12 @@ final class SessionRoom extends FrequencySessionState {
   /// isn't a stable session key. Null in the same cases as [macAddress].
   final String? sessionUuidLow8;
 
+  /// Current BLE link health between this guest and the host. Always
+  /// [ConnectionPhase.online] for host-role sessions. Updated by
+  /// [FrequencySessionCubit.notifyDrop] and cleared back to [online] by
+  /// [FrequencySessionCubit.applyJoinAccepted] on a successful rejoin.
+  final ConnectionPhase connectionPhase;
+
   const SessionRoom({
     required this.myName,
     required this.roomFreq,
@@ -108,6 +124,7 @@ final class SessionRoom extends FrequencySessionState {
     this.mediaState,
     this.macAddress,
     this.sessionUuidLow8,
+    this.connectionPhase = ConnectionPhase.online,
   });
 
   /// `??` would conflate "argument omitted" with "argument explicitly set
@@ -133,6 +150,7 @@ final class SessionRoom extends FrequencySessionState {
     Object? mediaState = _unset,
     Object? macAddress = _unset,
     Object? sessionUuidLow8 = _unset,
+    ConnectionPhase? connectionPhase,
   }) =>
       SessionRoom(
         myName: myName ?? this.myName,
@@ -153,6 +171,7 @@ final class SessionRoom extends FrequencySessionState {
         sessionUuidLow8: identical(sessionUuidLow8, _unset)
             ? this.sessionUuidLow8
             : sessionUuidLow8 as String?,
+        connectionPhase: connectionPhase ?? this.connectionPhase,
       );
 
   @override
@@ -165,5 +184,6 @@ final class SessionRoom extends FrequencySessionState {
         mediaState,
         macAddress,
         sessionUuidLow8,
+        connectionPhase,
       ];
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,6 +81,7 @@ class WalkieTalkieApp extends StatelessWidget {
               recentFrequenciesStore:
                   context.read<RecentFrequenciesStore>(),
               transport: context.read<BleControlTransport>(),
+              audio: context.read<AudioService>(),
             )..bootstrap(),
           ),
           BlocProvider(

--- a/lib/services/reconnect_controller.dart
+++ b/lib/services/reconnect_controller.dart
@@ -39,7 +39,9 @@ class ReconnectController {
       await Future.delayed(delay);
       if (_cancelled) return false;
       try {
-        if (await _audio.connectDevice(macAddress)) return true;
+        final connected = await _audio.connectDevice(macAddress);
+        if (_cancelled) return false;
+        if (connected) return true;
       } catch (_) {
         // Native errors are already logged inside AudioService; treat as a
         // failed attempt and continue to the next retry.

--- a/lib/services/reconnect_controller.dart
+++ b/lib/services/reconnect_controller.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'audio_service.dart';
+
+/// Drives the guest-side exponential-backoff reconnect loop after a transient
+/// BLE drop. Call [attempt] once a drop is detected; cancel with [cancel] if
+/// the user manually leaves the room before the loop completes.
+///
+/// The six delay steps give a total worst-case budget of ~19 s — designed to
+/// complete before the host's heartbeat window (15 s + 5 s grace) purges the
+/// peer. Coordinate with the heartbeat implementation: the host should NOT
+/// purge a peer whose last heartbeat arrived ≤ 5 s before the silence began.
+class ReconnectController {
+  static const List<Duration> delays = [
+    Duration(milliseconds: 250),
+    Duration(milliseconds: 500),
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 5),
+    Duration(seconds: 10),
+  ];
+
+  final AudioService _audio;
+  final List<Duration> _delays;
+  bool _cancelled = false;
+
+  ReconnectController({required AudioService audio, List<Duration>? delays})
+      : _audio = audio,
+        _delays = delays ?? ReconnectController.delays;
+
+  /// Attempt to reconnect to [macAddress], retrying up to [delays.length]
+  /// times with exponential backoff. Returns `true` if the BLE connection is
+  /// re-established, `false` if all retries are exhausted or [cancel] was
+  /// called.
+  Future<bool> attempt({required String macAddress}) async {
+    _cancelled = false;
+    for (final delay in _delays) {
+      if (_cancelled) return false;
+      await Future.delayed(delay);
+      if (_cancelled) return false;
+      try {
+        if (await _audio.connectDevice(macAddress)) return true;
+      } catch (_) {
+        // Native errors are already logged inside AudioService; treat as a
+        // failed attempt and continue to the next retry.
+        continue;
+      }
+    }
+    return false;
+  }
+
+  /// Signals the in-progress [attempt] to stop after its current delay.
+  /// Safe to call after [attempt] has already completed.
+  void cancel() => _cancelled = true;
+}

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/bloc/frequency_session_cubit.dart';
 import 'package:walkie_talkie/bloc/frequency_session_state.dart';
 import 'package:walkie_talkie/protocol/messages.dart';
 import 'package:walkie_talkie/protocol/peer.dart';
+import 'package:walkie_talkie/services/audio_service.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 
@@ -78,14 +80,28 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
   Future<void> clear() async => _entries.clear();
 }
 
+// Zero delays so reconnect tests don't actually wait.
+const _testReconnectDelays = [
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+];
+
 FrequencySessionCubit _makeCubit({
   IdentityStore? identityStore,
   RecentFrequenciesStore? recentFrequenciesStore,
+  AudioService? audio,
+  List<Duration>? reconnectDelays,
 }) =>
     FrequencySessionCubit(
       identityStore: identityStore ?? _FakeStore(),
       recentFrequenciesStore:
           recentFrequenciesStore ?? _FakeRecentFrequenciesStore(),
+      audio: audio,
+      reconnectDelays: reconnectDelays,
     );
 
 void main() {
@@ -804,6 +820,224 @@ void main() {
         ),
       ],
     );
+  });
+
+  // ── Reconnect / ConnectionPhase ───────────────────────────────────────
+
+  group('notifyDrop / ConnectionPhase', () {
+    late AudioService audio;
+    // The mock handler returns values pushed here; empty = return false.
+    final List<bool> connectQueue = [];
+    // Completer to block the first connectDevice call so we can inspect
+    // intermediate state.
+    Completer<bool>? blockFirst;
+
+    setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+    setUp(() {
+      audio = AudioService();
+      connectQueue.clear();
+      blockFirst = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('com.elodin.walkie_talkie/audio'),
+        (MethodCall call) async {
+          if (call.method == 'connectDevice') {
+            final blocker = blockFirst;
+            if (blocker != null) {
+              blockFirst = null;
+              return blocker.future;
+            }
+            if (connectQueue.isEmpty) return false;
+            return connectQueue.removeAt(0);
+          }
+          return null;
+        },
+      );
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('com.elodin.walkie_talkie/audio'),
+        null,
+      );
+    });
+
+    test('notifyDrop without audio injected is a no-op', () async {
+      final cubit = _makeCubit(
+        reconnectDelays: _testReconnectDelays,
+      ); // no audio
+      cubit.emit(const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: false,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+      ));
+
+      await cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      expect(
+        (cubit.state as SessionRoom).connectionPhase,
+        ConnectionPhase.online,
+      );
+      await cubit.close();
+    });
+
+    test('notifyDrop on host room is a no-op', () async {
+      final cubit = _makeCubit(
+        audio: audio,
+        reconnectDelays: _testReconnectDelays,
+      );
+      cubit.emit(const SessionRoom(
+        myName: 'Devon',
+        roomFreq: '104.3',
+        roomIsHost: true,
+      ));
+
+      await cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      expect(
+        (cubit.state as SessionRoom).connectionPhase,
+        ConnectionPhase.online,
+      );
+      await cubit.close();
+    });
+
+    test('notifyDrop transitions state to reconnecting', () async {
+      // Block the first connectDevice so we can observe the intermediate state.
+      final blocker = Completer<bool>();
+      blockFirst = blocker;
+
+      final cubit = _makeCubit(
+        audio: audio,
+        reconnectDelays: _testReconnectDelays,
+      );
+      cubit.emit(const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: false,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+      ));
+
+      final dropFuture = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      // Yield to let the cubit emit reconnecting before connectDevice resolves.
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        (cubit.state as SessionRoom).connectionPhase,
+        ConnectionPhase.reconnecting,
+      );
+
+      // Let the connection succeed and allow the cubit to finish.
+      blocker.complete(true);
+      await dropFuture;
+
+      await cubit.close();
+    });
+
+    test('notifyDrop while already reconnecting is a no-op', () async {
+      final blocker = Completer<bool>();
+      blockFirst = blocker;
+
+      final cubit = _makeCubit(
+        audio: audio,
+        reconnectDelays: _testReconnectDelays,
+      );
+      cubit.emit(const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: false,
+      ));
+
+      final first = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+      await Future<void>.delayed(Duration.zero); // let it emit reconnecting
+
+      expect(
+        (cubit.state as SessionRoom).connectionPhase,
+        ConnectionPhase.reconnecting,
+      );
+
+      // Second call while already reconnecting — state must not change.
+      await cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+      expect(
+        (cubit.state as SessionRoom).connectionPhase,
+        ConnectionPhase.reconnecting,
+      );
+
+      blocker.complete(true);
+      await first;
+      await cubit.close();
+    });
+
+    test('applyJoinAccepted resets connectionPhase to online', () async {
+      final cubit = _makeCubit(
+        audio: audio,
+        reconnectDelays: _testReconnectDelays,
+      );
+      cubit.emit(const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: false,
+        connectionPhase: ConnectionPhase.reconnecting,
+      ));
+
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [],
+      ));
+
+      expect(
+        (cubit.state as SessionRoom).connectionPhase,
+        ConnectionPhase.online,
+      );
+      await cubit.close();
+    });
+
+    test('notifyDrop drops to Discovery when all retries fail', () async {
+      // connectQueue empty → mock always returns false.
+      final cubit = _makeCubit(
+        audio: audio,
+        reconnectDelays: _testReconnectDelays,
+      );
+      cubit.emit(const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: false,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+      ));
+
+      await cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      expect(cubit.state, isA<SessionDiscovery>());
+      await cubit.close();
+    });
+
+    test('close() during reconnect does not throw', () async {
+      final blocker = Completer<bool>();
+      blockFirst = blocker;
+
+      final cubit = _makeCubit(
+        audio: audio,
+        reconnectDelays: _testReconnectDelays,
+      );
+      cubit.emit(const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: false,
+      ));
+
+      final dropFuture = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+      await Future<void>.delayed(Duration.zero); // enter reconnecting
+
+      await cubit.close();
+      blocker.complete(false);
+      await expectLater(dropFuture, completes);
+    });
   });
 
   group('FrequencySessionState', () {

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -998,6 +998,80 @@ void main() {
       await cubit.close();
     });
 
+    test(
+      'applyJoinAccepted mid-reconnect does not trigger spurious leaveRoom',
+      () async {
+        // Scenario: reconnect attempt is running; the native BLE stack
+        // re-establishes the link and the host sends JoinAccepted before
+        // attempt() returns. That causes attempt() to return false (cancel
+        // propagates). The cubit must NOT treat this as a failure.
+        final blocker = Completer<bool>();
+        blockFirst = blocker;
+
+        final cubit = _makeCubit(
+          audio: audio,
+          reconnectDelays: _testReconnectDelays,
+        );
+        cubit.emit(const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: false,
+        ));
+
+        final dropFuture = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+        await Future<void>.delayed(Duration.zero); // enter reconnecting
+
+        // Host JoinAccepted arrives — cancels the controller and sets online.
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [],
+        ));
+
+        // Let the blocked connectDevice resolve with false (the cancel signal
+        // will override it anyway, but the mock needs to settle).
+        blocker.complete(false);
+        await dropFuture;
+
+        // State must remain SessionRoom(online), not Discovery.
+        expect(cubit.state, isA<SessionRoom>());
+        expect(
+          (cubit.state as SessionRoom).connectionPhase,
+          ConnectionPhase.online,
+        );
+        await cubit.close();
+      },
+    );
+
+    test('leaveRoom() during reconnect cancels the controller', () async {
+      final blocker = Completer<bool>();
+      blockFirst = blocker;
+
+      final cubit = _makeCubit(
+        audio: audio,
+        reconnectDelays: _testReconnectDelays,
+      );
+      cubit.emit(const SessionRoom(
+        myName: 'Maya',
+        roomFreq: '104.3',
+        roomIsHost: false,
+      ));
+
+      final dropFuture = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+      await Future<void>.delayed(Duration.zero); // enter reconnecting
+
+      // User manually leaves — must cancel the reconnect controller.
+      final leaveFuture = cubit.leaveRoom();
+      blocker.complete(false); // unblock so futures settle
+      await Future.wait([dropFuture, leaveFuture]);
+
+      // Should be in Discovery, not stuck in reconnecting.
+      expect(cubit.state, isA<SessionDiscovery>());
+      await cubit.close();
+    });
+
     test('notifyDrop drops to Discovery when all retries fail', () async {
       // connectQueue empty → mock always returns false.
       final cubit = _makeCubit(

--- a/test/services/reconnect_controller_test.dart
+++ b/test/services/reconnect_controller_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/audio_service.dart';
+import 'package:walkie_talkie/services/reconnect_controller.dart';
+
+// Short delays used in all tests so the suite runs fast.
+const _testDelays = [
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+  Duration.zero,
+];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AudioService audio;
+  // connectDevice results consumed in order; empty = false.
+  final List<bool> connectResults = [];
+  int connectCallCount = 0;
+
+  setUp(() {
+    audio = AudioService();
+    connectResults.clear();
+    connectCallCount = 0;
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('com.elodin.walkie_talkie/audio'),
+      (MethodCall call) async {
+        if (call.method == 'connectDevice') {
+          connectCallCount++;
+          if (connectResults.isEmpty) return false;
+          return connectResults.removeAt(0);
+        }
+        return null;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('com.elodin.walkie_talkie/audio'),
+      null,
+    );
+  });
+
+  group('ReconnectController', () {
+    test('returns true immediately when first attempt succeeds', () async {
+      connectResults.addAll([true]);
+      final controller =
+          ReconnectController(audio: audio, delays: _testDelays);
+
+      final result = await controller.attempt(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      expect(result, isTrue);
+      expect(connectCallCount, 1);
+    });
+
+    test('retries until a later attempt succeeds', () async {
+      connectResults.addAll([false, false, true]);
+      final controller =
+          ReconnectController(audio: audio, delays: _testDelays);
+
+      final result = await controller.attempt(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      expect(result, isTrue);
+      expect(connectCallCount, 3);
+    });
+
+    test('returns false when all retries are exhausted', () async {
+      final controller =
+          ReconnectController(audio: audio, delays: _testDelays);
+
+      final result = await controller.attempt(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      expect(result, isFalse);
+      expect(connectCallCount, _testDelays.length);
+    });
+
+    test('cancel stops the loop before the next attempt', () async {
+      // fail on first attempt, then succeed — but we cancel between them
+      connectResults.addAll([false, true]);
+
+      bool cancelled = false;
+      // One non-zero delay to create a cancellation window.
+      final delays = List<Duration>.filled(6, Duration.zero);
+      delays[1] = const Duration(milliseconds: 20);
+
+      final controller = ReconnectController(audio: audio, delays: delays);
+
+      // Cancel partway through the second delay.
+      Future.delayed(const Duration(milliseconds: 10), () {
+        cancelled = true;
+        controller.cancel();
+      });
+
+      final result =
+          await controller.attempt(macAddress: 'AA:BB:CC:DD:EE:FF');
+
+      expect(cancelled, isTrue);
+      expect(result, isFalse);
+      // Only the first attempt (false) should have run.
+      expect(connectCallCount, 1);
+    });
+
+    test('cancel after completion is a no-op', () async {
+      connectResults.addAll([true]);
+      final controller =
+          ReconnectController(audio: audio, delays: _testDelays);
+
+      await controller.attempt(macAddress: 'AA:BB:CC:DD:EE:FF');
+      controller.cancel(); // must not throw
+    });
+
+    test('delays list has six entries covering ~19s total budget', () {
+      final total = ReconnectController.delays
+          .fold(Duration.zero, (acc, d) => acc + d);
+      // 250ms + 500ms + 1s + 2s + 5s + 10s = 18750ms
+      expect(total.inMilliseconds, 18750);
+      expect(ReconnectController.delays, hasLength(6));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the pure-Dart reconnect infrastructure from issue #56 (graceful auto-reconnect for transient BLE drops ≤30s).

- **New `lib/services/reconnect_controller.dart`** — exponential-backoff retry service (250ms → 10s, ~19s total budget). Injectable delays for tests. `cancel()` for mid-flight abort on room-leave or cubit disposal.
- **`lib/bloc/frequency_session_state.dart`** — new `ConnectionPhase` enum (`online` / `reconnecting` / `lost`). `SessionRoom.connectionPhase` field (default `online`), added to `copyWith` and `props`. UI can now show a "Reconnecting…" pill.
- **`lib/bloc/frequency_session_cubit.dart`** — new `notifyDrop({required String macAddress})` method (heartbeat detection will call this in #51). Transitions state to `reconnecting`, starts the controller, resets to `online` via `applyJoinAccepted` on success, or calls `leaveRoom()` after exhausting retries. `close()` cancels the controller.
- **`lib/main.dart`** — threads `AudioService` into `FrequencySessionCubit`.

## What's not yet wired (next PRs)

- Heartbeat trigger → call `notifyDrop` (#51)
- Voice-channel reconnect via `connectVoiceClient` (#46)

This PR is the pure-Dart seam those native PRs plug into — approach mirrors [PR #28](https://github.com/ElodinLaarz/walkie-talkie/pull/28).

## Test plan

- [ ] `flutter analyze` — clean
- [ ] `flutter test` — all existing + new tests passing
  - New: `test/services/reconnect_controller_test.dart` — attempt/retry/cancel/exhaustion paths
  - New: 7 tests in `test/bloc/frequency_session_cubit_test.dart` — notifyDrop state transitions, host no-op, close-during-reconnect safety
- [ ] `SessionRoom` equality still correct with new `connectionPhase` field in `props`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added connection health monitoring to track BLE link status (online, reconnecting, lost).
  * Implemented automatic reconnection with exponential backoff when connection drops occur in non-host sessions.
  * Enhanced session management to support audio service integration for improved device connectivity.

* **Tests**
  * Added comprehensive test coverage for connection drop handling and reconnection retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->