### PR TITLE
feat(#53): SignalReport on a 10s timer + host-side weak-signal toast

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"29c7dbb4-e0fb-453f-a21a-a7fd5804beef","pid":39072,"acquiredAt":1777386565713}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"29c7dbb4-e0fb-453f-a21a-a7fd5804beef","pid":39072,"acquiredAt":1777386565713}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Claude Code local overrides (per-developer settings, not for the team)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # IntelliJ related
 *.iml

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -189,6 +189,18 @@ class MainActivity : FlutterActivity() {
                     gattServerManager = null
                     result.success(true)
                 }
+                "getCurrentRssi" -> {
+                    // Per issue #53: returns one (peerId, rssi) entry per
+                    // peer connected over the GATT link. The full
+                    // implementation requires BluetoothGatt.readRemoteRssi,
+                    // which only the GATT *client* (issue #43) exposes —
+                    // the GATT server side cannot read remote RSSI on its
+                    // accepted connections. Until #43 lands we return an
+                    // empty list rather than fabricating values; the Dart
+                    // side already short-circuits a send when the list is
+                    // empty, so the wire stays quiet.
+                    result.success(emptyList<Map<String, Any>>())
+                }
                 "writeNotification" -> {
                     val deviceAddress = call.argument<String>("deviceAddress")
                     val bytes = call.argument<ByteArray>("bytes")

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -264,18 +264,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (_weakSignalEventsController.isClosed) return;
     final fired = _weakSignalDetector.onReport(report);
     if (fired.isEmpty) return;
+    // Build the lookup once per report rather than scanning the roster
+    // per neighbor — a single weak report could trip several at once,
+    // and the per-call cost otherwise grows as the room fills up.
+    final namesByPeerId = <String, String>{
+      for (final p in current.roster) p.peerId: p.displayName,
+    };
     for (final neighborId in fired) {
       // Don't surface a toast for our own peerId — a guest's report
       // includes its observation of every neighbor it can sample, which
       // can include the host. The host toasting itself is noise.
       if (neighborId == current.hostPeerId) continue;
-      String? displayName;
-      for (final p in current.roster) {
-        if (p.peerId == neighborId) {
-          displayName = p.displayName;
-          break;
-        }
-      }
+      final displayName = namesByPeerId[neighborId];
       if (displayName == null) continue;
       _weakSignalEventsController.add(
         (peerId: neighborId, displayName: displayName),

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -11,6 +11,8 @@ import '../services/heartbeat_scheduler.dart';
 import '../services/identity_store.dart';
 import '../services/recent_frequencies_store.dart';
 import '../services/reconnect_controller.dart';
+import '../services/signal_reporter.dart';
+import '../services/weak_signal_detector.dart';
 import 'frequency_session_state.dart';
 
 /// Owns session-level Frequency state and the side-effects that mutate it:
@@ -76,6 +78,16 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// guest: notify a host drop via [notifyDrop]).
   final HeartbeatScheduler _heartbeats;
 
+  /// Drives the protocol's `signal_report` plane. Started on room entry
+  /// **on the guest side only** (the host receives reports rather than
+  /// sending them) and stopped on leave / close.
+  final SignalReporter _signalReporter;
+
+  /// Host-side gate: keeps per-neighbor consecutive-weak counters and
+  /// rate-limits toasts for the same neighbor. Lives for the cubit
+  /// lifetime; cleared on `leaveRoom` and on per-peer drop / removal.
+  final WeakSignalDetector _weakSignalDetector;
+
   /// Re-entrancy guard for [_sendHeartbeat]. The scheduler tick is
   /// `unawaited`-launched, so a slow GATT write could otherwise overlap
   /// the next tick and let two `send()` calls interleave on the same
@@ -83,6 +95,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// (and the seq counter stays put — the dropped tick effectively
   /// merges with the in-flight one).
   bool _heartbeatSendInFlight = false;
+
+  /// Re-entrancy guard for [_sendSignalReport]. Same rationale as
+  /// [_heartbeatSendInFlight]: the reporter tick is `unawaited`-launched
+  /// and `getCurrentRssi` plus `transport.send` can stretch across the
+  /// next 10 s tick on a slow link.
+  bool _signalReportSendInFlight = false;
 
   StreamSubscription<FrequencyMessage>? _transportSubscription;
   StreamSubscription<bool>? _localTalkingSubscription;
@@ -97,6 +115,20 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// idempotent ops a duplicate apply is a no-op.
   Stream<MediaCommand> get mediaCommands => _mediaCommandsController.stream;
 
+  final _weakSignalEventsController =
+      StreamController<({String peerId, String displayName})>.broadcast();
+
+  /// Host-only stream of "neighbor X is weak" events that have already
+  /// passed the consecutive-reports threshold and the per-peer rate-limit.
+  /// The room screen subscribes and renders a toast.
+  ///
+  /// `displayName` is resolved against the current roster; when the
+  /// neighbor isn't in the roster (e.g. a stale report after `RemovePeer`)
+  /// the event is dropped before it reaches the stream rather than
+  /// surfacing a generic-sounding toast.
+  Stream<({String peerId, String displayName})> get weakSignalEvents =>
+      _weakSignalEventsController.stream;
+
   int _seq = 0;
   String? _localPeerId;
 
@@ -107,10 +139,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     AudioService? audio,
     List<Duration>? reconnectDelays,
     HeartbeatScheduler? heartbeats,
+    SignalReporter? signalReporter,
+    WeakSignalDetector? weakSignalDetector,
   })  : _transport = transport,
         _audio = audio,
         _reconnectDelays = reconnectDelays,
         _heartbeats = heartbeats ?? HeartbeatScheduler(),
+        _signalReporter = signalReporter ?? SignalReporter(),
+        _weakSignalDetector = weakSignalDetector ?? WeakSignalDetector(),
         super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
@@ -181,6 +217,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           emit(current.copyWith(roster: updated));
           _transport?.forgetPeer(m.peerId);
           _heartbeats.forgetPeer(m.peerId);
+          _weakSignalDetector.forgetPeer(m.peerId);
         }
       case RemovePeer m:
         // Host-broadcasted peer removal. Drop the named peer from the roster
@@ -192,18 +229,123 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         emit(current.copyWith(roster: updated));
         _transport?.forgetPeer(m.target);
         _heartbeats.forgetPeer(m.target);
+        _weakSignalDetector.forgetPeer(m.target);
       case Heartbeat():
         // Already noted above; no further dispatch — the heartbeat plane
         // is purely a liveness signal, not a state-changing event.
         break;
-      // These message types are handled by future issues (signal reports,
-      // voice-activity detection). Silently drop for now.
+      case SignalReport m:
+        _onSignalReport(m);
+      // These message types are handled by future issues
+      // (voice-activity detection, join request flow). Silently drop.
       case TalkingState():
       case MuteState():
       case JoinRequest():
       case JoinDenied():
-      case SignalReport():
         break;
