### PR TITLE
feat(#51): HeartbeatScheduler + dirty-disconnect detection

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -4,8 +4,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../protocol/messages.dart';
+import '../protocol/peer.dart';
 import '../services/audio_service.dart';
 import '../services/ble_control_transport.dart';
+import '../services/heartbeat_scheduler.dart';
 import '../services/identity_store.dart';
 import '../services/recent_frequencies_store.dart';
 import '../services/reconnect_controller.dart';
@@ -68,6 +70,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// production schedule; tests pass short delays to avoid slow test runs.
   final List<Duration>? _reconnectDelays;
 
+  /// Drives the protocol's `ping` plane. Started on room entry, stopped
+  /// on leave / close. The cubit owns the role-specific reaction to a
+  /// lost peer (host: drop from roster + broadcast `RosterUpdate`;
+  /// guest: notify a host drop via [notifyDrop]).
+  final HeartbeatScheduler _heartbeats;
+
   StreamSubscription<FrequencyMessage>? _transportSubscription;
   ReconnectController? _reconnectController;
 
@@ -88,9 +96,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     BleControlTransport? transport,
     AudioService? audio,
     List<Duration>? reconnectDelays,
+    HeartbeatScheduler? heartbeats,
   })  : _transport = transport,
         _audio = audio,
         _reconnectDelays = reconnectDelays,
+        _heartbeats = heartbeats ?? HeartbeatScheduler(),
         super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
@@ -124,6 +134,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   }
 
   void _onTransportMessage(FrequencyMessage msg) {
+    // Any inbound activity from a peer counts as a sign-of-life — refresh
+    // the heartbeat watermark before dispatching, so a peer that's actively
+    // sending control messages won't be declared lost just because a
+    // dedicated `ping` was delayed.
+    _heartbeats.notePingFrom(msg.peerId);
     switch (msg) {
       case JoinAccepted m:
         applyJoinAccepted(m);
@@ -145,6 +160,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
               current.roster.where((p) => p.peerId != m.peerId).toList();
           emit(current.copyWith(roster: updated));
           _transport?.forgetPeer(m.peerId);
+          _heartbeats.forgetPeer(m.peerId);
         }
       case RemovePeer m:
         // Host-broadcasted peer removal. Drop the named peer from the roster
@@ -155,16 +171,119 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
             current.roster.where((p) => p.peerId != m.target).toList();
         emit(current.copyWith(roster: updated));
         _transport?.forgetPeer(m.target);
-      // These message types are handled by future issues (heartbeats,
-      // signal reports, voice-activity detection). Silently drop for now.
+        _heartbeats.forgetPeer(m.target);
+      case Heartbeat():
+        // Already noted above; no further dispatch — the heartbeat plane
+        // is purely a liveness signal, not a state-changing event.
+        break;
+      // These message types are handled by future issues (signal reports,
+      // voice-activity detection). Silently drop for now.
       case TalkingState():
       case MuteState():
-      case Heartbeat():
       case JoinRequest():
       case JoinDenied():
       case SignalReport():
         break;
     }
+  }
+
+  /// Tick callback wired into [HeartbeatScheduler.start] on room entry.
+  /// Builds + sends a single `Heartbeat` over the transport. The native
+  /// layer decides whether `send` broadcasts to all subscribed centrals
+  /// (host) or unicasts to the connected host (guest).
+  ///
+  /// The seq counter advances even when the transport is null so it
+  /// stays monotonic once the BLE link comes up — same defensive pattern
+  /// as [broadcastMute].
+  Future<void> _sendHeartbeat() async {
+    final t = _transport;
+    if (t == null) {
+      _seq++;
+      return;
+    }
+    final String peerId;
+    try {
+      peerId = await identityStore.getPeerId();
+    } catch (error, stackTrace) {
+      debugPrint('Failed to resolve peer id for heartbeat: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      _seq++;
+      return;
+    }
+    if (isClosed) return;
+    final msg = Heartbeat(
+      peerId: peerId,
+      seq: ++_seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+    );
+    unawaited(t.send(msg));
+  }
+
+  /// Fired by [HeartbeatScheduler] when [missThreshold] elapses without
+  /// a `notePingFrom` for [peerId]. Role-specific behaviour:
+  ///
+  ///   * **Host** — drop the peer from the local roster, clean up
+  ///     transport state, and broadcast a `RosterUpdate` to the
+  ///     remaining guests. Mirrors the protocol's host-as-authority
+  ///     dirty-disconnect contract.
+  ///   * **Guest** — only react if the lost peer is the host. Routes
+  ///     into [notifyDrop] (which starts the reconnect loop) when a
+  ///     MAC is on the room state, or to [leaveRoom] as a fallback
+  ///     when there's nothing to dial.
+  ///
+  /// No-op outside `SessionRoom` (e.g. a late tick after the user has
+  /// already left), or after the cubit is closed.
+  void _onHeartbeatPeerLost(String peerId) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! SessionRoom) return;
+    if (current.roomIsHost) {
+      // Don't react to a "lost" event for the local host's own peerId
+      // (defensive — shouldn't happen, but a stale watermark from a
+      // prior session shouldn't trigger a self-delete).
+      final updated =
+          current.roster.where((p) => p.peerId != peerId).toList();
+      if (updated.length == current.roster.length) return;
+      emit(current.copyWith(roster: updated));
+      _transport?.forgetPeer(peerId);
+      final t = _transport;
+      if (t == null) return;
+      // Best-effort RosterUpdate to remaining guests. We need a peerId
+      // for the envelope; resolve lazily and fire-and-forget.
+      unawaited(_broadcastRosterUpdate(updated));
+    } else {
+      // Guest: only the host's silence matters. A guest going quiet is
+      // the host's problem to handle and broadcast — we'd just hear
+      // about it via a `RosterUpdate`.
+      if (peerId != current.hostPeerId) return;
+      final mac = current.macAddress;
+      if (mac != null) {
+        unawaited(notifyDrop(macAddress: mac));
+      } else {
+        unawaited(leaveRoom());
+      }
+    }
+  }
+
+  Future<void> _broadcastRosterUpdate(List<ProtocolPeer> roster) async {
+    final t = _transport;
+    if (t == null) return;
+    final String peerId;
+    try {
+      peerId = await identityStore.getPeerId();
+    } catch (error, stackTrace) {
+      debugPrint('Failed to resolve peer id for roster update: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      return;
+    }
+    if (isClosed) return;
+    final msg = RosterUpdate(
+      peerId: peerId,
+      seq: ++_seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+      roster: roster,
+    );
+    unawaited(t.send(msg));
   }
 
   /// Persists [name] and advances to Discovery. The state changes even if
@@ -262,6 +381,20 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       macAddress: isHost ? null : macAddress,
       sessionUuidLow8: isHost ? null : sessionUuidLow8,
     ));
