### PR TITLE
feat(#56): Complete reconnecting UI — show yellow pill during BLE reconnect attempts

### DIFF
--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -701,26 +701,31 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         pillBg = c.warnSoft;
         pillText = c.warn;
         statusText = 'Reconnecting…';
-        // Spinning progress indicator for reconnecting
+        // Spinning progress indicator for reconnecting - size matches PulseDot
         statusIcon = SizedBox(
-          width: 10,
-          height: 10,
+          width: 12,
+          height: 12,
           child: CircularProgressIndicator(
             strokeWidth: 2,
             valueColor: AlwaysStoppedAnimation(pillText),
           ),
         );
       case ConnectionPhase.lost:
-        pillBg = const Color(0xFFFFE5E5); // Light red background
+        // Use danger color with reduced opacity for dark mode compatibility
+        pillBg = c.danger.withValues(alpha: 0.15);
         pillText = c.danger;
         statusText = 'Lost connection';
         statusIcon = Icon(Icons.error_outline, size: 12, color: pillText);
       case ConnectionPhase.online:
-      default:
         pillBg = c.accentSoft;
         pillText = c.accentInk;
         statusText = 'On air';
-        statusIcon = const PulseDot(size: 6);
+        // Wrap PulseDot in SizedBox for consistent icon sizing
+        statusIcon = const SizedBox(
+          width: 12,
+          height: 12,
+          child: Center(child: PulseDot(size: 6)),
+        );
     }
 
     return Container(

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -567,11 +567,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
             children: [
               BlocBuilder<FrequencySessionCubit, FrequencySessionState>(
                 buildWhen: (prev, next) {
-                  // Rebuild chrome when connectionPhase changes
+                  // Rebuild chrome when connectionPhase changes or state type changes
                   if (prev is SessionRoom && next is SessionRoom) {
                     return prev.connectionPhase != next.connectionPhase;
                   }
-                  return false;
+                  // Also rebuild when transitioning to/from SessionRoom (initial build)
+                  return true;
                 },
                 builder: (context, state) {
                   final phase = state is SessionRoom

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -565,7 +565,21 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         body: SafeArea(
           child: Column(
             children: [
-              _buildChrome(context),
+              BlocBuilder<FrequencySessionCubit, FrequencySessionState>(
+                buildWhen: (prev, next) {
+                  // Rebuild chrome when connectionPhase changes
+                  if (prev is SessionRoom && next is SessionRoom) {
+                    return prev.connectionPhase != next.connectionPhase;
+                  }
+                  return false;
+                },
+                builder: (context, state) {
+                  final phase = state is SessionRoom
+                      ? state.connectionPhase
+                      : ConnectionPhase.online;
+                  return _buildChrome(context, phase);
+                },
+              ),
               Expanded(
                 child: ListView(
                   padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
@@ -673,8 +687,42 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     );
   }
 
-  Widget _buildChrome(BuildContext context) {
+  Widget _buildChrome(BuildContext context, ConnectionPhase phase) {
     final c = FrequencyTheme.of(context).colors;
+
+    // Choose pill color and text based on connection phase
+    final Color pillBg;
+    final Color pillText;
+    final String statusText;
+    final Widget statusIcon;
+
+    switch (phase) {
+      case ConnectionPhase.reconnecting:
+        pillBg = c.warnSoft;
+        pillText = c.warn;
+        statusText = 'Reconnecting…';
+        // Spinning progress indicator for reconnecting
+        statusIcon = SizedBox(
+          width: 10,
+          height: 10,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            valueColor: AlwaysStoppedAnimation(pillText),
+          ),
+        );
+      case ConnectionPhase.lost:
+        pillBg = const Color(0xFFFFE5E5); // Light red background
+        pillText = c.danger;
+        statusText = 'Lost connection';
+        statusIcon = Icon(Icons.error_outline, size: 12, color: pillText);
+      case ConnectionPhase.online:
+      default:
+        pillBg = c.accentSoft;
+        pillText = c.accentInk;
+        statusText = 'On air';
+        statusIcon = const PulseDot(size: 6);
+    }
+
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 12, 20, 14),
       decoration: BoxDecoration(
@@ -686,24 +734,32 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 4),
             decoration: BoxDecoration(
-              color: c.accentSoft,
+              color: pillBg,
               borderRadius: BorderRadius.circular(999),
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const PulseDot(size: 6),
+                statusIcon,
                 const SizedBox(width: 6),
                 Text(
-                  'On air · ',
+                  statusText,
                   style: TextStyle(
                     fontFamily: 'Inter',
                     fontSize: 11,
-                    color: c.accentInk,
+                    color: pillText,
                     fontWeight: FontWeight.w500,
                   ),
                 ),
-                Text(widget.freq, style: kMonoStyle.copyWith(fontSize: 11, color: c.accentInk)),
+                if (phase == ConnectionPhase.online) ...[
+                  Text(' · ', style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 11,
+                    color: pillText,
+                    fontWeight: FontWeight.w500,
+                  )),
+                  Text(widget.freq, style: kMonoStyle.copyWith(fontSize: 11, color: pillText)),
+                ],
               ],
             ),
           ),

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -156,7 +156,7 @@ void main() {
       await tester.pump();
 
       // On-air pill in the chrome carries the frequency.
-      expect(find.text('On air · '), findsOneWidget);
+      expect(find.text('On air'), findsOneWidget);
       expect(find.text('104.3'), findsOneWidget);
 
       // Me-row shows the configured name without the muted suffix.


### PR DESCRIPTION
## Summary

Complete the UI integration for issue #56. The backend logic (ReconnectController, ConnectionPhase enum, cubit state management) was already implemented in PR #77, but the room screen UI was not updated to reflect the connection phase.

This PR adds the missing UI piece: a dynamic status pill in the room chrome that changes based on the guest's BLE connection health.

## Changes

- **`lib/screens/frequency_room_screen.dart`** — Wrap chrome builder in a BlocBuilder that watches `connectionPhase`. Update `_buildChrome` to accept the phase as a parameter and render different pills:
  * `online` — Green "On air · [freq]" with pulsing dot (existing behavior)
  * `reconnecting` — Yellow "Reconnecting…" with spinning progress indicator
  * `lost` — Red "Lost connection" with error icon (briefly shown before leaveRoom)
- Uses theme's `warn` / `warnSoft` colors for the reconnecting state, matching the existing design system.

## Why this completes #56

Issue #56 specified:

> UI: while `phase == reconnecting`, show a yellow "Reconnecting…" pill in the chrome instead of returning to Discovery.

All other parts were implemented in PR #77:
- ✅ ReconnectController with exponential backoff
- ✅ ConnectionPhase enum
- ✅ SessionRoom.connectionPhase field
- ✅ Cubit logic to set phase during reconnect attempts
- ❌ **UI to display the phase** ← this PR

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 243 passing (0 failures, 1 pre-existing skip)
- [x] Widget tests cover the room screen lifecycle (startVoice/stopVoice, mute toggles, PTT) — no regressions
- [ ] Manual smoke-test on real devices once merged: walk behind a wall for 3s → yellow "Reconnecting…" pill appears; come back → voice resumes and pill returns to "On air"

## Closes

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection status indicators added to the frequency room header with distinct visual styles for Online, Reconnecting, and Lost states
  * Shows a spinning indicator with "Reconnecting..." during reconnection attempts and an error icon with "Lost connection" when disconnected
  * Frequency info (and separator) is shown only when actively connected; header updates only when the connection state changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->