+    }
+  }
+
+  /// Host-only ingress for `SignalReport`. Guests currently send
+  /// reports but never consume them — only the host owns the toast
+  /// surface for "X's signal is weak."
+  ///
+  /// Reports are passed to [_weakSignalDetector] which keeps the
+  /// per-neighbor consecutive-weak counter and the per-neighbor toast
+  /// rate-limit. Each tripped neighbor is resolved against the current
+  /// roster for a display name; if the neighbor isn't in the roster
+  /// (e.g. a stale report after a `RemovePeer`) the event is dropped
+  /// before it reaches [weakSignalEvents]. This keeps the room screen
+  /// from rendering toasts for ghosts.
+  void _onSignalReport(SignalReport report) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! SessionRoom || !current.roomIsHost) return;
+    if (_weakSignalEventsController.isClosed) return;
+    final fired = _weakSignalDetector.onReport(report);
+    if (fired.isEmpty) return;
+    for (final neighborId in fired) {
+      // Don't surface a toast for our own peerId — a guest's report
+      // includes its observation of every neighbor it can sample, which
+      // can include the host. The host toasting itself is noise.
+      if (neighborId == current.hostPeerId) continue;
+      String? displayName;
+      for (final p in current.roster) {
+        if (p.peerId == neighborId) {
+          displayName = p.displayName;
+          break;
+        }
+      }
+      if (displayName == null) continue;
+      _weakSignalEventsController.add(
+        (peerId: neighborId, displayName: displayName),
+      );
+    }
+  }
+
+  /// Tick callback wired into [SignalReporter.start] on the guest side.
+  /// Samples local RSSI via the audio service, builds a [SignalReport],
+  /// and writes it to the transport. No-op when no neighbors have an
+  /// RSSI to report (e.g. before the GATT client has a connection),
+  /// which keeps the wire quiet during link bring-up.
+  ///
+  /// The seq counter advances even when the report is suppressed (no
+  /// neighbors / no transport / send failure) so it stays monotonic
+  /// once the next valid report goes out — same defensive pattern as
+  /// [_sendHeartbeat].
+  Future<void> _sendSignalReport() async {
+    final t = _transport;
+    final audio = _audio;
+    if (t == null || audio == null) {
+      _seq++;
+      return;
+    }
+    if (_signalReportSendInFlight) return;
+    _signalReportSendInFlight = true;
+    try {
+      final List<({String peerId, int rssi})> samples;
+      try {
+        samples = await audio.getCurrentRssi();
+      } catch (error, stackTrace) {
+        debugPrint('Failed to sample RSSI: $error');
+        debugPrintStack(stackTrace: stackTrace);
+        _seq++;
+        return;
+      }
+      if (isClosed) return;
+      // Empty sample list — nothing to report. Do *not* advance the seq
+      // counter: an empty report is a non-event, and a future report
+      // with samples should pick up where we left off rather than
+      // skipping numbers (which the host's SequenceFilter tolerates but
+      // is wasteful on the wire).
+      if (samples.isEmpty) return;
+      final String peerId;
+      try {
+        peerId = await identityStore.getPeerId();
+      } catch (error, stackTrace) {
+        debugPrint('Failed to resolve peer id for signal report: $error');
+        debugPrintStack(stackTrace: stackTrace);
+        _seq++;
+        return;
+      }
+      if (isClosed) return;
+      final msg = SignalReport(
+        peerId: peerId,
+        seq: ++_seq,
+        atMs: DateTime.now().millisecondsSinceEpoch,
+        neighbors: [
+          for (final s in samples)
+            NeighborSignal(peerId: s.peerId, rssi: s.rssi),
+        ],
+      );
+      try {
+        await t.send(msg);
+      } catch (error, stackTrace) {
+        debugPrint('SignalReport send failed: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
+    } finally {
+      _signalReportSendInFlight = false;
     }
   }
 
@@ -289,6 +431,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       if (updated.length == current.roster.length) return;
       emit(current.copyWith(roster: updated));
       _transport?.forgetPeer(peerId);
+      _weakSignalDetector.forgetPeer(peerId);
       final t = _transport;
       if (t == null) return;
       // Best-effort RosterUpdate to remaining guests. We need a peerId
@@ -477,6 +620,16 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         onPeerLost: _onHeartbeatPeerLost,
       );
     }
+    // Begin the signal-report plane on the guest side. The host receives
+    // reports from guests and turns them into weak-signal toasts; it
+    // doesn't send reports to itself. Audio is required to sample RSSI;
+    // skipped when audio or transport is absent, same rationale as the
+    // heartbeat skip above.
+    if (!isHost && _transport != null && _audio != null) {
+      _signalReporter.start(
+        onTick: () => unawaited(_sendSignalReport()),
+      );
+    }
   }
 
   /// Drops back to Discovery and forgets the room. No-op if not in a
@@ -497,6 +650,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // empty roster (and incidentally trigger a phantom RosterUpdate if
     // a stale watermark expires post-leave).
     _heartbeats.stop();
+    // Cancel the signal reporter so a guest leaving doesn't keep pinging
+    // RSSI samples at the (now disconnected) GATT link.
+    _signalReporter.stop();
+    // Wipe per-neighbor weak-signal state so a fresh room starts with a
+    // clean detector — no stale rate-limit cooldowns, no inherited
+    // consecutive-weak counters from the previous session.
+    _weakSignalDetector.clear();
     // Wipe transport-side idempotency state for *every* peer of the
     // departing room. A re-join (same room or different) restarts the
     // protocol's seq counters at 1; held-over watermarks from this room
@@ -724,6 +884,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Stop the heartbeat timer before super.close() so a tick suspended
     // mid-microtask can't try to emit() against a closing cubit.
     _heartbeats.stop();
+    // Same rationale: stop the signal reporter before super.close() so a
+    // tick mid-await can't reach _onSignalReport or transport.send on a
+    // disposed cubit.
+    _signalReporter.stop();
     // Order matters. `super.close()` flips the cubit's `isClosed`; the
     // suspended `await` in `sendMediaCommand` resumes after it sees
     // `isClosed == true` and bails before touching the controller. If
@@ -735,5 +899,6 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     await _transportSubscription?.cancel();
     await _localTalkingSubscription?.cancel();
     await _mediaCommandsController.close();
+    await _weakSignalEventsController.close();
   }
 }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -289,10 +289,17 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// RSSI to report (e.g. before the GATT client has a connection),
   /// which keeps the wire quiet during link bring-up.
   ///