+    // Begin the heartbeat plane for the lifetime of the room. Pings the
+    // wire every interval and watches inbound activity for silent peers
+    // (host) / a silent host (guest). Calling start() is idempotent —
+    // re-entry into a fresh room will reset its watermarks.
+    //
+    // Skipped when no transport is wired: there's no wire to ping and no
+    // peers to detect silence on. Avoids leaking a long-running periodic
+    // timer in widget tests that exercise the cubit in loopback mode.
+    if (_transport != null) {
+      _heartbeats.start(
+        onTick: () => unawaited(_sendHeartbeat()),
+        onPeerLost: _onHeartbeatPeerLost,
+      );
+    }
   }
 
   /// Drops back to Discovery and forgets the room. No-op if not in a
@@ -278,6 +411,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // the user manually leaves rather than waiting for the next delay tick.
     _reconnectController?.cancel();
     _reconnectController = null;
+    // Cancel the heartbeat timer so it doesn't keep ticking against an
+    // empty roster (and incidentally trigger a phantom RosterUpdate if
+    // a stale watermark expires post-leave).
+    _heartbeats.stop();
     _seq = 0;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
@@ -497,6 +634,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Cancel an in-progress reconnect before closing so the attempt loop
     // won't call emit() or leaveRoom() after the cubit is disposed.
     _reconnectController?.cancel();
+    // Stop the heartbeat timer before super.close() so a tick suspended
+    // mid-microtask can't try to emit() against a closing cubit.
+    _heartbeats.stop();
     // Order matters. `super.close()` flips the cubit's `isClosed`; the
     // suspended `await` in `sendMediaCommand` resumes after it sees
     // `isClosed == true` and bails before touching the controller. If

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -294,6 +294,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // the host's problem to handle and broadcast — we'd just hear
       // about it via a `RosterUpdate`.
       if (peerId != current.hostPeerId) return;
+      // Drop the transport's idempotency state for the host before the
+      // reconnect attempt: the fresh `JoinAccepted` after reconnect
+      // restarts seq at 1 per protocol, and a stale watermark of, say, 7
+      // from this session would otherwise swallow the new session's seqs
+      // 1–7.
+      _transport?.forgetPeer(peerId);
+      _heartbeats.forgetPeer(peerId);
       final mac = current.macAddress;
       if (mac != null) {
         unawaited(notifyDrop(macAddress: mac));
@@ -485,6 +492,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // empty roster (and incidentally trigger a phantom RosterUpdate if
     // a stale watermark expires post-leave).
     _heartbeats.stop();
+    // Wipe transport-side idempotency state for *every* peer of the
+    // departing room. A re-join (same room or different) restarts the
+    // protocol's seq counters at 1; held-over watermarks from this room
+    // would otherwise swallow the next session's first messages.
+    _transport?.forgetAllPeers();
     _seq = 0;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -223,31 +223,36 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     }
     // Coalesce overlapping ticks: a slow link must not fan out into
     // concurrent transport writes that interleave fragments on the wire.
+    // The flag is set *synchronously* before the first `await` below — if
+    // it's set after the await on getPeerId, two ticks could both pass
+    // this check, both await the peerId, and then both reach the send.
     if (_heartbeatSendInFlight) return;
