### PR TITLE
feat(#50): Voice-activity detection + outbound TalkingState messages

### DIFF
--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -18,6 +18,7 @@
 static std::atomic<bool> g_muted{false};
 
 // Global JNI references for voice activity callbacks
+static std::mutex g_jniMutex;
 static JavaVM* g_jvm = nullptr;
 static jobject g_mainActivity = nullptr;
 
@@ -56,34 +57,39 @@ private:
 
     // Emit talking event to Flutter via JNI
     void emitTalkingEvent(bool talking) {
-        if (g_jvm == nullptr || g_mainActivity == nullptr) return;
+        // Snapshot JNI globals under lock to avoid use-after-free
+        JavaVM* jvm = nullptr;
+        jobject activity = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(g_jniMutex);
+            if (g_jvm == nullptr || g_mainActivity == nullptr) return;
+            jvm = g_jvm;
+            activity = g_mainActivity;
+        }
 
         JNIEnv* env = nullptr;
         bool needDetach = false;
 
         // Get JNI environment
-        if (g_jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
-            if (g_jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
-                LOGE("Failed to attach thread for talking event");
-                return;
+        if (jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+            if (jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+                return;  // Skip logging in audio callback to avoid glitches
             }
             needDetach = true;
         }
 
         // Call MainActivity.sendLocalTalkingEvent(boolean)
-        jclass activityClass = env->GetObjectClass(g_mainActivity);
+        jclass activityClass = env->GetObjectClass(activity);
         if (activityClass != nullptr) {
             jmethodID method = env->GetMethodID(activityClass, "sendLocalTalkingEvent", "(Z)V");
             if (method != nullptr) {
-                env->CallVoidMethod(g_mainActivity, method, talking);
-            } else {
-                LOGE("Failed to find sendLocalTalkingEvent method");
+                env->CallVoidMethod(activity, method, talking);
             }
             env->DeleteLocalRef(activityClass);
         }
 
         if (needDetach) {
-            g_jvm->DetachCurrentThread();
+            jvm->DetachCurrentThread();
         }
     }
 
@@ -176,7 +182,6 @@ public:
                 if (!lastTalking && aboveThresholdFrames >= onHysteresisFrames) {
                     lastTalking = true;
                     emitTalkingEvent(true);
-                    LOGI("Voice activity detected (RMS: %.4f)", rms);
                 }
             } else {
                 belowThresholdFrames += numFrames;
@@ -185,7 +190,6 @@ public:
                 if (lastTalking && belowThresholdFrames >= offHysteresisFrames) {
                     lastTalking = false;
                     emitTalkingEvent(false);
-                    LOGI("Voice activity ended (RMS: %.4f)", rms);
                 }
             }
 
@@ -222,6 +226,8 @@ extern "C" {
 
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_MainActivity_nativeRegisterForCallbacks(JNIEnv *env, jobject thiz) {
+    std::lock_guard<std::mutex> lock(g_jniMutex);
+
     // Store JavaVM for thread attachment
     if (g_jvm == nullptr) {
         env->GetJavaVM(&g_jvm);
@@ -237,13 +243,15 @@ Java_com_elodin_walkie_1talkie_MainActivity_nativeRegisterForCallbacks(JNIEnv *e
 
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_MainActivity_nativeUnregisterCallbacks(JNIEnv *env, jobject thiz) {
-    // Clean up global references
-    if (g_mainActivity != nullptr) {
+    std::lock_guard<std::mutex> lock(g_jniMutex);
+
+    // Only unregister if this is the same activity instance
+    if (g_mainActivity != nullptr && env->IsSameObject(thiz, g_mainActivity)) {
         env->DeleteGlobalRef(g_mainActivity);
         g_mainActivity = nullptr;
+        g_jvm = nullptr;
+        LOGI("MainActivity unregistered from voice activity callbacks");
     }
-    g_jvm = nullptr;
-    LOGI("MainActivity unregistered from voice activity callbacks");
 }
 
 JNIEXPORT jboolean JNICALL

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <atomic>
 #include <cstring>
+#include <cmath>
 #include "audio_mixer.h"
 
 #define LOG_TAG "WalkieTalkieAudio"
@@ -15,6 +16,10 @@
 // Global mute flag — declared before AudioEngine so onAudioReady (inline
 // in the class body) can reference it without a forward declaration.
 static std::atomic<bool> g_muted{false};
+
+// Global JNI references for voice activity callbacks
+static JavaVM* g_jvm = nullptr;
+static jobject g_mainActivity = nullptr;
 
 class AudioEngine : public oboe::AudioStreamDataCallback {
 private:
@@ -26,6 +31,61 @@ private:
     static constexpr int32_t kSampleRate = 48000;  // LE Audio standard
     static constexpr int32_t kChannelCount = 1;    // Mono for voice
     static constexpr oboe::AudioFormat kFormat = oboe::AudioFormat::I16;  // 16-bit PCM
+
+    // Voice activity detection
+    static constexpr double kTalkingThreshold = 0.01;  // -40 dBFS ≈ 0.01 RMS
+    static constexpr int32_t kOnHysteresisMs = 100;    // 100ms above threshold to flip on
+    static constexpr int32_t kOffHysteresisMs = 300;   // 300ms below threshold to flip off
+    bool lastTalking = false;
+    int32_t aboveThresholdFrames = 0;
+    int32_t belowThresholdFrames = 0;
+    const int32_t onHysteresisFrames = (kSampleRate * kOnHysteresisMs) / 1000;
+    const int32_t offHysteresisFrames = (kSampleRate * kOffHysteresisMs) / 1000;
+
+    // Compute RMS (Root Mean Square) of audio samples
+    double computeRms(const int16_t* samples, int32_t numFrames) {
+        if (numFrames == 0) return 0.0;
+
+        double sum = 0.0;
+        for (int32_t i = 0; i < numFrames; ++i) {
+            double normalized = samples[i] / 32768.0;  // Normalize to [-1, 1]
+            sum += normalized * normalized;
+        }
+        return std::sqrt(sum / numFrames);
+    }
+
+    // Emit talking event to Flutter via JNI
+    void emitTalkingEvent(bool talking) {
+        if (g_jvm == nullptr || g_mainActivity == nullptr) return;
+
+        JNIEnv* env = nullptr;
+        bool needDetach = false;
+
+        // Get JNI environment
+        if (g_jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+            if (g_jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+                LOGE("Failed to attach thread for talking event");
+                return;
+            }
+            needDetach = true;
+        }
+
+        // Call MainActivity.sendLocalTalkingEvent(boolean)
+        jclass activityClass = env->GetObjectClass(g_mainActivity);
+        if (activityClass != nullptr) {
+            jmethodID method = env->GetMethodID(activityClass, "sendLocalTalkingEvent", "(Z)V");
+            if (method != nullptr) {
+                env->CallVoidMethod(g_mainActivity, method, talking);
+            } else {
+                LOGE("Failed to find sendLocalTalkingEvent method");
+            }
+            env->DeleteLocalRef(activityClass);
+        }
+
+        if (needDetach) {
+            g_jvm->DetachCurrentThread();
+        }
+    }
 
 public:
     AudioEngine() {}
@@ -101,10 +161,38 @@ public:
             // Recording: feed to mixer directly
             auto *inputData = static_cast<int16_t *>(audioData);
 
+            bool isMuted = g_muted.load(std::memory_order_relaxed);
+
+            // Voice activity detection (compute RMS before mute gate, so we
+            // detect talking state even when muted for UI feedback)
+            double rms = computeRms(inputData, numFrames);
+            bool nowAboveThreshold = rms > kTalkingThreshold;
+
+            // Hysteresis: require sustained signal to flip talking state
+            if (nowAboveThreshold) {
+                aboveThresholdFrames += numFrames;
+                belowThresholdFrames = 0;
+                // Flip to talking if we've been above threshold for long enough
+                if (!lastTalking && aboveThresholdFrames >= onHysteresisFrames) {
+                    lastTalking = true;
+                    emitTalkingEvent(true);
+                    LOGI("Voice activity detected (RMS: %.4f)", rms);
+                }
+            } else {
+                belowThresholdFrames += numFrames;
+                aboveThresholdFrames = 0;
+                // Flip to not talking if we've been below threshold for long enough
+                if (lastTalking && belowThresholdFrames >= offHysteresisFrames) {
+                    lastTalking = false;
+                    emitTalkingEvent(false);
+                    LOGI("Voice activity ended (RMS: %.4f)", rms);
+                }
+            }
+
             // When muted, zero the mic frames so they don't reach the mixer
             // or any future BLE transport. The streams stay warm so unmuting
             // is instant — no codec reinit round-trip.
-            if (g_muted.load(std::memory_order_relaxed)) {
+            if (isMuted) {
                 std::memset(inputData, 0, numFrames * sizeof(int16_t));
             }
 
@@ -131,6 +219,32 @@ public:
 static AudioEngine* g_audioEngine = nullptr;
 
 extern "C" {
+
+JNIEXPORT void JNICALL
+Java_com_elodin_walkie_1talkie_MainActivity_nativeRegisterForCallbacks(JNIEnv *env, jobject thiz) {
+    // Store JavaVM for thread attachment
+    if (g_jvm == nullptr) {
+        env->GetJavaVM(&g_jvm);
+    }
+
+    // Store global reference to MainActivity for callbacks
+    if (g_mainActivity != nullptr) {
+        env->DeleteGlobalRef(g_mainActivity);
+    }
+    g_mainActivity = env->NewGlobalRef(thiz);
+    LOGI("MainActivity registered for voice activity callbacks");
+}
+
+JNIEXPORT void JNICALL
+Java_com_elodin_walkie_1talkie_MainActivity_nativeUnregisterCallbacks(JNIEnv *env, jobject thiz) {
+    // Clean up global references
+    if (g_mainActivity != nullptr) {
+        env->DeleteGlobalRef(g_mainActivity);
+        g_mainActivity = nullptr;
+    }
+    g_jvm = nullptr;
+    LOGI("MainActivity unregistered from voice activity callbacks");
+}
 
 JNIEXPORT jboolean JNICALL
 Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeStart(JNIEnv *env, jobject thiz) {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -15,6 +15,10 @@ class MainActivity : FlutterActivity() {
         private const val METHOD_CHANNEL = "com.elodin.walkie_talkie/audio"
         private const val EVENT_CHANNEL = "com.elodin.walkie_talkie/audio_events"
         private const val CONTROL_BYTES_EVENT_CHANNEL = "com.elodin.walkie_talkie/control_bytes"
+
+        init {
+            System.loadLibrary("walkie_talkie_audio")
+        }
     }
 
     private var methodChannel: MethodChannel? = null
@@ -28,6 +32,9 @@ class MainActivity : FlutterActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+
+        // Register for native voice activity callbacks
+        nativeRegisterForCallbacks()
 
         // Initialize audio routing manager
         // Auto-detect will be started when voice capture begins (startVoice)
@@ -233,7 +240,6 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-<<<<<<< HEAD
     private fun sendControlBytesToFlutter(deviceAddress: String, bytes: ByteArray) {
         Handler(Looper.getMainLooper()).post {
             controlBytesSink?.success(mapOf(
@@ -242,8 +248,15 @@ class MainActivity : FlutterActivity() {
             ))
         }
     }
-    
-=======
+
+    // Called from JNI when voice activity crosses threshold
+    fun sendLocalTalkingEvent(talking: Boolean) {
+        sendEventToFlutter(mapOf(
+            "type" to "localTalking",
+            "talking" to talking
+        ))
+    }
+
     // Called when the notification's Leave action brings this activity back to
     // the foreground (singleTop launchMode prevents a new instance). The action
     // extra is forwarded to Flutter so the room screen can call leaveRoom().
@@ -254,10 +267,9 @@ class MainActivity : FlutterActivity() {
             sendEventToFlutter(mapOf("type" to "leaveRoom"))
         }
     }
-
->>>>>>> origin/main
     override fun onDestroy() {
         super.onDestroy()
+        nativeUnregisterCallbacks()
         audioRoutingManager?.cleanup()
         bluetoothManager?.cleanup()
         gattServerManager?.stop()
@@ -265,4 +277,8 @@ class MainActivity : FlutterActivity() {
         eventChannel?.setStreamHandler(null)
         controlBytesEventChannel?.setStreamHandler(null)
     }
+
+    // Native methods for voice activity detection callbacks
+    private external fun nativeRegisterForCallbacks()
+    private external fun nativeUnregisterCallbacks()
 }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -69,6 +69,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   final List<Duration>? _reconnectDelays;
 
   StreamSubscription<FrequencyMessage>? _transportSubscription;
+  StreamSubscription<bool>? _localTalkingSubscription;
   ReconnectController? _reconnectController;
 
   final _mediaCommandsController = StreamController<MediaCommand>.broadcast();
@@ -99,9 +100,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   ///
   /// Also wires the BLE transport's [BleControlTransport.incoming] stream
   /// so incoming wire messages drive state transitions for the lifetime of
-  /// the cubit.
+  /// the cubit. Subscribes to voice activity detection from [_audio] to send
+  /// TalkingState messages over the control transport.
   Future<void> bootstrap() async {
     _transportSubscription = _transport?.incoming.listen(_onTransportMessage);
+    _localTalkingSubscription = _audio?.localTalking.listen(_onLocalTalking);
 
     String? persisted;
     try {
@@ -165,6 +168,40 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       case SignalReport():
         break;
     }
+  }
+
+  /// Called when local voice activity detection triggers. Sends a [TalkingState]
+  /// message over the BLE control transport to notify other peers about the
+  /// local user's speaking state.
+  ///
+  /// Only sends when in a room and when the transport is wired. If the transport
+  /// is absent, the seq counter still advances so messages stay monotonic once
+  /// the transport connects.
+  void _onLocalTalking(bool talking) {
+    final current = state;
+    if (isClosed || current is! SessionRoom) return;
+
+    final t = _transport;
+    if (t == null) {
+      _seq++;
+      return;
+    }
+
+    // Resolve peerId asynchronously and send the message
+    identityStore.getPeerId().then((peerId) {
+      if (isClosed) return;
+      final msg = TalkingState(
+        peerId: peerId,
+        seq: ++_seq,
+        atMs: DateTime.now().millisecondsSinceEpoch,
+        talking: talking,
+      );
+      unawaited(t.send(msg));
+    }).catchError((error, stackTrace) {
+      debugPrint('Failed to resolve peer id for talking state: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      _seq++;
+    });
   }
 
   /// Persists [name] and advances to Discovery. The state changes even if
@@ -506,6 +543,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // `cubit.isClosed = true` and throw on `add`.
     await super.close();
     await _transportSubscription?.cancel();
+    await _localTalkingSubscription?.cancel();
     await _mediaCommandsController.close();
   }
 }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -82,6 +82,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Stream<MediaCommand> get mediaCommands => _mediaCommandsController.stream;
 
   int _seq = 0;
+  String? _localPeerId;
 
   FrequencySessionCubit({
     required this.identityStore,
@@ -105,6 +106,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Future<void> bootstrap() async {
     _transportSubscription = _transport?.incoming.listen(_onTransportMessage);
     _localTalkingSubscription = _audio?.localTalking.listen(_onLocalTalking);
+
+    // Cache peerId to avoid async resolution in hot path (voice activity)
+    try {
+      _localPeerId = await identityStore.getPeerId();
+    } catch (error, stackTrace) {
+      debugPrint('Failed to load peer ID: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
 
     String? persisted;
     try {
@@ -176,32 +185,30 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   ///
   /// Only sends when in a room and when the transport is wired. If the transport
   /// is absent, the seq counter still advances so messages stay monotonic once
-  /// the transport connects.
+  /// the transport connects. Uses cached [_localPeerId] to avoid async resolution
+  /// and ensure sequence numbers are assigned at event time (no race).
   void _onLocalTalking(bool talking) {
     final current = state;
     if (isClosed || current is! SessionRoom) return;
 
     final t = _transport;
-    if (t == null) {
-      _seq++;
-      return;
+    final peerId = _localPeerId;
+
+    // Increment seq immediately at event time to preserve order
+    final seq = ++_seq;
+
+    if (t == null || peerId == null) {
+      return;  // seq already incremented
     }
 
-    // Resolve peerId asynchronously and send the message
-    identityStore.getPeerId().then((peerId) {
-      if (isClosed) return;
-      final msg = TalkingState(
-        peerId: peerId,
-        seq: ++_seq,
-        atMs: DateTime.now().millisecondsSinceEpoch,
-        talking: talking,
-      );
-      unawaited(t.send(msg));
-    }).catchError((error, stackTrace) {
-      debugPrint('Failed to resolve peer id for talking state: $error');
-      debugPrintStack(stackTrace: stackTrace);
-      _seq++;
-    });
+    // Build and send message synchronously
+    final msg = TalkingState(
+      peerId: peerId,
+      seq: seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+      talking: talking,
+    );
+    unawaited(t.send(msg));
   }
 
   /// Persists [name] and advances to Discovery. The state changes even if

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -224,6 +224,20 @@ class AudioService {
         });
   }
 
+  /// Stream of local voice activity detection events.
+  ///
+  /// Emits true when the native audio engine detects voice activity above the
+  /// threshold (RMS > -40 dBFS), false when activity drops below threshold.
+  /// Includes hysteresis (100ms to flip on, 300ms to flip off) to avoid
+  /// flickering at the threshold boundary.
+  ///
+  /// Filters audioEvents for 'localTalking' events from the native layer.
+  Stream<bool> get localTalking {
+    return audioEvents
+        .where((e) => e['type'] == 'localTalking')
+        .map((e) => e['talking'] == true);
+  }
+
   /// Start the GATT server for the host.
   ///
   /// Exposes REQUEST (write) and RESPONSE (notify) characteristics over


### PR DESCRIPTION
## Summary

Closes #50. Implements voice activity detection in the native audio engine and wires it through to the Dart cubit to send `TalkingState` protocol messages over the BLE control transport.

## Changes

### Native (C++)
- **audio_engine.cpp** — Added `computeRms` method to calculate RMS of input frames; added VAD state tracking with hysteresis (100ms above threshold to flip on, 300ms below to flip off); added `emitTalkingEvent` JNI callback that invokes `MainActivity.sendLocalTalkingEvent`. Detection runs **before** the mute gate so UI indicators work even when muted (as specified in the issue).
- **MainActivity.kt** — Added `nativeRegisterForCallbacks` / `nativeUnregisterCallbacks` JNI methods to pass MainActivity as a global ref for audio engine callbacks. Added `sendLocalTalkingEvent(Boolean)` method that forwards talking state to Flutter via the existing `audioEvents` EventChannel. Called in `configureFlutterEngine` and `onDestroy`.

### Dart
- **audio_service.dart** — New `localTalking` stream that filters `audioEvents` for `'localTalking'` type and maps to `bool`.
- **frequency_session_cubit.dart** — Subscribe to `audio.localTalking` in `bootstrap()`, handle events in `_onLocalTalking` which sends `TalkingState` messages (with local peerId + seq) over the BLE transport. When transport is absent (not yet wired), seq counter still advances to stay monotonic. Clean up subscription in `close()`.

## Why VAD before mute gate

The issue pseudocode suggests computing RMS after the mute gate, but I moved it **before** the `memset` for two reasons:
1. UI feedback while muted — users can see the talking ring light up when they speak into a muted mic, confirming the mic is working before they unmute.
2. The mute gate zeros frames in-place, destroying the signal; computing RMS on zeroed frames would always return 0.

This matches the behavior of professional conferencing apps (Zoom, Teams) which show mic activity indicators even when muted.

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] `flutter test` — all passing
- [ ] Manual device test: speak into mic → local talking ring lights up within 100ms
- [ ] Manual device test: two devices, peer sees ring respond to speech within 100ms
- [ ] Manual device test: speech at threshold boundary doesn't flicker
- [ ] Verify talking events emitted even when muted (for UI feedback)

## Dependencies

- Depends on BleControlTransport (#44) — already merged in PR #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added voice activity detection to identify when users are actively speaking
  * Local talking state is now synchronized with other session participants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->