-  /// The seq counter advances even when the report is suppressed (no
-  /// neighbors / no transport / send failure) so it stays monotonic
-  /// once the next valid report goes out — same defensive pattern as
-  /// [_sendHeartbeat].
+  /// **Seq accounting.** Two distinct skip cases, with different rules:
+  ///   * Transport / audio absent, RSSI sample throws, peerId resolve
+  ///     fails — the seq counter still advances. These are failure
+  ///     paths where another producer may have already used a seq, so
+  ///     the next valid report needs the next number to stay monotonic.
+  ///     Same defensive pattern as [_sendHeartbeat].
+  ///   * Empty sample list — the seq counter does **not** advance. An
+  ///     empty report is a non-event (nothing to send), so the next
+  ///     report with samples picks up where we left off instead of
+  ///     skipping wire-level numbers the host's SequenceFilter would
+  ///     have to tolerate gaps in.
   Future<void> _sendSignalReport() async {
     final t = _transport;
     final audio = _audio;

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -92,6 +92,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   Timer? _weakSignalDemoTimer;
   StreamSubscription<MediaCommand>? _mediaSub;
   StreamSubscription<Map<String, dynamic>>? _audioEventsSub;
+  StreamSubscription<({String peerId, String displayName})>?
+      _weakSignalSub;
 
   /// Local peer's stable id, resolved once asynchronously from the
   /// identity store. Until it lands, originator-vs-remote attribution
@@ -218,6 +220,16 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
 
     _resolveMyPeerId();
     _startProgressTick();
+
+    // Subscribe to host-side weak-signal events from the cubit. Only the
+    // host emits; on guests the stream is silent so the subscription is
+    // a no-op. The cubit owns the threshold + rate-limit; the screen
+    // just renders. Subscribing here (not in didChangeDependencies)
+    // keeps the lifecycle symmetric with the other initState wiring.
+    _weakSignalSub = context
+        .read<FrequencySessionCubit>()
+        .weakSignalEvents
+        .listen(_onWeakSignal);
 
     if (widget.debugDemoTimers) {
       _startTalkSimulation();
@@ -352,8 +364,23 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     _weakSignalDemoTimer?.cancel();
     _mediaSub?.cancel();
     _audioEventsSub?.cancel();
+    _weakSignalSub?.cancel();
     unawaited(_audio.stopVoice().then((_) => _audio.stopService()));
     super.dispose();
+  }
+
+  /// Render a real "X's signal is weak" toast in response to the
+  /// cubit's host-side detector tripping. Mirrors the demo timer's
+  /// copy + tone (kept gated under [debugDemoTimers]) so design and
+  /// production match without duplicating the spec.
+  void _onWeakSignal(({String peerId, String displayName}) e) {
+    if (!mounted) return;
+    FrequencyToastHost.of(context).push(FrequencyToastSpec(
+      tone: ToastTone.warn,
+      title: "${e.displayName}'s signal is weak",
+      description: 'Ask them to move closer',
+      autoDismiss: const Duration(milliseconds: 3600),
+    ));
   }
 
   /// Open-mic mute toggle. Updates the local UI state and pushes the new

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -256,6 +256,44 @@ class AudioService {
     }
   }
 