-    final String peerId;
-    try {
-      peerId = await identityStore.getPeerId();
-    } catch (error, stackTrace) {
-      debugPrint('Failed to resolve peer id for heartbeat: $error');
-      debugPrintStack(stackTrace: stackTrace);
-      _seq++;
-      return;
-    }
-    if (isClosed) return;
-    final msg = Heartbeat(
-      peerId: peerId,
-      seq: ++_seq,
-      atMs: DateTime.now().millisecondsSinceEpoch,
-    );
     _heartbeatSendInFlight = true;
     try {
-      await t.send(msg);
-    } catch (error, stackTrace) {
-      // Transport-layer failures are already logged inside
-      // BleControlTransport; swallow here so a single bad tick doesn't
-      // poison the timer.
-      debugPrint('Heartbeat send failed: $error');
-      debugPrintStack(stackTrace: stackTrace);
+      final String peerId;
+      try {
+        peerId = await identityStore.getPeerId();
+      } catch (error, stackTrace) {
+        debugPrint('Failed to resolve peer id for heartbeat: $error');
+        debugPrintStack(stackTrace: stackTrace);
+        _seq++;
+        return;
+      }
+      if (isClosed) return;
+      final msg = Heartbeat(
+        peerId: peerId,
+        seq: ++_seq,
+        atMs: DateTime.now().millisecondsSinceEpoch,
+      );
+      try {
+        await t.send(msg);
+      } catch (error, stackTrace) {
+        // Transport-layer failures are already logged inside
+        // BleControlTransport; swallow here so a single bad tick doesn't
+        // poison the timer.
+        debugPrint('Heartbeat send failed: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
     } finally {
       _heartbeatSendInFlight = false;
     }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -76,6 +76,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// guest: notify a host drop via [notifyDrop]).
   final HeartbeatScheduler _heartbeats;
 
+  /// Re-entrancy guard for [_sendHeartbeat]. The scheduler tick is
+  /// `unawaited`-launched, so a slow GATT write could otherwise overlap
+  /// the next tick and let two `send()` calls interleave on the same
+  /// transport. When a send is in flight, later ticks become no-ops
+  /// (and the seq counter stays put — the dropped tick effectively
+  /// merges with the in-flight one).
+  bool _heartbeatSendInFlight = false;
+
   StreamSubscription<FrequencyMessage>? _transportSubscription;
   ReconnectController? _reconnectController;
 
@@ -201,6 +209,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       _seq++;
       return;
     }
+    // Coalesce overlapping ticks: a slow link must not fan out into
+    // concurrent transport writes that interleave fragments on the wire.
+    if (_heartbeatSendInFlight) return;
     final String peerId;
     try {
       peerId = await identityStore.getPeerId();
@@ -216,7 +227,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       seq: ++_seq,
       atMs: DateTime.now().millisecondsSinceEpoch,
     );
-    unawaited(t.send(msg));
+    _heartbeatSendInFlight = true;
+    try {
+      await t.send(msg);
+    } catch (error, stackTrace) {
+      // Transport-layer failures are already logged inside
+      // BleControlTransport; swallow here so a single bad tick doesn't
+      // poison the timer.
+      debugPrint('Heartbeat send failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    } finally {
+      _heartbeatSendInFlight = false;
+    }
   }
 
   /// Fired by [HeartbeatScheduler] when [missThreshold] elapses without
@@ -238,9 +260,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     final current = state;
     if (current is! SessionRoom) return;
     if (current.roomIsHost) {
-      // Don't react to a "lost" event for the local host's own peerId
-      // (defensive — shouldn't happen, but a stale watermark from a
-      // prior session shouldn't trigger a self-delete).
+      // Defensive guard: never react to a "lost" event for the local
+      // host's own peerId — a stale watermark must not self-delete the
+      // host roster entry or emit a `RosterUpdate` that erases it.
+      // The host's own peerId shouldn't end up in `_lastSeen` in
+      // production (we never receive our own messages back through the
+      // wire), but the guard is cheap and removes the failure mode.
+      if (peerId == current.hostPeerId) return;
       final updated =
           current.roster.where((p) => p.peerId != peerId).toList();
       if (updated.length == current.roster.length) return;

--- a/lib/services/ble_control_transport.dart
+++ b/lib/services/ble_control_transport.dart
@@ -84,6 +84,20 @@ class BleControlTransport {
     }
   }
 
+  /// Drop the watermark and reassembler buffer for **every** known peer.
+  ///
+  /// Called when the cubit leaves a room — held-over watermarks from the
+  /// previous session would silently swallow `seq=1` of the next session
+  /// (per the protocol's "fresh JoinAccepted resets seq" rule). Cheaper
+  /// than enumerating the roster and calling [forgetPeer] N times, and
+  /// also clears any peer the cubit didn't know about (ghosts left in
+  /// the reassembler from a partial-fragment burst).
+  void forgetAllPeers() {
+    _filter.clear();
+    _endpointByPeer.clear();
+    _reassemblers.clear();
+  }
+
   /// Cancel the native-bytes subscription and close [incoming].
   ///
   /// After dispose, [incoming] emits no further events. Call once during

--- a/lib/services/heartbeat_scheduler.dart
+++ b/lib/services/heartbeat_scheduler.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Drives the protocol's `ping`/heartbeat plane: emits an [onTick] every
+/// [pingInterval] so the caller can send a `Heartbeat` over the wire, and
+/// declares a peer "lost" when no `notePingFrom` has arrived for that peer
+/// within [missThreshold].
+///
+/// The scheduler is **role-agnostic**. The cubit owns the host-vs-guest
+/// distinction: on the host side a lost peer means "drop from roster +
+/// broadcast a `RosterUpdate`"; on the guest side it means "the host went
+/// silent → start the reconnect loop". The scheduler just signals.
+///
+/// Per [docs/protocol.md] §"Health":
+///   * `pingInterval` defaults to 5 s.
+///   * `missThreshold` defaults to 15 s — three consecutive missed pings.
+///
+/// **Lifecycle.** [start] must be called when the room is entered and
+/// [stop] when it's left. [start] is idempotent: calling it twice cancels
+/// the prior timer first, so callers don't need to guard against double-start.
+///
+/// **`lastSeen` semantics.** A peer is only tracked once they've sent at
+/// least one ping (or other inbound activity routed through
+/// [notePingFrom]). A peer that never pings is never declared lost — that
+/// failure mode belongs to a different layer (transport-level disconnect).
+class HeartbeatScheduler {
+  /// Default cadence: send a ping every 5 s.
+  static const Duration defaultPingInterval = Duration(seconds: 5);
+
+  /// Default miss threshold: declare a peer lost after 15 s of silence
+  /// (three missed pings at the default cadence).
+  static const Duration defaultMissThreshold = Duration(seconds: 15);
+
+  final Duration pingInterval;
+  final Duration missThreshold;
+
+  /// Test seam: lets unit tests advance "now" without sleeping. Production
+  /// callers omit and get [DateTime.now].
+  final DateTime Function() _now;
+
+  Timer? _timer;
+  final Map<String, DateTime> _lastSeen = {};
+
+  void Function()? _onTick;
+  void Function(String peerId)? _onPeerLost;
+
+  HeartbeatScheduler({
+    this.pingInterval = defaultPingInterval,
+    this.missThreshold = defaultMissThreshold,
+    DateTime Function()? clock,
+  })  : assert(pingInterval > Duration.zero,
+            'pingInterval must be positive — Timer.periodic(0) busy-loops'),
+        assert(missThreshold > Duration.zero,
+            'missThreshold must be positive — otherwise every peer is "lost"'),
+        _now = clock ?? DateTime.now;
+
+  /// Whether the periodic timer is currently active.
+  bool get isRunning => _timer != null;
+
+  /// Starts the periodic tick. [onTick] fires every [pingInterval] so the
+  /// caller can serialise + send a `Heartbeat`. [onPeerLost] fires once
+  /// per peer that has crossed [missThreshold] since their last
+  /// [notePingFrom]; the peer is removed from the internal table before
+  /// [onPeerLost] is called, so a flapping peer needs a fresh ping to
+  /// be tracked again.
+  ///
+  /// Calling [start] while already running cancels the previous timer
+  /// and clears the [lastSeen] table — a fresh room entry shouldn't
+  /// inherit watermarks from a previous session.
+  void start({
+    required void Function() onTick,
+    required void Function(String peerId) onPeerLost,
+  }) {
+    stop();
+    _onTick = onTick;
+    _onPeerLost = onPeerLost;
+    _timer = Timer.periodic(pingInterval, (_) => _tick());
+  }
+
+  /// Records that a heartbeat (or other inbound activity routed through
+  /// the cubit's dispatch) just arrived from [peerId]. Resets the silence
+  /// clock for that peer.
+  void notePingFrom(String peerId) {
+    _lastSeen[peerId] = _now();
+  }
+
+  /// Drops the watermark for [peerId] without firing [onPeerLost]. Call
+  /// on clean disconnects (`Leave` / `RemovePeer` flow) so the peer's
+  /// next session starts fresh — and so a stale watermark from before
+  /// the clean Leave can't cause a spurious "lost" event later.
+  void forgetPeer(String peerId) {
+    _lastSeen.remove(peerId);
+  }
+
+  /// Cancels the timer and clears all state. Safe to call when not
+  /// running (e.g. during cubit `close()` after [stop] has already
+  /// fired through [leaveRoom]).
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _lastSeen.clear();
+    _onTick = null;
+    _onPeerLost = null;
+  }
+
+  /// Read-only view of the watermark table for assertions in tests.
+  @visibleForTesting
+  Map<String, DateTime> get lastSeen => Map.unmodifiable(_lastSeen);
+
+  /// Drives one tick synchronously. Used by tests to verify the
+  /// onTick / onPeerLost wiring without depending on real-time timers.
+  @visibleForTesting
+  void debugTick() => _tick();
+
+  void _tick() {
+    _onTick?.call();
+    final now = _now();
+    // Snapshot keys before iterating so the onPeerLost callback can
+    // mutate the map (forgetPeer / notePingFrom) without breaking the loop.
+    final lost = <String>[];
+    _lastSeen.forEach((peerId, last) {
+      if (now.difference(last) > missThreshold) {
+        lost.add(peerId);
+      }
+    });
+    for (final peerId in lost) {
+      _lastSeen.remove(peerId);
+      _onPeerLost?.call(peerId);
+    }
+  }
+}

--- a/lib/services/heartbeat_scheduler.dart
+++ b/lib/services/heartbeat_scheduler.dart
@@ -49,11 +49,26 @@ class HeartbeatScheduler {
     this.pingInterval = defaultPingInterval,
     this.missThreshold = defaultMissThreshold,
     DateTime Function()? clock,
-  })  : assert(pingInterval > Duration.zero,
-            'pingInterval must be positive — Timer.periodic(0) busy-loops'),
-        assert(missThreshold > Duration.zero,
-            'missThreshold must be positive — otherwise every peer is "lost"'),
-        _now = clock ?? DateTime.now;
+  }) : _now = clock ?? DateTime.now {
+    // Runtime checks (not `assert`s): the constraints have to hold in
+    // release builds too. A zero `pingInterval` makes `Timer.periodic`
+    // busy-loop; a non-positive `missThreshold` declares every peer
+    // "lost" on the first tick.
+    if (pingInterval <= Duration.zero) {
+      throw ArgumentError.value(
+        pingInterval,
+        'pingInterval',
+        'Must be positive — Timer.periodic(0) busy-loops.',
+      );
+    }
+    if (missThreshold <= Duration.zero) {
+      throw ArgumentError.value(
+        missThreshold,
+        'missThreshold',
+        'Must be positive — otherwise every peer is "lost" on first tick.',
+      );
+    }
+  }
 
   /// Whether the periodic timer is currently active.
   bool get isRunning => _timer != null;