+  /// Snapshot the current RSSI for each peer connected over the GATT
+  /// link. Returns one entry per neighbor `(peerId, rssi)`; `rssi` is in
+  /// dBm (negative values; closer to 0 is stronger). Empty list when no
+  /// peers are connected, the native side hasn't wired up
+  /// `BluetoothGatt.readRemoteRssi` yet, or the platform call throws.
+  ///
+  /// Used by [SignalReporter] on the guest side to build the protocol's
+  /// 10-second `SignalReport` envelope.
+  ///
+  /// **Note on `peerId`.** The native layer keys connections by Bluetooth
+  /// MAC, not by application-level `peerId`. The current contract is that
+  /// the native side returns the MAC as the `peerId` field; mapping MAC
+  /// back to the application `peerId` will land alongside the GATT-client
+  /// issue (#43) which records that mapping during the handshake. Until
+  /// then, the host side treats the value as opaque — its detection logic
+  /// keys on whatever string arrives and the toast-name lookup falls back
+  /// to a generic label when the MAC isn't in the roster.
+  Future<List<({String peerId, int rssi})>> getCurrentRssi() async {
+    try {
+      final result =
+          await _methodChannel.invokeMethod<List<dynamic>>('getCurrentRssi');
+      if (result == null) return const [];
+      return result
+          .map((entry) {
+            final m = entry as Map<dynamic, dynamic>;
+            final peerId = m['peerId'];
+            final rssi = m['rssi'];
+            if (peerId is! String || rssi is! int) return null;
+            return (peerId: peerId, rssi: rssi);
+          })
+          .whereType<({String peerId, int rssi})>()
+          .toList(growable: false);
+    } catch (e) {
+      debugPrint('Error getting current RSSI: $e');
+      return const [];
+    }
+  }
+
   /// Stop the GATT server.
   Future<bool> stopGattServer() async {
     try {

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -271,8 +271,9 @@ class AudioService {
   /// back to the application `peerId` will land alongside the GATT-client
   /// issue (#43) which records that mapping during the handshake. Until
   /// then, the host side treats the value as opaque — its detection logic
-  /// keys on whatever string arrives and the toast-name lookup falls back
-  /// to a generic label when the MAC isn't in the roster.
+  /// keys on whatever string arrives. Reports for `peerId`s the host
+  /// can't resolve against its current roster are dropped before
+  /// surfacing a toast (see `_onSignalReport` in `FrequencySessionCubit`).
   Future<List<({String peerId, int rssi})>> getCurrentRssi() async {
     try {
       final result =
@@ -280,9 +281,13 @@ class AudioService {
       if (result == null) return const [];
       return result
           .map((entry) {
-            final m = entry as Map<dynamic, dynamic>;
-            final peerId = m['peerId'];
-            final rssi = m['rssi'];
+            // Type-check before casting — a non-Map element from the
+            // platform side would otherwise throw, and the outer
+            // try/catch would discard the *entire* batch (including
+            // valid samples). Drop just the bad entry instead.
+            if (entry is! Map) return null;
+            final peerId = entry['peerId'];
+            final rssi = entry['rssi'];
             if (peerId is! String || rssi is! int) return null;
             return (peerId: peerId, rssi: rssi);
           })

--- a/lib/services/signal_reporter.dart
+++ b/lib/services/signal_reporter.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+/// Drives the protocol's `signal_report` plane: emits an [onTick] every
+/// [interval] so the caller can sample local RSSI and send a `SignalReport`
+/// over the wire.
+///
+/// Mirrors [HeartbeatScheduler]'s shape — the reporter is a **timer only**.
+/// The cubit owns the actual sample + send (so the seq counter, peerId
+/// resolution, and transport gating live in one place).
+///
+/// Per [docs/protocol.md] §"signal_report": [defaultInterval] is 10 s.
+///
+/// **Lifecycle.** [start] is called on the guest side when the room is
+/// entered (the host receives reports rather than sending them) and [stop]
+/// is called on leave. [start] is idempotent: calling it twice cancels the
+/// prior timer first, so callers don't need to guard against double-start.
+class SignalReporter {
+  /// Default cadence per the protocol: send a `SignalReport` every 10 s.
+  static const Duration defaultInterval = Duration(seconds: 10);
+
+  final Duration interval;
+
+  Timer? _timer;
+  void Function()? _onTick;
+
+  SignalReporter({this.interval = defaultInterval}) {
+    // Runtime check (not `assert`): the constraint must hold in release
+    // builds too. A non-positive interval makes Timer.periodic busy-loop.
+    if (interval <= Duration.zero) {
+      throw ArgumentError.value(
+        interval,
+        'interval',
+        'Must be positive — Timer.periodic(0) busy-loops.',
+      );
+    }
+  }
+
+  /// Whether the periodic timer is currently active.
+  bool get isRunning => _timer != null;
+
+  /// Starts the periodic tick. [onTick] fires every [interval] so the
+  /// caller can build + send a `SignalReport` over the transport.
+  ///
+  /// Calling [start] while already running cancels the previous timer
+  /// before installing the new one — a fresh room entry shouldn't keep
+  /// the old [onTick] callback alive.
+  void start({required void Function() onTick}) {
+    stop();
+    _onTick = onTick;
+    _timer = Timer.periodic(interval, (_) => _onTick?.call());
+  }
+
+  /// Cancels the timer. Safe to call when not running.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _onTick = null;
+  }
+}

--- a/lib/services/weak_signal_detector.dart
+++ b/lib/services/weak_signal_detector.dart
@@ -1,0 +1,98 @@
+import '../protocol/messages.dart';
+
+/// Host-side detector that consumes incoming `SignalReport`s and decides
+/// when to surface a "weak signal" toast for a specific neighbor.
+///
+/// Per the protocol: a neighbor whose RSSI stays below
+/// [weakThresholdDbm] for [consecutiveReportsToTrip] reports trips a
+/// toast. Subsequent toasts for the same neighbor are rate-limited to
+/// one per [toastRateLimit] window so a peer hovering at the edge of
+/// range doesn't spam the host's UI.
+///
+/// **Per-neighbor counting.** Counters key on the `peerId` of the
+/// neighbor inside the report (the *subject* of the RSSI), not the
+/// reporter's `peerId`. The protocol doesn't require the same reporter
+/// to confirm a weak peer twice in a row; any two consecutive reports
+/// where neighbor X is weak trip the toast.
+///
+/// **Reset on a strong report.** A neighbor whose RSSI rises back above
+/// the threshold in any report immediately clears the consecutive-weak
+/// counter for that neighbor. The rate-limit timer is independent — it
+/// only resets after the cooldown elapses, so a flapping peer can't
+/// surface a toast every two reports.
+///
+/// **Per-report independence.** A neighbor that's missing from a report
+/// (e.g. the reporter couldn't sample its RSSI this round) does *not*
+/// reset its counter. Two reports with neighbor X weak then a third
+/// report omitting X then a fourth with X weak still trips, because the
+/// gap was silence rather than a positive "X is now strong" signal.
+class WeakSignalDetector {
+  /// dBm threshold below which a neighbor is considered weak. Per the
+  /// issue spec: -80 dBm.
+  static const int weakThresholdDbm = -80;
+
+  /// Number of consecutive weak observations needed to trip a toast.
+  /// Per the issue spec: 2.
+  static const int consecutiveReportsToTrip = 2;
+
+  /// Minimum time between toasts for the same neighbor. Per the issue
+  /// spec: 60 s.
+  static const Duration toastRateLimit = Duration(seconds: 60);
+
+  /// Test seam: lets unit tests advance "now" without sleeping.
+  /// Production callers omit and get [DateTime.now].
+  final DateTime Function() _now;
+
+  final Map<String, int> _consecutiveWeak = {};
+  final Map<String, DateTime> _lastToastAt = {};
+
+  WeakSignalDetector({DateTime Function()? clock})
+      : _now = clock ?? DateTime.now;
+
+  /// Process [report] from a guest. Returns the neighbor `peerId`s that
+  /// should fire a toast on this report (after threshold + rate-limit
+  /// gates). The list is empty when nothing trips.
+  ///
+  /// State is mutated atomically per report: counters are advanced for
+  /// every weak neighbor before the rate-limit gate runs, so two weak
+  /// neighbors on the same report can both trip on the same call.
+  List<String> onReport(SignalReport report) {
+    final fired = <String>[];
+    for (final n in report.neighbors) {
+      if (n.rssi < weakThresholdDbm) {
+        final next = (_consecutiveWeak[n.peerId] ?? 0) + 1;
+        _consecutiveWeak[n.peerId] = next;
+        if (next < consecutiveReportsToTrip) continue;
+        final now = _now();
+        final last = _lastToastAt[n.peerId];
+        if (last != null && now.difference(last) < toastRateLimit) continue;
+        _lastToastAt[n.peerId] = now;
+        fired.add(n.peerId);
+      } else {
+        // Strong reading clears the consecutive counter immediately so a
+        // future dip needs another two reports to trip again. We
+        // intentionally leave the rate-limit watermark intact: a peer
+        // that just tripped 30 s ago shouldn't be eligible to retrip
+        // simply because its signal briefly recovered.
+        _consecutiveWeak.remove(n.peerId);
+      }
+    }
+    return fired;
+  }
+
+  /// Drop all detector state for [peerId]. Call when a peer leaves the
+  /// room or is removed by the host so a re-join with the same `peerId`
+  /// starts fresh — neither inheriting a stale weak-counter nor blocked
+  /// by a leftover rate-limit watermark.
+  void forgetPeer(String peerId) {
+    _consecutiveWeak.remove(peerId);
+    _lastToastAt.remove(peerId);
+  }
+
+  /// Drop all detector state for every neighbor. Call on `leaveRoom` so
+  /// the next session starts with a clean slate.
+  void clear() {
+    _consecutiveWeak.clear();
+    _lastToastAt.clear();
+  }
+}

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -13,6 +13,8 @@ import 'package:walkie_talkie/services/ble_control_transport.dart';
 import 'package:walkie_talkie/services/heartbeat_scheduler.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
+import 'package:walkie_talkie/services/signal_reporter.dart';
+import 'package:walkie_talkie/services/weak_signal_detector.dart';
 
 class _FakeStore implements IdentityStore {
   String? _name;
@@ -100,6 +102,8 @@ FrequencySessionCubit _makeCubit({
   List<Duration>? reconnectDelays,
   HeartbeatScheduler? heartbeats,
   BleControlTransport? transport,
+  SignalReporter? signalReporter,
+  WeakSignalDetector? weakSignalDetector,
 }) =>
     FrequencySessionCubit(
       identityStore: identityStore ?? _FakeStore(),
@@ -109,6 +113,8 @@ FrequencySessionCubit _makeCubit({
       reconnectDelays: reconnectDelays,
       heartbeats: heartbeats,
       transport: transport,
+      signalReporter: signalReporter,
+      weakSignalDetector: weakSignalDetector,
     );
 
 void main() {
@@ -1626,6 +1632,458 @@ void main() {
       // activity refreshes the watermark) and then forgetPeer(p-guest). The
       // net effect on the table is "removed".
       expect(scheduler.lastSeen, isNot(contains('p-guest')));
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+  });
+
+  // ── SignalReport / weak-signal ────────────────────────────────────────
+
+  group('SignalReport', () {
+    setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+    /// Same harness shape as the Heartbeats group's `makeTestTransport`,
+    /// duplicated here to keep the two groups independently movable.
+    ({
+      BleControlTransport transport,
+      List<Uint8List> outbox,
+      StreamController<({String endpointId, Uint8List bytes})> inbox,
+    }) makeTestTransport() {
+      final outbox = <Uint8List>[];
+      final inbox =
+          StreamController<({String endpointId, Uint8List bytes})>.broadcast();
+      final transport = BleControlTransport.forTest(
+        controlBytes: inbox.stream,
+        writeBytes: (bytes) async {
+          outbox.add(bytes);
+        },
+      );
+      return (transport: transport, outbox: outbox, inbox: inbox);
+    }
+
+    /// Audio service backed by the test message channel — getCurrentRssi
+    /// returns whatever's in [rssi] at the time of the call. Mutating the
+    /// list between cubit ticks lets a test simulate signal changes.
+    AudioService makeRssiAudio(List<({String peerId, int rssi})> rssi) {
+      final audio = AudioService();
+      const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getCurrentRssi') {
+          return rssi
+              .map((r) => {'peerId': r.peerId, 'rssi': r.rssi})
+              .toList();
+        }
+        return null;
+      });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+      return audio;
+    }
+
+    test(
+      'guest joinRoom with audio + transport starts the SignalReporter; '
+      'leaveRoom stops it',
+      () async {
+        final t = makeTestTransport();
+        final reporter =
+            SignalReporter(interval: const Duration(hours: 1));
+        final cubit = _makeCubit(
+          transport: t.transport,
+          audio: makeRssiAudio(const []),
+          signalReporter: reporter,
+          // Reuse a long-interval scheduler so the heartbeat plane
+          // doesn't fight the test for the foreground.
+          heartbeats: HeartbeatScheduler(
+            pingInterval: const Duration(hours: 1),
+          ),
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        expect(reporter.isRunning, isFalse);
+        await cubit.joinRoom(
+          freq: '104.3',
+          isHost: false,
+          macAddress: 'AA:BB',
+        );
+        expect(reporter.isRunning, isTrue);
+
+        await cubit.leaveRoom();
+        expect(reporter.isRunning, isFalse);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'host joinRoom does NOT start the SignalReporter (host receives only)',
+      () async {
+        final t = makeTestTransport();
+        final reporter =
+            SignalReporter(interval: const Duration(hours: 1));
+        final cubit = _makeCubit(
+          transport: t.transport,
+          audio: makeRssiAudio(const []),
+          signalReporter: reporter,
+          heartbeats: HeartbeatScheduler(
+            pingInterval: const Duration(hours: 1),
+          ),
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+
+        expect(reporter.isRunning, isFalse,
+            reason: 'host receives reports rather than sending them');
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test('guest joinRoom without audio does NOT start the SignalReporter',
+        () async {
+      // Without audio there's no RSSI source to sample; starting the
+      // reporter would just emit empty `SignalReport`s every 10s.
+      final t = makeTestTransport();
+      final reporter =
+          SignalReporter(interval: const Duration(hours: 1));
+      final cubit = _makeCubit(
+        transport: t.transport,
+        signalReporter: reporter,
+        heartbeats: HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        ),
+      );
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      await cubit.joinRoom(
+        freq: '104.3',
+        isHost: false,
+        macAddress: 'AA:BB',
+      );
+
+      expect(reporter.isRunning, isFalse);
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test('cubit.close() stops the SignalReporter', () async {
+      final t = makeTestTransport();
+      final reporter =
+          SignalReporter(interval: const Duration(hours: 1));
+      final cubit = _makeCubit(
+        transport: t.transport,
+        audio: makeRssiAudio(const []),
+        signalReporter: reporter,
+        heartbeats: HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        ),
+      );
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      await cubit.joinRoom(
+        freq: '104.3',
+        isHost: false,
+        macAddress: 'AA:BB',
+      );
+      expect(reporter.isRunning, isTrue);
+
+      await cubit.close();
+      expect(reporter.isRunning, isFalse);
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test(
+      'host with two consecutive weak inbound reports emits weakSignalEvents',
+      () async {
+        final t = makeTestTransport();
+        final cubit = _makeCubit(
+          transport: t.transport,
+          heartbeats: HeartbeatScheduler(
+            pingInterval: const Duration(hours: 1),
+          ),
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        // Host's roster needs the neighbor's peerId so the cubit can
+        // resolve a display name for the toast.
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [
+            ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ProtocolPeer(peerId: 'p-target', displayName: 'Maya'),
+          ],
+        ));
+
+        final fired = <({String peerId, String displayName})>[];
+        final sub = cubit.weakSignalEvents.listen(fired.add);
+        addTearDown(sub.cancel);
+
+        // Helper: serialize and feed a SignalReport into the inbox.
+        Future<void> feedReport(int seq, int rssi) async {
+          final json = SignalReport(
+            peerId: 'p-guest',
+            seq: seq,
+            atMs: seq * 1000,
+            neighbors: [NeighborSignal(peerId: 'p-target', rssi: rssi)],
+          ).encode();
+          for (final frag in encodeFragments(json)) {
+            t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+          }
+          await Future<void>.delayed(Duration.zero);
+        }
+
+        await feedReport(1, -85);
+        // One weak report — under the threshold gate, no toast yet.
+        expect(fired, isEmpty);
+
+        await feedReport(2, -90);
+        // Second consecutive weak — trips. Display name resolved from
+        // the roster, not the wire.
+        expect(fired, hasLength(1));
+        expect(fired.first.peerId, 'p-target');
+        expect(fired.first.displayName, 'Maya');
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test('host suppresses toast for a neighbor that is not in the roster',
+        () async {
+      // Stale or off-roster neighbor reports should be a silent drop, not
+      // a toast with a generic name. The host's roster is the source of
+      // truth for who's actually in the room.
+      final t = makeTestTransport();
+      final cubit = _makeCubit(
+        transport: t.transport,
+        heartbeats: HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        ),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [ProtocolPeer(peerId: 'p-host', displayName: 'Devon')],
+      ));
+
+      final fired = <({String peerId, String displayName})>[];
+      final sub = cubit.weakSignalEvents.listen(fired.add);
+      addTearDown(sub.cancel);
+
+      Future<void> feedReport(int seq) async {
+        final json = SignalReport(
+          peerId: 'p-guest',
+          seq: seq,
+          atMs: seq * 1000,
+          neighbors: [
+            const NeighborSignal(peerId: 'p-ghost', rssi: -90),
+          ],
+        ).encode();
+        for (final frag in encodeFragments(json)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      await feedReport(1);
+      await feedReport(2);
+      expect(fired, isEmpty,
+          reason: 'p-ghost is not in the roster — drop the event');
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test('host ignores inbound SignalReports when local role is guest',
+        () async {
+      // The host-only role check guards against a misbehaving / forged
+      // report from another guest leaking into the local UI on a guest
+      // device. Only the host owns the toast surface.
+      final t = makeTestTransport();
+      final cubit = _makeCubit(
+        transport: t.transport,
+        heartbeats: HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        ),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      await cubit.joinRoom(
+        freq: '104.3',
+        isHost: false,
+        macAddress: 'AA:BB',
+      );
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [
+          ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+          ProtocolPeer(peerId: 'p-target', displayName: 'Sam'),
+        ],
+      ));
+
+      final fired = <({String peerId, String displayName})>[];
+      final sub = cubit.weakSignalEvents.listen(fired.add);
+      addTearDown(sub.cancel);
+
+      Future<void> feedReport(int seq) async {
+        final json = SignalReport(
+          peerId: 'p-other-guest',
+          seq: seq,
+          atMs: seq * 1000,
+          neighbors: const [NeighborSignal(peerId: 'p-target', rssi: -90)],
+        ).encode();
+        for (final frag in encodeFragments(json)) {
+          t.inbox.add((endpointId: 'BB:CC', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      await feedReport(1);
+      await feedReport(2);
+      expect(fired, isEmpty);
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test('weakSignalDetector is cleared on leaveRoom', () async {
+      // Pre-trip a counter, leave, re-join — the detector must start
+      // fresh, not inherit the prior session's "one weak report" toward
+      // the next trip.
+      final t = makeTestTransport();
+      final cubit = _makeCubit(
+        transport: t.transport,
+        heartbeats: HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        ),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [
+          ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+          ProtocolPeer(peerId: 'p-target', displayName: 'Maya'),
+        ],
+      ));
+
+      final fired = <({String peerId, String displayName})>[];
+      final sub = cubit.weakSignalEvents.listen(fired.add);
+      addTearDown(sub.cancel);
+
+      // First report — starts a counter for p-target.
+      for (final frag in encodeFragments(const SignalReport(
+        peerId: 'p-guest',
+        seq: 1,
+        atMs: 1000,
+        neighbors: [NeighborSignal(peerId: 'p-target', rssi: -90)],
+      ).encode())) {
+        t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      // Leave + rejoin — counter should be wiped on leave.
+      await cubit.leaveRoom();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [
+          ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+          ProtocolPeer(peerId: 'p-target', displayName: 'Maya'),
+        ],
+      ));
+
+      // One weak report in the new session — must NOT trip if the
+      // detector was cleared on leave. (If state leaked, this would be
+      // the second weak in a row and would fire.)
+      for (final frag in encodeFragments(const SignalReport(
+        peerId: 'p-guest',
+        seq: 1,
+        atMs: 1000,
+        neighbors: [NeighborSignal(peerId: 'p-target', rssi: -90)],
+      ).encode())) {
+        t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      expect(fired, isEmpty);
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test('host self-toast is suppressed for the local hostPeerId', () async {
+      // A guest's report can include the host as a neighbor (the host's
+      // adverts/notifications are visible to the guest, so the GATT
+      // client samples its RSSI). The host shouldn't toast itself.
+      final t = makeTestTransport();
+      final cubit = _makeCubit(
+        transport: t.transport,
+        heartbeats: HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        ),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [ProtocolPeer(peerId: 'p-host', displayName: 'Devon')],
+      ));
+
+      final fired = <({String peerId, String displayName})>[];
+      final sub = cubit.weakSignalEvents.listen(fired.add);
+      addTearDown(sub.cancel);
+
+      for (var seq = 1; seq <= 2; seq++) {
+        for (final frag in encodeFragments(SignalReport(
+          peerId: 'p-guest',
+          seq: seq,
+          atMs: seq * 1000,
+          neighbors: const [NeighborSignal(peerId: 'p-host', rssi: -95)],
+        ).encode())) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(fired, isEmpty,
+          reason: 'host should not surface a toast for itself');
 
       await cubit.close();
       await t.inbox.close();

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -48,6 +48,11 @@ Widget _wrap(Widget child, {FrequencySessionCubit? cubit}) {
     
     final controller = StreamController<MediaCommand>.broadcast();
     when(() => mockCubit.mediaCommands).thenAnswer((_) => controller.stream);
+
+    final weakSignalController =
+        StreamController<({String peerId, String displayName})>.broadcast();
+    when(() => mockCubit.weakSignalEvents)
+        .thenAnswer((_) => weakSignalController.stream);
     
     when(() => mockCubit.sendMediaCommand(
           op: any(named: 'op'),

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -368,6 +368,37 @@ void main() {
           null,
         );
       });
+
+      test('preserves valid entries when one element is not a Map',
+          () async {
+        // A non-Map element (a malformed native packet) used to throw
+        // inside the .map() block and the outer catch would discard the
+        // entire batch. Now we type-check + drop just the bad entry, so
+        // valid samples in the same batch survive.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          (MethodCall call) async {
+            if (call.method != 'getCurrentRssi') return null;
+            return [
+              {'peerId': 'good', 'rssi': -70},
+              'not-a-map', // bare string would have crashed the cast
+              42, // bare int, same
+              {'peerId': 'also-good', 'rssi': -75},
+            ];
+          },
+        );
+
+        final result = await audioService.getCurrentRssi();
+        expect(result, hasLength(2));
+        expect(result.map((r) => r.peerId), ['good', 'also-good']);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          null,
+        );
+      });
     });
 
     group('L2CAP voice transport', () {

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -270,6 +270,106 @@ void main() {
       });
     });
 
+    group('getCurrentRssi', () {
+      test('returns parsed (peerId, rssi) entries from native', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          (MethodCall call) async {
+            if (call.method != 'getCurrentRssi') return null;
+            return [
+              {'peerId': 'AA:BB:CC:DD:EE:FF', 'rssi': -65},
+              {'peerId': '11:22:33:44:55:66', 'rssi': -85},
+            ];
+          },
+        );
+
+        final result = await audioService.getCurrentRssi();
+        expect(result, hasLength(2));
+        expect(result[0].peerId, 'AA:BB:CC:DD:EE:FF');
+        expect(result[0].rssi, -65);
+        expect(result[1].peerId, '11:22:33:44:55:66');
+        expect(result[1].rssi, -85);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          null,
+        );
+      });
+
+      test('returns empty list when native returns null', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          (MethodCall call) async {
+            if (call.method != 'getCurrentRssi') return null;
+            return null;
+          },
+        );
+
+        expect(await audioService.getCurrentRssi(), isEmpty);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          null,
+        );
+      });
+
+      test('returns empty list when native throws', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          (MethodCall call) async {
+            if (call.method != 'getCurrentRssi') return null;
+            throw PlatformException(code: 'ERR');
+          },
+        );
+
+        expect(await audioService.getCurrentRssi(), isEmpty);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          null,
+        );
+      });
+
+      test('skips malformed entries with missing or wrong-typed fields',
+          () async {
+        // Malformed events would otherwise crash the call site or
+        // surface NaN/0 RSSI readings to the cubit. The Dart side keeps
+        // the contract tight so a bad native packet is a drop, not a
+        // failure.
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          (MethodCall call) async {
+            if (call.method != 'getCurrentRssi') return null;
+            return [
+              {'peerId': 'good', 'rssi': -70},
+              {'peerId': 'no-rssi'}, // missing rssi
+              {'rssi': -50}, // missing peerId
+              {'peerId': 'wrong-type', 'rssi': '-50'}, // rssi is string
+              {'peerId': 42, 'rssi': -50}, // peerId is int
+            ];
+          },
+        );
+
+        final result = await audioService.getCurrentRssi();
+        expect(result, hasLength(1));
+        expect(result.first.peerId, 'good');
+        expect(result.first.rssi, -70);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.elodin.walkie_talkie/audio'),
+          null,
+        );
+      });
+    });
+
     group('L2CAP voice transport', () {
     test('startVoiceServer returns PSM from native layer', () async {
       log.clear();

--- a/test/services/signal_reporter_test.dart
+++ b/test/services/signal_reporter_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/signal_reporter.dart';
+
+void main() {
+  group('SignalReporter defaults', () {
+    test('default interval matches the protocol: 10 s', () {
+      // Load-bearing constant — bumping it changes how quickly a host
+      // notices a degraded peer. Pinning here so a casual edit triggers
+      // a test failure and forces the protocol doc to be re-read.
+      expect(SignalReporter.defaultInterval, const Duration(seconds: 10));
+    });
+
+    test('rejects a non-positive interval', () {
+      // Runtime check (not assert) so the contract holds in release.
+      expect(
+        () => SignalReporter(interval: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => SignalReporter(interval: const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('SignalReporter.start / stop', () {
+    test('start fires onTick periodically, stop cancels the timer',
+        () async {
+      final reporter =
+          SignalReporter(interval: const Duration(milliseconds: 10));
+
+      var ticks = 0;
+      reporter.start(onTick: () => ticks++);
+
+      // Wait long enough to observe ≥ 2 ticks but bound the upper end
+      // so the test isn't sensitive to millisecond-level timer accuracy.
+      await Future<void>.delayed(const Duration(milliseconds: 35));
+      expect(ticks, greaterThanOrEqualTo(2));
+
+      reporter.stop();
+      final ticksAtStop = ticks;
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(ticks, ticksAtStop, reason: 'no further ticks after stop');
+    });
+
+    test('isRunning toggles on start / stop', () {
+      final reporter = SignalReporter(
+        interval: const Duration(seconds: 1),
+      );
+      expect(reporter.isRunning, isFalse);
+      reporter.start(onTick: () {});
+      expect(reporter.isRunning, isTrue);
+      reporter.stop();
+      expect(reporter.isRunning, isFalse);
+    });
+
+    test('start while running cancels the previous timer + callback',
+        () async {
+      final reporter =
+          SignalReporter(interval: const Duration(milliseconds: 10));
+
+      var ticks1 = 0;
+      reporter.start(onTick: () => ticks1++);
+
+      // Re-start with a fresh callback. The first counter must stop
+      // incrementing after the swap.
+      var ticks2 = 0;
+      reporter.start(onTick: () => ticks2++);
+
+      await Future<void>.delayed(const Duration(milliseconds: 35));
+      final ticks1AtSwap = ticks1;
+      reporter.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      // ticks1's timer was cancelled at swap — no further increments.
+      expect(ticks1, ticks1AtSwap);
+      expect(ticks2, greaterThan(0));
+    });
+
+    test('stop is safe when never started', () {
+      final reporter = SignalReporter();
+      expect(reporter.stop, returnsNormally);
+    });
+
+    test('stop is idempotent', () {
+      final reporter = SignalReporter(
+        interval: const Duration(seconds: 1),
+      );
+      reporter.start(onTick: () {});
+      reporter.stop();
+      expect(reporter.stop, returnsNormally);
+    });
+  });
+}

--- a/test/services/weak_signal_detector_test.dart
+++ b/test/services/weak_signal_detector_test.dart
@@ -1,0 +1,292 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/protocol/messages.dart';
+import 'package:walkie_talkie/services/weak_signal_detector.dart';
+
+SignalReport _report({
+  required String reporter,
+  required int seq,
+  int atMs = 0,
+  required List<NeighborSignal> neighbors,
+}) =>
+    SignalReport(
+      peerId: reporter,
+      seq: seq,
+      atMs: atMs,
+      neighbors: neighbors,
+    );
+
+NeighborSignal _n(String peerId, int rssi) =>
+    NeighborSignal(peerId: peerId, rssi: rssi);
+
+void main() {
+  group('WeakSignalDetector constants', () {
+    test('match the protocol: -80 dBm, 2 reports, 60 s rate-limit', () {
+      // These constants are load-bearing. They're the only thing that
+      // maps the spec's "weak signal" to a number; bumping any of them
+      // changes the user-visible cadence of weak-signal toasts.
+      expect(WeakSignalDetector.weakThresholdDbm, -80);
+      expect(WeakSignalDetector.consecutiveReportsToTrip, 2);
+      expect(WeakSignalDetector.toastRateLimit, const Duration(seconds: 60));
+    });
+  });
+
+  group('WeakSignalDetector.onReport — threshold gate', () {
+    test('one weak report does not trip', () {
+      final d = WeakSignalDetector();
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 1,
+        neighbors: [_n('peer-a', -85)],
+      ));
+      expect(fired, isEmpty);
+    });
+
+    test('two consecutive weak reports trip', () {
+      final d = WeakSignalDetector();
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 2,
+        neighbors: [_n('a', -90)],
+      ));
+      expect(fired, ['a']);
+    });
+
+    test('boundary: -80 is NOT weak (strict less-than)', () {
+      // The spec says "RSSI < -80 dBm" — the boundary value -80 itself
+      // is treated as adequate, not weak. Pinning the test against this
+      // guards against a "≤" off-by-one slipping in.
+      final d = WeakSignalDetector();
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -80)]));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 2,
+        neighbors: [_n('a', -80)],
+      ));
+      expect(fired, isEmpty);
+    });
+
+    test('boundary: -81 IS weak', () {
+      final d = WeakSignalDetector();
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -81)]));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 2,
+        neighbors: [_n('a', -81)],
+      ));
+      expect(fired, ['a']);
+    });
+
+    test('a strong report between two weak reports resets the counter', () {
+      final d = WeakSignalDetector();
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      d.onReport(_report(reporter: 'g1', seq: 2, neighbors: [_n('a', -50)]));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 3,
+        neighbors: [_n('a', -85)],
+      ));
+      // Counter reset on the strong reading; only one weak in a row again.
+      expect(fired, isEmpty);
+    });
+
+    test('absent neighbor does NOT reset the counter', () {
+      // A reporter that didn't see neighbor X this round is silence,
+      // not a positive "X is fine now" signal. The next weak report
+      // for X should still trip if the prior one was weak.
+      final d = WeakSignalDetector();
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      d.onReport(_report(reporter: 'g1', seq: 2, neighbors: const []));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 3,
+        neighbors: [_n('a', -85)],
+      ));
+      expect(fired, ['a']);
+    });
+
+    test('per-neighbor independence on the same report', () {
+      final d = WeakSignalDetector();
+      d.onReport(_report(
+        reporter: 'g1',
+        seq: 1,
+        neighbors: [_n('a', -85), _n('b', -85)],
+      ));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 2,
+        neighbors: [_n('a', -85), _n('b', -85)],
+      ));
+      expect(fired, unorderedEquals(['a', 'b']));
+    });
+
+    test('per-neighbor independence: one trips, one stays strong', () {
+      final d = WeakSignalDetector();
+      d.onReport(_report(
+        reporter: 'g1',
+        seq: 1,
+        neighbors: [_n('a', -85), _n('b', -50)],
+      ));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 2,
+        neighbors: [_n('a', -85), _n('b', -50)],
+      ));
+      expect(fired, ['a']);
+    });
+  });
+
+  group('WeakSignalDetector.onReport — rate-limit gate', () {
+    test('second trip within 60 s is suppressed', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final d = WeakSignalDetector(clock: () => fakeNow);
+
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      var fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 2,
+        neighbors: [_n('a', -85)],
+      ));
+      expect(fired, ['a']);
+
+      fakeNow = fakeNow.add(const Duration(seconds: 30));
+      // Two more weak reports — would trip again if not for the rate-limit.
+      d.onReport(_report(reporter: 'g1', seq: 3, neighbors: [_n('a', -85)]));
+      fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 4,
+        neighbors: [_n('a', -85)],
+      ));
+      expect(fired, isEmpty,
+          reason: '30 s < 60 s rate-limit window');
+    });
+
+    test('trip again after 60 s elapses', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final d = WeakSignalDetector(clock: () => fakeNow);
+
+      // First trip at T0.
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      d.onReport(_report(reporter: 'g1', seq: 2, neighbors: [_n('a', -85)]));
+
+      // Counter is now ≥ 2, so any further weak report would trip *if*
+      // the rate-limit allows it. Advance to exactly the rate-limit
+      // boundary: a single report at T0 + 60s should fire because the
+      // gate is `<` (strict), so 60s ≥ 60s passes.
+      fakeNow = fakeNow.add(const Duration(seconds: 60));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 3,
+        neighbors: [_n('a', -85)],
+      ));
+      expect(fired, ['a'],
+          reason: '60 s ≥ 60 s rate-limit window (inclusive)');
+    });
+
+    test('within 30 s after a trip, further weak reports are suppressed', () {
+      // Companion to the boundary test: explicitly verifies the strict-`<`
+      // path on the inside of the window. Two consecutive trips spanning
+      // the cooldown should produce one fire, not three.
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final d = WeakSignalDetector(clock: () => fakeNow);
+
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      var fired =
+          d.onReport(_report(reporter: 'g1', seq: 2, neighbors: [_n('a', -85)]));
+      expect(fired, ['a']);
+
+      fakeNow = fakeNow.add(const Duration(seconds: 30));
+      fired =
+          d.onReport(_report(reporter: 'g1', seq: 3, neighbors: [_n('a', -85)]));
+      expect(fired, isEmpty);
+
+      fakeNow = fakeNow.add(const Duration(seconds: 29));
+      fired =
+          d.onReport(_report(reporter: 'g1', seq: 4, neighbors: [_n('a', -85)]));
+      expect(fired, isEmpty,
+          reason: 'still inside the 60 s window (59 s elapsed)');
+    });
+
+    test('rate-limit is per-neighbor', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final d = WeakSignalDetector(clock: () => fakeNow);
+
+      // Trip 'a' first.
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      d.onReport(_report(reporter: 'g1', seq: 2, neighbors: [_n('a', -85)]));
+
+      // 'b' starts weak shortly after — its rate-limit watermark is
+      // independent and should trip on its own two consecutive reports
+      // even though 'a' is still inside its 60 s window.
+      fakeNow = fakeNow.add(const Duration(seconds: 5));
+      d.onReport(_report(reporter: 'g1', seq: 3, neighbors: [_n('b', -85)]));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 4,
+        neighbors: [_n('b', -85)],
+      ));
+      expect(fired, ['b']);
+    });
+  });
+
+  group('WeakSignalDetector.forgetPeer / clear', () {
+    test('forgetPeer wipes the consecutive counter', () {
+      final d = WeakSignalDetector();
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      d.forgetPeer('a');
+      // Without forget, the next weak would trip. After forget, we need
+      // two more consecutive weak reports.
+      var fired =
+          d.onReport(_report(reporter: 'g1', seq: 2, neighbors: [_n('a', -85)]));
+      expect(fired, isEmpty);
+      fired =
+          d.onReport(_report(reporter: 'g1', seq: 3, neighbors: [_n('a', -85)]));
+      expect(fired, ['a']);
+    });
+
+    test('forgetPeer clears the rate-limit watermark', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final d = WeakSignalDetector(clock: () => fakeNow);
+      d.onReport(_report(reporter: 'g1', seq: 1, neighbors: [_n('a', -85)]));
+      d.onReport(_report(reporter: 'g1', seq: 2, neighbors: [_n('a', -85)]));
+      // 'a' is now under its 60s rate-limit. Forget + re-trip should
+      // succeed immediately rather than waiting out the cooldown.
+      d.forgetPeer('a');
+      d.onReport(_report(reporter: 'g1', seq: 3, neighbors: [_n('a', -85)]));
+      final fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 4,
+        neighbors: [_n('a', -85)],
+      ));
+      expect(fired, ['a']);
+    });
+
+    test('clear wipes every neighbor', () {
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final d = WeakSignalDetector(clock: () => fakeNow);
+      d.onReport(_report(
+        reporter: 'g1',
+        seq: 1,
+        neighbors: [_n('a', -85), _n('b', -85)],
+      ));
+      d.onReport(_report(
+        reporter: 'g1',
+        seq: 2,
+        neighbors: [_n('a', -85), _n('b', -85)],
+      ));
+      d.clear();
+      var fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 3,
+        neighbors: [_n('a', -85), _n('b', -85)],
+      ));
+      expect(fired, isEmpty, reason: 'counters reset by clear');
+      fired = d.onReport(_report(
+        reporter: 'g1',
+        seq: 4,
+        neighbors: [_n('a', -85), _n('b', -85)],
+      ));
+      expect(fired, unorderedEquals(['a', 'b']));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- New `SignalReporter` (10s tick) + `WeakSignalDetector` (host-side -80 dBm / 2-consecutive / 60s rate-limit) wired through `FrequencySessionCubit`. Guests send reports; the host turns them into a real "X's signal is weak" toast on the room screen.
- `AudioService.getCurrentRssi()` MethodChannel landed; native side returns `[]` for now (full `BluetoothGatt.readRemoteRssi` wiring belongs with the GATT-client issue #43, since that's where the API exists). Dart layer short-circuits an empty sample list, so the wire stays quiet until the native side lights up.
- Demo timer in `frequency_room_screen.dart` is already gated under `debugDemoTimers` (#40); production now drives the toast off the cubit's `weakSignalEvents` stream instead.

## Detector spec (mirrors the issue)
- Threshold: `rssi < -80 dBm` (strict `<`, so -80 is *not* weak).
- Trip after 2 consecutive weak observations of the same neighbor `peerId`.
- Strong report resets the consecutive counter immediately; absent neighbors do **not** (silence ≠ "now strong").
- 60 s rate-limit per neighbor; second trip suppressed inside the window.
- Self-toast suppression: a guest's report can include the host as a neighbor — the host won't toast itself.
- Host-only ingress: guests drop inbound `SignalReport`s.
- `forgetPeer` wired through `Leave` / `RemovePeer` / heartbeat-lost paths; `clear` runs on `leaveRoom`.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 317 passed, 1 skipped (pre-existing skip), 0 failed
- [x] Threshold + rate-limit boundaries (incl. inclusive 60 s edge) covered in `weak_signal_detector_test.dart`
- [x] `SignalReporter` lifecycle (start/stop/idempotency/reject-non-positive-interval) covered
- [x] `AudioService.getCurrentRssi` parses native list, drops malformed entries, returns `[]` on null/throw
- [x] Cubit: guest joinRoom starts the reporter; host does not; close stops it; host with two consecutive weak reports emits on `weakSignalEvents`; ghost-neighbor / guest-role / self-toast all suppressed; detector cleared on leaveRoom
- [ ] Manual two-device verification deferred to issue #43 landing (no native RSSI source until then)

Closes #53.