--- a/lib/services/heartbeat_scheduler.dart
+++ b/lib/services/heartbeat_scheduler.dart
@@ -118,9 +118,13 @@ class HeartbeatScheduler {
     final now = _now();
     // Snapshot keys before iterating so the onPeerLost callback can
     // mutate the map (forgetPeer / notePingFrom) without breaking the loop.
+    //
+    // Use `>=` so a peer silent for exactly [missThreshold] is declared
+    // lost on this tick rather than the next — matches the protocol's
+    // "~15 s elapsed since last arrival" wording.
     final lost = <String>[];
     _lastSeen.forEach((peerId, last) {
-      if (now.difference(last) > missThreshold) {
+      if (now.difference(last) >= missThreshold) {
         lost.add(peerId);
       }
     });

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1352,11 +1352,13 @@ void main() {
         final t = makeTestTransport();
         // notifyDrop needs an AudioService; keep it on a non-existent MAC
         // and let the (zero-delay) attempts fail.
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-          const MethodChannel('com.elodin.walkie_talkie/audio'),
-          (call) async => false,
-        );
+            .setMockMethodCallHandler(channel, (call) async => false);
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
 
         var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
         final scheduler = HeartbeatScheduler(
@@ -1407,11 +1409,6 @@ void main() {
         await cubit.close();
         await t.inbox.close();
         t.transport.dispose();
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-          const MethodChannel('com.elodin.walkie_talkie/audio'),
-          null,
-        );
       },
     );
 
@@ -1526,11 +1523,13 @@ void main() {
         // seq to 1, so the transport's stale watermark from the dying
         // session must be cleared — otherwise the new session's first
         // messages get silently swallowed.
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-          const MethodChannel('com.elodin.walkie_talkie/audio'),
-          (call) async => false,
-        );
+            .setMockMethodCallHandler(channel, (call) async => false);
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
         final t = makeTestTransport();
         var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
         final scheduler = HeartbeatScheduler(
@@ -1587,11 +1586,6 @@ void main() {
         await cubit.close();
         await t.inbox.close();
         t.transport.dispose();
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-          const MethodChannel('com.elodin.walkie_talkie/audio'),
-          null,
-        );
       },
     );
 

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1210,6 +1210,44 @@ void main() {
     });
 
     test(
+      'inbound non-Heartbeat messages also refresh the watermark',
+      () async {
+        // The cubit treats any inbound activity as a sign-of-life so an
+        // actively-chatty peer can't be declared lost on a delayed
+        // dedicated ping. Pin that contract — `notePingFrom` must run
+        // for non-`Heartbeat` kinds too.
+        final t = makeTestTransport();
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+
+        final updateJson = const RosterUpdate(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          roster: [],
+        ).encode();
+        for (final frag in encodeFragments(updateJson)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        expect(scheduler.lastSeen, contains('p-guest'));
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
       'incoming Heartbeat refreshes the watermark for the sender',
       () async {
         final t = makeTestTransport();

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -5,9 +5,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/bloc/frequency_session_cubit.dart';
 import 'package:walkie_talkie/bloc/frequency_session_state.dart';
+import 'package:walkie_talkie/protocol/framing.dart';
 import 'package:walkie_talkie/protocol/messages.dart';
 import 'package:walkie_talkie/protocol/peer.dart';
 import 'package:walkie_talkie/services/audio_service.dart';
+import 'package:walkie_talkie/services/ble_control_transport.dart';
+import 'package:walkie_talkie/services/heartbeat_scheduler.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 
@@ -95,6 +98,8 @@ FrequencySessionCubit _makeCubit({
   RecentFrequenciesStore? recentFrequenciesStore,
   AudioService? audio,
   List<Duration>? reconnectDelays,
+  HeartbeatScheduler? heartbeats,
+  BleControlTransport? transport,
 }) =>
     FrequencySessionCubit(
       identityStore: identityStore ?? _FakeStore(),
@@ -102,6 +107,8 @@ FrequencySessionCubit _makeCubit({
           recentFrequenciesStore ?? _FakeRecentFrequenciesStore(),
       audio: audio,
       reconnectDelays: reconnectDelays,
+      heartbeats: heartbeats,
+      transport: transport,
     );
 
 void main() {
@@ -1111,6 +1118,354 @@ void main() {
       await cubit.close();
       blocker.complete(false);
       await expectLater(dropFuture, completes);
+    });
+  });
+
+  // ── Heartbeats / dirty-disconnect ──────────────────────────────────────
+
+  group('Heartbeats', () {
+    setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+    /// Builds a transport whose `send` writes to [outbox] without touching
+    /// MethodChannels. The incoming stream is exposed via [inbox] so tests
+    /// can deliver synthesised wire messages.
+    ({BleControlTransport transport, List<Uint8List> outbox, StreamController<({String endpointId, Uint8List bytes})> inbox})
+        makeTestTransport() {
+      final outbox = <Uint8List>[];
+      final inbox = StreamController<({String endpointId, Uint8List bytes})>.broadcast();
+      final transport = BleControlTransport.forTest(
+        controlBytes: inbox.stream,
+        writeBytes: (bytes) async {
+          outbox.add(bytes);
+        },
+      );
+      return (transport: transport, outbox: outbox, inbox: inbox);
+    }
+
+    test(
+      'joinRoom starts the heartbeat scheduler when a transport is wired; '
+      'leaveRoom stops it',
+      () async {
+        final t = makeTestTransport();
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+          missThreshold: const Duration(seconds: 60),
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        expect(scheduler.isRunning, isFalse);
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        expect(scheduler.isRunning, isTrue);
+
+        await cubit.leaveRoom();
+        expect(scheduler.isRunning, isFalse);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'joinRoom without a transport does NOT start the heartbeat scheduler',
+      () async {
+        // The wire-less loopback mode is the path widget tests use, and
+        // a periodic timer outliving the test triggers Flutter's
+        // "Timer is still pending" assertion. Heartbeats are useless
+        // without a transport (no wire to ping) so we leave the scheduler
+        // dormant.
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        );
+        final cubit = _makeCubit(heartbeats: scheduler);
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+
+        expect(scheduler.isRunning, isFalse);
+        await cubit.close();
+      },
+    );
+
+    test('cubit.close() stops the heartbeat scheduler', () async {
+      final t = makeTestTransport();
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(hours: 1),
+      );
+      final cubit = _makeCubit(
+        heartbeats: scheduler,
+        transport: t.transport,
+      );
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      expect(scheduler.isRunning, isTrue);
+
+      await cubit.close();
+      expect(scheduler.isRunning, isFalse);
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test(
+      'incoming Heartbeat refreshes the watermark for the sender',
+      () async {
+        final t = makeTestTransport();
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+        );
+        await cubit.bootstrap(); // wires the transport.incoming subscription
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+
+        // Inject a Heartbeat from a guest peer — frame it through
+        // encodeFragments so the inbox receives the same shape it would
+        // see from the native GATT layer.
+        final pingJson = const Heartbeat(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+        ).encode();
+        for (final frag in encodeFragments(pingJson)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        expect(scheduler.lastSeen, contains('p-guest'));
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'host: peer-lost drops the peer from the roster and broadcasts RosterUpdate',
+      () async {
+        final t = makeTestTransport();
+        // Use a deterministic clock so debugTick() can drive the silence test.
+        var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+          missThreshold: const Duration(seconds: 15),
+          clock: () => fakeNow,
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        // Seed the host's roster (would normally come from JoinAccepted /
+        // RosterUpdate flow). This is the snapshot the lost-peer handler
+        // edits down.
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [
+            ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ProtocolPeer(peerId: 'p-stale', displayName: 'Stale'),
+            ProtocolPeer(peerId: 'p-fresh', displayName: 'Fresh'),
+          ],
+        ));
+
+        // p-stale pinged at t=0; p-fresh pings at t=14. Tick at t=20 → only
+        // p-stale should be declared lost (20s > 15s threshold).
+        scheduler.notePingFrom('p-stale');
+        fakeNow = fakeNow.add(const Duration(seconds: 14));
+        scheduler.notePingFrom('p-fresh');
+        fakeNow = fakeNow.add(const Duration(seconds: 6));
+        scheduler.debugTick();
+        await Future<void>.delayed(Duration.zero); // settle the broadcast
+
+        final room = cubit.state as SessionRoom;
+        expect(
+          room.roster.map((p) => p.peerId),
+          unorderedEquals(['p-host', 'p-fresh']),
+          reason: 'p-stale crossed the silence threshold',
+        );
+
+        // The cubit should have written a RosterUpdate to the wire so the
+        // remaining guests learn of the drop. We don't pin the exact framing
+        // here (other tests cover encodeFragments) — just check that *some*
+        // outbound bytes contain "roster_update".
+        final wire = t.outbox.map((b) => String.fromCharCodes(b)).join();
+        expect(wire, contains('roster_update'));
+        expect(wire, contains('p-fresh'));
+        expect(wire, isNot(contains('p-stale')));
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'guest: host-lost transitions the room to reconnecting via notifyDrop',
+      () async {
+        final t = makeTestTransport();
+        // notifyDrop needs an AudioService; keep it on a non-existent MAC
+        // and let the (zero-delay) attempts fail.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          (call) async => false,
+        );
+
+        var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+          missThreshold: const Duration(seconds: 15),
+          clock: () => fakeNow,
+        );
+        final audio = AudioService();
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+          audio: audio,
+          reconnectDelays: _testReconnectDelays,
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+        await cubit.joinRoom(
+          freq: '104.3',
+          isHost: false,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [ProtocolPeer(peerId: 'p-host', displayName: 'Devon')],
+        ));
+
+        scheduler.notePingFrom('p-host');
+        fakeNow = fakeNow.add(const Duration(seconds: 20));
+        scheduler.debugTick();
+        // Yield once so notifyDrop emits ConnectionPhase.reconnecting before
+        // the (zero-delay) attempts exhaust.
+        await Future<void>.delayed(Duration.zero);
+
+        // notifyDrop has been entered: state must be SessionRoom with
+        // reconnecting phase, OR the loop has already exhausted to Discovery.
+        final s = cubit.state;
+        if (s is SessionRoom) {
+          expect(s.connectionPhase, isNot(ConnectionPhase.online));
+        } else {
+          expect(s, isA<SessionDiscovery>());
+        }
+
+        // Drain any pending reconnect work before closing so background
+        // futures don't outlive the test.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          null,
+        );
+      },
+    );
+
+    test(
+      'guest: a non-host peer-lost is ignored',
+      () async {
+        final t = makeTestTransport();
+        var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+          missThreshold: const Duration(seconds: 15),
+          clock: () => fakeNow,
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+        await cubit.joinRoom(
+          freq: '104.3',
+          isHost: false,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [
+            ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ProtocolPeer(peerId: 'p-other', displayName: 'Other'),
+          ],
+        ));
+
+        // A non-host peer goes silent. The guest doesn't know about other
+        // guests (star topology — that's the host's bookkeeping), so it
+        // must NOT call notifyDrop / leaveRoom on a stale watermark.
+        scheduler.notePingFrom('p-other');
+        fakeNow = fakeNow.add(const Duration(seconds: 30));
+        scheduler.debugTick();
+
+        final s = cubit.state;
+        expect(s, isA<SessionRoom>());
+        expect((s as SessionRoom).connectionPhase, ConnectionPhase.online);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test('forgetPeer is wired through Leave dispatch', () async {
+      final t = makeTestTransport();
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(hours: 1),
+      );
+      final cubit = _makeCubit(
+        heartbeats: scheduler,
+        transport: t.transport,
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [
+          ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+          ProtocolPeer(peerId: 'p-guest', displayName: 'Maya'),
+        ],
+      ));
+
+      // Synthesise a Leave from p-guest delivered through the transport.
+      scheduler.notePingFrom('p-guest');
+      expect(scheduler.lastSeen, contains('p-guest'));
+
+      final leaveJson = const Leave(peerId: 'p-guest', seq: 1, atMs: 0).encode();
+      for (final frag in encodeFragments(leaveJson)) {
+        t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      // Note: the dispatch first calls notePingFrom(p-guest) (any inbound
+      // activity refreshes the watermark) and then forgetPeer(p-guest). The
+      // net effect on the table is "removed".
+      expect(scheduler.lastSeen, isNot(contains('p-guest')));
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
     });
   });
 

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1463,6 +1463,138 @@ void main() {
       },
     );
 
+    test(
+      'leaveRoom wipes transport idempotency state for every peer',
+      () async {
+        // Held-over watermarks across a leave + re-join would silently
+        // swallow `seq=1` of the next session per protocol — exercise the
+        // forgetAllPeers cleanup end-to-end.
+        final t = makeTestTransport();
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+
+        // Push two peers' messages to advance the transport's per-peer
+        // sequence watermarks past 1.
+        for (final peer in const ['p-a', 'p-b']) {
+          for (var seq = 1; seq <= 3; seq++) {
+            for (final frag in encodeFragments(
+                Heartbeat(peerId: peer, seq: seq, atMs: 0).encode())) {
+              t.inbox.add((endpointId: peer, bytes: frag));
+            }
+          }
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        await cubit.leaveRoom();
+
+        // Re-emit Discovery so we can synthesise a re-join behaviour
+        // through the transport.
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+
+        // After leaveRoom + new joinRoom, a fresh `seq=1` from p-a must
+        // not be filtered as a duplicate. We piggyback on the watermark
+        // refresh: notePingFrom doesn't drive the sequence filter, so the
+        // best signal here is whether the inbound message is dispatched
+        // through to `_heartbeats.notePingFrom` (only happens on accept).
+        for (final frag in encodeFragments(
+            const Heartbeat(peerId: 'p-a', seq: 1, atMs: 0).encode())) {
+          t.inbox.add((endpointId: 'p-a', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+        expect(scheduler.lastSeen, contains('p-a'),
+            reason: 'fresh seq=1 must pass the cleared sequence filter');
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'guest host-lost forgets the host on the transport before reconnect',
+      () async {
+        // Per Gemini review: the fresh JoinAccepted after reconnect resets
+        // seq to 1, so the transport's stale watermark from the dying
+        // session must be cleared — otherwise the new session's first
+        // messages get silently swallowed.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          (call) async => false,
+        );
+        final t = makeTestTransport();
+        var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+          missThreshold: const Duration(seconds: 15),
+          clock: () => fakeNow,
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+          audio: AudioService(),
+          reconnectDelays: _testReconnectDelays,
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+        await cubit.joinRoom(
+          freq: '104.3',
+          isHost: false,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [ProtocolPeer(peerId: 'p-host', displayName: 'Devon')],
+        ));
+
+        // Push the host's seq watermark past 1 by sending a message.
+        for (final frag in encodeFragments(
+            const Heartbeat(peerId: 'p-host', seq: 5, atMs: 0).encode())) {
+          t.inbox.add((endpointId: 'p-host', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        scheduler.notePingFrom('p-host');
+        fakeNow = fakeNow.add(const Duration(seconds: 16));
+        scheduler.debugTick();
+        // Yield once so notifyDrop fires + the host-forget runs ahead of
+        // the (zero-delay) reconnect attempts.
+        await Future<void>.delayed(Duration.zero);
+
+        // After the silence detection, a fresh JoinAccepted (seq=1) for the
+        // host should be accepted by the transport's filter — proving the
+        // stale seq=5 watermark was cleared.
+        for (final frag in encodeFragments(JoinAccepted(
+                peerId: 'p-host', seq: 1, atMs: 0, hostPeerId: 'p-host',
+                roster: const []).encode())) {
+          t.inbox.add((endpointId: 'p-host', bytes: frag));
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // Drain background reconnect work before closing.
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          null,
+        );
+      },
+    );
+
     test('forgetPeer is wired through Leave dispatch', () async {
       final t = makeTestTransport();
       final scheduler = HeartbeatScheduler(

--- a/test/services/ble_control_transport_test.dart
+++ b/test/services/ble_control_transport_test.dart
@@ -254,6 +254,35 @@ void main() {
         await sub.cancel();
       });
 
+      test('forgetAllPeers clears every peer\'s watermark + reassembler',
+          () async {
+        // Wipe-the-slate-clean variant for the leaveRoom path: held-over
+        // watermarks from an old session must not silently swallow `seq=1`
+        // of the next session.
+        final emitted = <FrequencyMessage>[];
+        final sub = transport.incoming.listen(emitted.add);
+
+        // Advance watermarks for two distinct peers.
+        _injectMessage(controlBytesController,
+            _heartbeat(peerId: 'peer-a', seq: 5));
+        _injectMessage(controlBytesController,
+            _heartbeat(peerId: 'peer-b', seq: 3));
+        await Future<void>.delayed(Duration.zero);
+        expect(emitted, hasLength(2));
+
+        transport.forgetAllPeers();
+
+        // Both peers' fresh sessions start at seq=1; both should land.
+        _injectMessage(controlBytesController,
+            _heartbeat(peerId: 'peer-a', seq: 1));
+        _injectMessage(controlBytesController,
+            _heartbeat(peerId: 'peer-b', seq: 1));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, hasLength(4));
+        await sub.cancel();
+      });
+
       test('cleans up the reassembler via endpointId mapping on reconnect',
           () async {
         final emitted = <FrequencyMessage>[];

--- a/test/services/heartbeat_scheduler_test.dart
+++ b/test/services/heartbeat_scheduler_test.dart
@@ -1,0 +1,272 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/heartbeat_scheduler.dart';
+
+void main() {
+  group('HeartbeatScheduler defaults', () {
+    test('defaults match the protocol: 5s interval, 15s miss threshold', () {
+      // The constants are load-bearing — they're how three "missed pings"
+      // gets resolved. If anyone retunes one without the other, the
+      // check-on-tick logic stops mapping cleanly to the protocol's
+      // "after 3 missed pings (~15s)" rule.
+      expect(HeartbeatScheduler.defaultPingInterval,
+          const Duration(seconds: 5));
+      expect(HeartbeatScheduler.defaultMissThreshold,
+          const Duration(seconds: 15));
+    });
+
+    test('rejects a non-positive pingInterval', () {
+      expect(
+        () => HeartbeatScheduler(pingInterval: Duration.zero),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('rejects a non-positive missThreshold', () {
+      expect(
+        () => HeartbeatScheduler(missThreshold: Duration.zero),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('HeartbeatScheduler.start / stop', () {
+    test('start fires onTick periodically and stop cancels the timer',
+        () async {
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(milliseconds: 10),
+        missThreshold: const Duration(seconds: 60),
+      );
+
+      var ticks = 0;
+      scheduler.start(
+        onTick: () => ticks++,
+        onPeerLost: (_) => fail('no peers tracked, none should be lost'),
+      );
+
+      // Wait long enough to observe ≥ 2 ticks but bound the upper end so
+      // the test doesn't depend on millisecond-level timer accuracy.
+      await Future<void>.delayed(const Duration(milliseconds: 35));
+      expect(ticks, greaterThanOrEqualTo(2));
+
+      scheduler.stop();
+      final ticksAtStop = ticks;
+      // After stop, no further ticks should arrive.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(ticks, ticksAtStop);
+    });
+
+    test('isRunning toggles on start / stop', () {
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 1),
+      );
+      expect(scheduler.isRunning, isFalse);
+      scheduler.start(onTick: () {}, onPeerLost: (_) {});
+      expect(scheduler.isRunning, isTrue);
+      scheduler.stop();
+      expect(scheduler.isRunning, isFalse);
+    });
+
+    test('start while running cancels the previous timer and clears state',
+        () async {
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(milliseconds: 10),
+        missThreshold: const Duration(seconds: 60),
+      );
+
+      var ticks1 = 0;
+      scheduler.start(
+        onTick: () => ticks1++,
+        onPeerLost: (_) {},
+      );
+      scheduler.notePingFrom('peer-a');
+      expect(scheduler.lastSeen, contains('peer-a'));
+
+      // Re-start with a fresh callback. The first counter must stop
+      // incrementing, and the watermarks must be wiped.
+      var ticks2 = 0;
+      scheduler.start(
+        onTick: () => ticks2++,
+        onPeerLost: (_) {},
+      );
+      expect(scheduler.lastSeen, isEmpty);
+
+      await Future<void>.delayed(const Duration(milliseconds: 35));
+      // Only ticks2 should still be advancing — ticks1's timer was cancelled.
+      // We can't pin exact counts, but ticks1 must not have been advanced
+      // *after* the second start.
+      final ticks1AtStart = ticks1;
+      scheduler.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(ticks1, ticks1AtStart);
+      expect(ticks2, greaterThan(0));
+    });
+
+    test('stop is safe when never started', () {
+      final scheduler = HeartbeatScheduler();
+      expect(scheduler.stop, returnsNormally);
+    });
+
+    test('stop is idempotent', () {
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 1),
+      );
+      scheduler.start(onTick: () {}, onPeerLost: (_) {});
+      scheduler.stop();
+      expect(scheduler.stop, returnsNormally);
+    });
+  });
+
+  group('HeartbeatScheduler peer-lost detection', () {
+    test('does NOT fire onPeerLost for a peer who never pinged', () {
+      // Spec: a peer is only tracked once the first ping arrives. A peer
+      // that has never pinged shouldn't surface as "lost" — that failure
+      // mode (silent join) belongs to a different layer.
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 60),
+        missThreshold: const Duration(milliseconds: 1),
+      );
+      final lost = <String>[];
+      scheduler.start(
+        onTick: () {},
+        onPeerLost: lost.add,
+      );
+
+      scheduler.debugTick();
+      expect(lost, isEmpty);
+      scheduler.stop();
+    });
+
+    test('fires onPeerLost when missThreshold elapses since last ping', () {
+      // Drive a fake clock so the test is deterministic under
+      // millisecond-jitter.
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 60),
+        missThreshold: const Duration(seconds: 15),
+        clock: () => fakeNow,
+      );
+      final lost = <String>[];
+      scheduler.start(onTick: () {}, onPeerLost: lost.add);
+
+      scheduler.notePingFrom('peer-a');
+      scheduler.notePingFrom('peer-b');
+
+      // Tick at +10s — within threshold for both.
+      fakeNow = fakeNow.add(const Duration(seconds: 10));
+      scheduler.debugTick();
+      expect(lost, isEmpty);
+
+      // Tick at +16s — past threshold for both (last ping was at 0s).
+      fakeNow = fakeNow.add(const Duration(seconds: 6));
+      scheduler.debugTick();
+      expect(lost, unorderedEquals(['peer-a', 'peer-b']));
+      // Both watermarks were dropped; a re-tick shouldn't refire.
+      lost.clear();
+      scheduler.debugTick();
+      expect(lost, isEmpty);
+
+      scheduler.stop();
+    });
+
+    test('a fresh ping resets the silence clock', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 60),
+        missThreshold: const Duration(seconds: 15),
+        clock: () => fakeNow,
+      );
+      final lost = <String>[];
+      scheduler.start(onTick: () {}, onPeerLost: lost.add);
+
+      scheduler.notePingFrom('peer-a');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 14));
+      scheduler.notePingFrom('peer-a'); // refresh watermark just in time
+
+      fakeNow = fakeNow.add(const Duration(seconds: 14));
+      scheduler.debugTick();
+      // 14s since the *latest* ping → still within threshold.
+      expect(lost, isEmpty);
+
+      fakeNow = fakeNow.add(const Duration(seconds: 2));
+      scheduler.debugTick();
+      // Now 16s since the latest ping — declared lost.
+      expect(lost, ['peer-a']);
+
+      scheduler.stop();
+    });
+
+    test('forgetPeer drops a watermark without firing onPeerLost', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 60),
+        missThreshold: const Duration(seconds: 15),
+        clock: () => fakeNow,
+      );
+      final lost = <String>[];
+      scheduler.start(onTick: () {}, onPeerLost: lost.add);
+
+      scheduler.notePingFrom('peer-a');
+      scheduler.forgetPeer('peer-a');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 30));
+      scheduler.debugTick();
+
+      // peer-a was forgotten cleanly — no spurious "lost" callback.
+      expect(lost, isEmpty);
+      scheduler.stop();
+    });
+
+    test('per-peer independence: one stale, one fresh', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 60),
+        missThreshold: const Duration(seconds: 15),
+        clock: () => fakeNow,
+      );
+      final lost = <String>[];
+      scheduler.start(onTick: () {}, onPeerLost: lost.add);
+
+      scheduler.notePingFrom('peer-stale');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 14));
+      scheduler.notePingFrom('peer-fresh');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 5));
+      scheduler.debugTick();
+      // peer-stale: 19s since last ping → lost.
+      // peer-fresh: 5s since last ping → still alive.
+      expect(lost, ['peer-stale']);
+      expect(scheduler.lastSeen.keys, ['peer-fresh']);
+
+      scheduler.stop();
+    });
+  });
+
+  group('HeartbeatScheduler.debugTick → onTick ordering', () {
+    test('onTick fires once per tick before onPeerLost dispatch', () {
+      // The cubit relies on this order: send our outbound ping first
+      // (so guests/host hear from us before they declare us lost on
+      // their side), then evaluate inbound silence on ours.
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final order = <String>[];
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 60),
+        missThreshold: const Duration(milliseconds: 1),
+        clock: () => fakeNow,
+      );
+
+      scheduler.start(
+        onTick: () => order.add('tick'),
+        onPeerLost: (id) => order.add('lost:$id'),
+      );
+
+      scheduler.notePingFrom('peer-a');
+      fakeNow = fakeNow.add(const Duration(seconds: 1));
+      scheduler.debugTick();
+
+      expect(order, ['tick', 'lost:peer-a']);
+      scheduler.stop();
+    });
+  });
+}

--- a/test/services/heartbeat_scheduler_test.dart
+++ b/test/services/heartbeat_scheduler_test.dart
@@ -136,6 +136,33 @@ void main() {
       scheduler.stop();
     });
 
+    test('fires onPeerLost when elapsed time exactly equals missThreshold',
+        () {
+      // Boundary test: the protocol's "~15 s elapsed" wording is read as
+      // an inclusive boundary, so a tick at exactly 15s should declare
+      // the peer lost rather than waiting one more interval.
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(seconds: 60),
+        missThreshold: const Duration(seconds: 15),
+        clock: () => fakeNow,
+      );
+      final lost = <String>[];
+      scheduler.start(onTick: () {}, onPeerLost: lost.add);
+
+      scheduler.notePingFrom('peer-a');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 14));
+      scheduler.debugTick();
+      expect(lost, isEmpty, reason: '14s < 15s threshold');
+
+      fakeNow = fakeNow.add(const Duration(seconds: 1)); // exactly 15s
+      scheduler.debugTick();
+      expect(lost, ['peer-a'], reason: '15s ≥ 15s threshold (inclusive)');
+
+      scheduler.stop();
+    });
+
     test('fires onPeerLost when missThreshold elapses since last ping', () {
       // Drive a fake clock so the test is deterministic under
       // millisecond-jitter.

--- a/test/services/heartbeat_scheduler_test.dart
+++ b/test/services/heartbeat_scheduler_test.dart
@@ -15,16 +15,17 @@ void main() {
     });
 
     test('rejects a non-positive pingInterval', () {
+      // Runtime check (not assert) so the contract holds in release builds.
       expect(
         () => HeartbeatScheduler(pingInterval: Duration.zero),
-        throwsA(isA<AssertionError>()),
+        throwsA(isA<ArgumentError>()),
       );
     });
 
     test('rejects a non-positive missThreshold', () {
       expect(
         () => HeartbeatScheduler(missThreshold: Duration.zero),
-        throwsA(isA<AssertionError>()),
+        throwsA(isA<ArgumentError>()),
       );
     });
   });


### PR DESCRIPTION
## Summary

Lands the protocol's `ping` plane and the role-aware cubit wiring that closes [#51](https://github.com/ElodinLaarz/walkie-talkie/issues/51). Per [docs/protocol.md](docs/protocol.md) §"Health": each side sends `ping` every ~5 s and treats 3 consecutive misses (~15 s) as a dropped peer / dead host.

- **New `HeartbeatScheduler`** ([lib/services/heartbeat_scheduler.dart](lib/services/heartbeat_scheduler.dart)) — pure Dart, role-agnostic. Runs the periodic timer, tracks per-peer `lastSeen`, fires `onTick` (caller sends the wire ping) and `onPeerLost` (caller decides what "lost" means). Injectable clock for tests; `debugTick()` so unit tests don't depend on real-time timers.

- **Cubit integration** ([lib/bloc/frequency_session_cubit.dart](lib/bloc/frequency_session_cubit.dart))
  - Started in `joinRoom` (only when a transport is wired — loopback mode stays dormant so widget tests don't leak periodic timers), stopped in `leaveRoom` and `close`.
  - Tick callback sends a `Heartbeat` with the local peerId + fresh seq, mirroring `broadcastMute`'s seq-advances-even-with-no-transport pattern.
  - Inbound dispatch calls `notePingFrom` for **any** message kind, not just `Heartbeat` — an actively-chatty peer can't be declared lost on a delayed dedicated ping.
  - Lost-peer routing is role-aware:
    - **Host** — drops the peer from the roster + broadcasts a `RosterUpdate` to remaining guests + `transport.forgetPeer`.
    - **Guest** — only reacts to a silent *host*; routes into the existing `notifyDrop` (which starts the [`ReconnectController`](lib/services/reconnect_controller.dart) loop), or `leaveRoom` as a fallback when no MAC is on the room state. A non-host peer going silent is ignored — the star topology means that's the host's bookkeeping.
  - `Leave` / `RemovePeer` dispatch also clears the heartbeat watermark for the departing peer so a stale entry can't fire a phantom "lost" later.

## Why no scope creep

- Native broadcast-vs-unicast for `transport.send(Heartbeat)` is left to the native layer — the issue and the GATT-server work track that. The Dart side just calls `transport.send` once per tick and trusts the transport.
- "Lost connection" toast UX (issue acceptance step on the guest path) lands separately because it depends on the in-frame toast system already wired into the room screen — this PR's `notifyDrop` integration already drives the existing `ConnectionPhase.lost → leaveRoom` path the toast hooks into.

## Test plan

- [x] `flutter analyze` — no issues.
- [x] `flutter test` — 269 passing, 1 pre-existing skip.
- [x] New `heartbeat_scheduler_test.dart` covers defaults, assertion guards, start/stop idempotence, miss-threshold detection (deterministic via fake clock), per-peer independence, `forgetPeer` cleanliness, tick-then-lost ordering.
- [x] Heartbeat cubit-level group covers: lifecycle (start on join with transport / no-start without / stop on leave / stop on close), inbound watermark refresh through the full reassembler path, host-side `RosterUpdate` broadcast on peer-lost, guest-side `notifyDrop` on host-lost, non-host silence ignored, `Leave` flow clears watermark.
- [ ] Manual: kill the host's BT, the guest returns to Discovery within 15 s. _(Deferred to device smoke-test once the GATT/L2CAP plane is wired end-to-end — same constraint that defers the click-through integration test in [frequency_room_screen_test.dart](test/screens/frequency_room_screen_test.dart).)_
- [ ] Manual: a guest force-quits, the host's roster updates within 15 s. _(Same deferral.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic heartbeat monitoring to detect unresponsive peers, start/stop with join/leave, and prevent phantom timers after close.
  * Role-specific peer-loss behavior: hosts remove silent peers and broadcast roster updates; guests trigger reconnect behavior when host is lost.
  * Added configurable liveness tracking with peer cleanup and ping refresh on inbound messages.

* **Tests**
  * Comprehensive tests for heartbeat scheduling, loss detection, lifecycle, and role-specific reactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->