### PR TITLE
feat(#57): Permission revocation handling — graceful teardown + denied screen

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -9,6 +9,7 @@ import '../services/audio_service.dart';
 import '../services/ble_control_transport.dart';
 import '../services/heartbeat_scheduler.dart';
 import '../services/identity_store.dart';
+import '../services/permission_watcher.dart';
 import '../services/recent_frequencies_store.dart';
 import '../services/reconnect_controller.dart';
 import '../services/signal_reporter.dart';
@@ -68,6 +69,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// [ConnectionPhase] was last emitted.
   final AudioService? _audio;
 
+  /// Optional permission watcher. When provided, the cubit subscribes during
+  /// [bootstrap] and transitions to [SessionPermissionDenied] whenever the
+  /// watcher reports a non-empty missing-permissions list — covering the
+  /// case where the user revokes mic / Bluetooth from system Settings while
+  /// the app is running. Null in tests / loopback builds that don't exercise
+  /// the permission surface.
+  final PermissionWatcher? _permissionWatcher;
+
   /// Delay schedule injected into [ReconnectController]. Defaults to the
   /// production schedule; tests pass short delays to avoid slow test runs.
   final List<Duration>? _reconnectDelays;
@@ -104,6 +113,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
 
   StreamSubscription<FrequencyMessage>? _transportSubscription;
   StreamSubscription<bool>? _localTalkingSubscription;
+  StreamSubscription<List<AppPermission>>? _permissionSubscription;
   ReconnectController? _reconnectController;
 
   final _mediaCommandsController = StreamController<MediaCommand>.broadcast();
@@ -137,12 +147,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     required this.recentFrequenciesStore,
     BleControlTransport? transport,
     AudioService? audio,
+    PermissionWatcher? permissionWatcher,
     List<Duration>? reconnectDelays,
     HeartbeatScheduler? heartbeats,
     SignalReporter? signalReporter,
     WeakSignalDetector? weakSignalDetector,
   })  : _transport = transport,
         _audio = audio,
+        _permissionWatcher = permissionWatcher,
         _reconnectDelays = reconnectDelays,
         _heartbeats = heartbeats ?? HeartbeatScheduler(),
         _signalReporter = signalReporter ?? SignalReporter(),
@@ -160,6 +172,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Future<void> bootstrap() async {
     _transportSubscription = _transport?.incoming.listen(_onTransportMessage);
     _localTalkingSubscription = _audio?.localTalking.listen(_onLocalTalking);
+    // Subscribe to runtime permission changes so a mid-session revoke
+    // (user toggling mic / Bluetooth in system Settings) tears down voice +
+    // BLE cleanly and the UI shows an explanatory screen instead of
+    // crashing on the next AudioRecord / GATT call. The watcher emits an
+    // initial snapshot on subscription, so a fresh launch with already-
+    // revoked perms is handled too.
+    _permissionSubscription =
+        _permissionWatcher?.watch().listen(_onPermissionsChanged);
 
     // Cache peerId to avoid async resolution in hot path (voice activity)
     try {
@@ -563,6 +583,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         emit(room.copyWith(myName: name));
       case SessionBooting():
       case SessionOnboarding():
+      case SessionPermissionDenied():
         break;
     }
   }
@@ -676,6 +697,126 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       myName: current.myName,
       recentHostedFrequencies: recent,
     ));
+  }
+
+  /// Reacts to a [PermissionWatcher] emission. Three cases:
+  ///
+  ///   * **Missing → empty**: the user re-granted everything (typically by
+  ///     coming back from Settings). If we're sitting in
+  ///     [SessionPermissionDenied], transition back to [SessionDiscovery]
+  ///     (or [SessionOnboarding] for a fresh install). Otherwise leave the
+  ///     state alone — the user might be mid-onboarding and the watcher's
+  ///     resume sample is just confirming what onboarding already knows.
+  ///
+  ///   * **Empty → missing**: the user revoked while the app was running.
+  ///     Tear down voice + BLE so the next OS callback can't fault on a
+  ///     missing permission, then emit [SessionPermissionDenied] carrying
+  ///     the displayName so recovery can route back to Discovery without
+  ///     re-reading the identity store.
+  ///
+  ///   * **Missing → different missing**: e.g. the user re-granted mic but
+  ///     left bluetooth off. Just refresh the missing list so the screen
+  ///     shows the current state.
+  ///
+  /// Onboarding is left untouched — that screen owns its own permission
+  /// flow and would fight a state transition mid-grant. Once onboarding
+  /// completes the cubit lands on Discovery, where the watcher's next
+  /// emission can take over.
+  void _onPermissionsChanged(List<AppPermission> missing) {
+    if (isClosed) return;
+    final current = state;
+    if (missing.isEmpty) {
+      // Recovered — only meaningful when we're already showing the denied
+      // screen. From any other stage, an "all granted" event is a no-op.
+      if (current is SessionPermissionDenied) {
+        unawaited(_recoverFromPermissionDenied(current));
+      }
+      return;
+    }
+    // Onboarding owns its own permission flow; don't yank the user out
+    // mid-grant. Booting is a transient pre-bootstrap blip — let bootstrap
+    // finish and the next watcher tick will catch it.
+    if (current is SessionOnboarding || current is SessionBooting) {
+      return;
+    }
+    // Already showing the denied screen — just refresh the missing list
+    // (e.g. mic was re-granted but bluetooth still off).
+    if (current is SessionPermissionDenied) {
+      emit(SessionPermissionDenied(
+        missing: missing,
+        myName: current.myName,
+      ));
+      return;
+    }
+    // Discovery or Room — tear down audio/BLE and surface the denied screen.
+    final myName = switch (current) {
+      SessionDiscovery(:final myName) => myName,
+      SessionRoom(:final myName) => myName,
+      _ => null,
+    };
+    unawaited(_teardownForPermissionRevoke());
+    if (isClosed) return;
+    emit(SessionPermissionDenied(missing: missing, myName: myName));
+  }
+
+  /// Stop voice + BLE side-effects on revoke without going through
+  /// [leaveRoom] (which would emit an intermediate [SessionDiscovery]).
+  /// Mirrors [leaveRoom]'s cleanup minus the state transition; see that
+  /// method for the per-step rationale.
+  Future<void> _teardownForPermissionRevoke() async {
+    _reconnectController?.cancel();
+    _reconnectController = null;
+    _heartbeats.stop();
+    _signalReporter.stop();
+    _weakSignalDetector.clear();
+    _transport?.forgetAllPeers();
+    _seq = 0;
+    // Best-effort native teardown — failures are already logged inside
+    // AudioService and must not block the state transition.
+    final audio = _audio;
+    if (audio != null) {
+      try {
+        await audio.stopVoice();
+      } catch (error, stackTrace) {
+        debugPrint('stopVoice during permission revoke failed: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
+      try {
+        await audio.stopService();
+      } catch (error, stackTrace) {
+        debugPrint('stopService during permission revoke failed: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
+    }
+  }
+
+  /// Transition out of [SessionPermissionDenied] now that the watcher has
+  /// reported all permissions granted. Routes to [SessionDiscovery] when
+  /// a display name is on hand (the typical case — the user had already
+  /// onboarded), or to [SessionOnboarding] otherwise.
+  Future<void> _recoverFromPermissionDenied(
+    SessionPermissionDenied current,
+  ) async {
+    final myName = current.myName;
+    if (myName == null) {
+      if (isClosed) return;
+      emit(const SessionOnboarding());
+      return;
+    }
+    final recent = await _loadRecentFrequencies();
+    if (isClosed) return;
+    emit(SessionDiscovery(
+      myName: myName,
+      recentHostedFrequencies: recent,
+    ));
+  }
+
+  /// Asks the [PermissionWatcher] to re-sample now. Wired to the "Retry"
+  /// button on the permission-denied screen so the user doesn't have to
+  /// wait up to one poll interval after re-granting in Settings. No-op when
+  /// no watcher was injected (loopback / test builds).
+  Future<void> recheckPermissions() async {
+    await _permissionWatcher?.checkNow();
   }
 
   Future<List<String>> _loadRecentFrequencies() async {
@@ -905,6 +1046,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     await super.close();
     await _transportSubscription?.cancel();
     await _localTalkingSubscription?.cancel();
+    // Drop the permission subscription before closing the broadcast
+    // controllers so a final watcher tick can't try to emit() against the
+    // closing cubit. The watcher itself is owned by the caller (not the
+    // cubit) — the same instance survives across re-bootstraps in tests,
+    // so we don't dispose it here.
+    await _permissionSubscription?.cancel();
     await _mediaCommandsController.close();
     await _weakSignalEventsController.close();
   }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -199,14 +199,36 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     if (persisted == null) {
       emit(const SessionOnboarding());
-      return;
+    } else {
+      final recent = await _loadRecentFrequencies();
+      if (isClosed) return;
+      emit(SessionDiscovery(
+        myName: persisted,
+        recentHostedFrequencies: recent,
+      ));
     }
-    final recent = await _loadRecentFrequencies();
-    if (isClosed) return;
-    emit(SessionDiscovery(
-      myName: persisted,
-      recentHostedFrequencies: recent,
-    ));
+    // Defensive replay of the latest permission state. The watcher's
+    // initial sample is emitted before bootstrap finishes (cubit is still
+    // in [SessionBooting] when the listener runs), and
+    // [_onPermissionsChanged] intentionally ignores Booting because
+    // onboarding owns its own permission flow. Without this re-check, an
+    // initial revoked state would be swallowed by the watcher's de-dup
+    // and never re-surface — a fresh launch with mic / BT already revoked
+    // would land on Discovery instead of the denied screen. Apply the
+    // latest sample through the same handler now that we've left Booting.
+    final watcher = _permissionWatcher;
+    if (watcher != null && !isClosed) {
+      unawaited(() async {
+        try {
+          final missing = await watcher.checkNow();
+          if (isClosed) return;
+          _onPermissionsChanged(missing);
+        } catch (error, stackTrace) {
+          debugPrint('Initial permission check failed: $error');
+          debugPrintStack(stackTrace: stackTrace);
+        }
+      }());
+    }
   }
 
   void _onTransportMessage(FrequencyMessage msg) {
@@ -794,17 +816,29 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// reported all permissions granted. Routes to [SessionDiscovery] when
   /// a display name is on hand (the typical case — the user had already
   /// onboarded), or to [SessionOnboarding] otherwise.
+  ///
+  /// Identity-checks the current state right before the final emit: between
+  /// the watcher's "all granted" signal and the recent-frequencies disk
+  /// read, the user could have toggled a permission off again and the
+  /// watcher could have pushed a fresh denied state through. Each
+  /// [_onPermissionsChanged] call emits a *new* [SessionPermissionDenied]
+  /// instance, so checking `identical(state, current)` rather than
+  /// `state is! SessionPermissionDenied` correctly distinguishes "same
+  /// denied state we entered recovery from" (safe to emit Discovery) from
+  /// "a newer denied state replaced it during the await" (don't clobber).
   Future<void> _recoverFromPermissionDenied(
     SessionPermissionDenied current,
   ) async {
     final myName = current.myName;
     if (myName == null) {
       if (isClosed) return;
+      if (!identical(state, current)) return;
       emit(const SessionOnboarding());
       return;
     }
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
+    if (!identical(state, current)) return;
     emit(SessionDiscovery(
       myName: myName,
       recentHostedFrequencies: recent,

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -62,10 +62,12 @@ final class SessionDiscovery extends FrequencySessionState {
 ///
 /// [missing] is the ordered list of permissions the user has revoked
 /// (microphone before bluetooth, mirroring the watcher's emission). The
-/// list is unmodifiable so subscribers can compare with `==` for change
-/// detection. The cubit clears this state by emitting [SessionDiscovery]
-/// (or [SessionOnboarding] for a fresh install) once the watcher reports
-/// an empty list — recovering room state mid-session is intentionally not
+/// list is unmodifiable so a caller can't retroactively mutate past states
+/// and break Equatable's diffing — this state's element-wise diff comes
+/// from [Equatable] (see [props]) rather than `List.==`, which is identity.
+/// The cubit clears this state by emitting [SessionDiscovery] (or
+/// [SessionOnboarding] for a fresh install) once the watcher reports an
+/// empty list — recovering room state mid-session is intentionally not
 /// attempted (see issue #57's acceptance criteria: re-grant returns the
 /// user to Discovery, not the previous room).
 final class SessionPermissionDenied extends FrequencySessionState {

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 
 import '../protocol/messages.dart';
 import '../protocol/peer.dart';
+import '../services/permission_watcher.dart';
 
 /// Sentinel marking an argument-not-supplied position in `copyWith`. A
 /// caller passing `null` explicitly is distinguishable from omitting
@@ -52,6 +53,40 @@ final class SessionDiscovery extends FrequencySessionState {
 
   @override
   List<Object?> get props => [myName, recentHostedFrequencies];
+}
+
+/// User revoked one or more required runtime permissions while the app was
+/// running. The cubit transitions here from any other stage when
+/// [PermissionWatcher] reports a non-empty missing list, so the UI can
+/// render an explanatory screen with a "Re-grant in Settings" affordance.
+///
+/// [missing] is the ordered list of permissions the user has revoked
+/// (microphone before bluetooth, mirroring the watcher's emission). The
+/// list is unmodifiable so subscribers can compare with `==` for change
+/// detection. The cubit clears this state by emitting [SessionDiscovery]
+/// (or [SessionOnboarding] for a fresh install) once the watcher reports
+/// an empty list — recovering room state mid-session is intentionally not
+/// attempted (see issue #57's acceptance criteria: re-grant returns the
+/// user to Discovery, not the previous room).
+final class SessionPermissionDenied extends FrequencySessionState {
+  /// Ordered, deduped list of currently-missing permissions.
+  final List<AppPermission> missing;
+
+  /// Persisted display name, threaded through so the recovery transition
+  /// back to [SessionDiscovery] doesn't have to round-trip through the
+  /// identity store. Null when the app hadn't completed onboarding before
+  /// the revocation (revoking during the onboarding permission step is
+  /// handled by the onboarding screen itself, not by this state — but
+  /// the field is nullable as a defensive measure).
+  final String? myName;
+
+  SessionPermissionDenied({
+    required List<AppPermission> missing,
+    this.myName,
+  }) : missing = List<AppPermission>.unmodifiable(missing);
+
+  @override
+  List<Object?> get props => [missing, myName];
 }
 
 /// Tracks whether the guest's BLE link to the host is healthy.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,11 +10,14 @@ import 'bloc/frequency_session_state.dart';
 import 'data/frequency_mock_data.dart';
 import 'screens/frequency_discovery_screen.dart';
 import 'screens/frequency_onboarding_screen.dart';
+import 'screens/frequency_permission_denied_screen.dart';
 import 'screens/frequency_room_screen.dart';
 import 'services/audio_service.dart';
 import 'services/ble_control_transport.dart';
 import 'services/bluetooth_discovery_service.dart';
 import 'services/identity_store.dart';
+import 'services/onboarding_permission_gateway.dart';
+import 'services/permission_watcher.dart';
 import 'services/recent_frequencies_store.dart';
 import 'theme/app_theme.dart';
 import 'widgets/frequency_toast_host.dart';
@@ -39,12 +42,18 @@ class WalkieTalkieApp extends StatelessWidget {
   /// the native MethodChannel/EventChannel.
   final AudioService? audioService;
 
+  /// Override for tests; defaults to [DefaultPermissionWatcher] which polls
+  /// permissions on app resume + every 5 s. Tests inject a fake to drive
+  /// the revocation flow without permission_handler's platform channel.
+  final PermissionWatcher? permissionWatcher;
+
   const WalkieTalkieApp({
     super.key,
     this.identityStore,
     this.recentFrequenciesStore,
     this.discoveryService,
     this.audioService,
+    this.permissionWatcher,
   });
 
   @override
@@ -72,6 +81,13 @@ class WalkieTalkieApp extends StatelessWidget {
           create: (context) =>
               BleControlTransport(context.read<AudioService>()),
         ),
+        RepositoryProvider<PermissionWatcher>(
+          // The watcher lives for the lifetime of the app — same scope as
+          // [DiscoveryService] and [AudioService] above. It uses
+          // [WidgetsBindingObserver]; the framework releases the observer
+          // alongside the binding at app exit.
+          create: (_) => permissionWatcher ?? DefaultPermissionWatcher(),
+        ),
       ],
       child: MultiBlocProvider(
         providers: [
@@ -82,6 +98,7 @@ class WalkieTalkieApp extends StatelessWidget {
                   context.read<RecentFrequenciesStore>(),
               transport: context.read<BleControlTransport>(),
               audio: context.read<AudioService>(),
+              permissionWatcher: context.read<PermissionWatcher>(),
             )..bootstrap(),
           ),
           BlocProvider(
@@ -175,6 +192,13 @@ class FrequencyApp extends StatelessWidget {
           onLeave: () {
             unawaited(cubit.leaveRoom());
           },
+        ),
+      SessionPermissionDenied(:final missing) =>
+        FrequencyPermissionDeniedScreen(
+          missing: missing,
+          onOpenSettings: const DefaultOnboardingPermissionGateway()
+              .openAppSettings,
+          onRetry: cubit.recheckPermissions,
         ),
     };
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ void main() async {
   runApp(const WalkieTalkieApp());
 }
 
-class WalkieTalkieApp extends StatelessWidget {
+class WalkieTalkieApp extends StatefulWidget {
   /// Override for tests; defaults to the Hive-backed implementation.
   final IdentityStore? identityStore;
 
@@ -57,37 +57,58 @@ class WalkieTalkieApp extends StatelessWidget {
   });
 
   @override
+  State<WalkieTalkieApp> createState() => _WalkieTalkieAppState();
+}
+
+class _WalkieTalkieAppState extends State<WalkieTalkieApp> {
+  /// Owned by this State so [PermissionWatcher.dispose] runs deterministically
+  /// when the app widget is unmounted (hot restart, tests, embedded usage).
+  /// `flutter_bloc` 8.1.6's [RepositoryProvider] suppresses the underlying
+  /// `dispose:` parameter, so we own the lifecycle here and inject the
+  /// instance into the provider below — only test-supplied watchers (whose
+  /// owner is the test) are skipped.
+  PermissionWatcher? _ownedWatcher;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.permissionWatcher == null) {
+      _ownedWatcher = DefaultPermissionWatcher();
+    }
+  }
+
+  @override
+  void dispose() {
+    // Only dispose if we created it; a caller-supplied watcher is the
+    // caller's responsibility to release.
+    unawaited(_ownedWatcher?.dispose());
+    _ownedWatcher = null;
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    // If the service is not provided, we create it here. Since RepositoryProvider
-    // doesn't have a dispose callback like Provider, it's safer to provide it via
-    // a StatefulWidget if we need to manage its lifecycle, but for the global
-    // app scope it's okay to just let it live.
+    final watcher = widget.permissionWatcher ?? _ownedWatcher!;
     return MultiRepositoryProvider(
       providers: [
         RepositoryProvider<IdentityStore>(
-          create: (_) => identityStore ?? HiveIdentityStore(),
+          create: (_) => widget.identityStore ?? HiveIdentityStore(),
         ),
         RepositoryProvider<RecentFrequenciesStore>(
           create: (_) =>
-              recentFrequenciesStore ?? HiveRecentFrequenciesStore(),
+              widget.recentFrequenciesStore ?? HiveRecentFrequenciesStore(),
         ),
         RepositoryProvider<DiscoveryService>(
-          create: (_) => discoveryService ?? DiscoveryService(),
+          create: (_) => widget.discoveryService ?? DiscoveryService(),
         ),
         RepositoryProvider<AudioService>(
-          create: (_) => audioService ?? AudioService(),
+          create: (_) => widget.audioService ?? AudioService(),
         ),
         RepositoryProvider<BleControlTransport>(
           create: (context) =>
               BleControlTransport(context.read<AudioService>()),
         ),
-        RepositoryProvider<PermissionWatcher>(
-          // The watcher lives for the lifetime of the app — same scope as
-          // [DiscoveryService] and [AudioService] above. It uses
-          // [WidgetsBindingObserver]; the framework releases the observer
-          // alongside the binding at app exit.
-          create: (_) => permissionWatcher ?? DefaultPermissionWatcher(),
-        ),
+        RepositoryProvider<PermissionWatcher>.value(value: watcher),
       ],
       child: MultiBlocProvider(
         providers: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,6 +78,26 @@ class _WalkieTalkieAppState extends State<WalkieTalkieApp> {
   }
 
   @override
+  void didUpdateWidget(covariant WalkieTalkieApp old) {
+    super.didUpdateWidget(old);
+    // Reconcile [permissionWatcher] across parent rebuilds: if the caller
+    // flips between supplying a watcher and asking us to own one (rare in
+    // production, but reachable from a test that switches fakes), make
+    // sure we either dispose what we owned or stand up a fresh default.
+    final wasOwning = old.permissionWatcher == null;
+    final stillOwning = widget.permissionWatcher == null;
+    if (wasOwning && !stillOwning) {
+      // We owned it; the caller is now supplying one. Release ours.
+      unawaited(_ownedWatcher?.dispose());
+      _ownedWatcher = null;
+    } else if (!wasOwning && stillOwning) {
+      // The caller dropped the supplied watcher; mint a default so build()
+      // never sees a null on both sides.
+      _ownedWatcher = DefaultPermissionWatcher();
+    }
+  }
+
+  @override
   void dispose() {
     // Only dispose if we created it; a caller-supplied watcher is the
     // caller's responsibility to release.

--- a/lib/screens/frequency_permission_denied_screen.dart
+++ b/lib/screens/frequency_permission_denied_screen.dart
@@ -41,57 +41,74 @@ class FrequencyPermissionDeniedScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: c.bg,
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const FrequencyWordmark(),
-              const SizedBox(height: 36),
-              Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  color: c.surface2,
-                  borderRadius: BorderRadius.circular(14),
+        // The screen lays out long-form copy plus two action buttons.
+        // [LayoutBuilder] + [SingleChildScrollView] keeps Open settings /
+        // Retry pinned to the bottom on tall devices (matching the original
+        // [Spacer] layout) but lets the whole stack scroll on small phones
+        // or with large accessibility text — without scroll, the action
+        // buttons would overflow off-screen and strand the user.
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: IntrinsicHeight(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const FrequencyWordmark(),
+                      const SizedBox(height: 36),
+                      Container(
+                        width: 56,
+                        height: 56,
+                        decoration: BoxDecoration(
+                          color: c.surface2,
+                          borderRadius: BorderRadius.circular(14),
+                        ),
+                        alignment: Alignment.center,
+                        child:
+                            Icon(Icons.lock_outline, size: 26, color: c.danger),
+                      ),
+                      const SizedBox(height: 18),
+                      Text(
+                        'Permissions revoked',
+                        style: Theme.of(context).textTheme.displayLarge,
+                      ),
+                      const SizedBox(height: 10),
+                      Text(
+                        _explainerCopy(missing),
+                        style:
+                            Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                  color: c.ink2,
+                                ),
+                      ),
+                      const SizedBox(height: 22),
+                      for (final perm in missing) ...[
+                        _DeniedRow(perm: perm),
+                        const SizedBox(height: 8),
+                      ],
+                      const Spacer(),
+                      PrimaryButton(
+                        label: 'Open settings',
+                        block: true,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        fontSize: 15,
+                        onPressed: () => unawaited(onOpenSettings()),
+                      ),
+                      const SizedBox(height: 8),
+                      FreqButton(
+                        label: 'Retry',
+                        block: true,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        fontSize: 15,
+                        onPressed: () => unawaited(onRetry()),
+                      ),
+                    ],
+                  ),
                 ),
-                alignment: Alignment.center,
-                child: Icon(Icons.lock_outline, size: 26, color: c.danger),
               ),
-              const SizedBox(height: 18),
-              Text(
-                'Permissions revoked',
-                style: Theme.of(context).textTheme.displayLarge,
-              ),
-              const SizedBox(height: 10),
-              Text(
-                _explainerCopy(missing),
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: c.ink2,
-                    ),
-              ),
-              const SizedBox(height: 22),
-              for (final perm in missing) ...[
-                _DeniedRow(perm: perm),
-                const SizedBox(height: 8),
-              ],
-              const Spacer(),
-              PrimaryButton(
-                label: 'Open settings',
-                block: true,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-                fontSize: 15,
-                onPressed: () => unawaited(onOpenSettings()),
-              ),
-              const SizedBox(height: 8),
-              FreqButton(
-                label: 'Retry',
-                block: true,
-                padding: const EdgeInsets.symmetric(vertical: 14),
-                fontSize: 15,
-                onPressed: () => unawaited(onRetry()),
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/frequency_permission_denied_screen.dart
+++ b/lib/screens/frequency_permission_denied_screen.dart
@@ -1,0 +1,178 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../services/onboarding_permission_gateway.dart';
+import '../services/permission_watcher.dart';
+import '../theme/app_theme.dart';
+import '../widgets/frequency_atoms.dart';
+
+/// Surfaced when [SessionPermissionDenied] is the active state — the user
+/// revoked microphone or Bluetooth from system Settings while the app was
+/// running. Explains which permissions were lost, offers a deep-link to
+/// system settings, and a Retry button that asks the cubit to re-sample
+/// permissions immediately rather than waiting for the next watcher tick.
+class FrequencyPermissionDeniedScreen extends StatelessWidget {
+  /// Permissions the watcher reported as denied. Order is preserved so
+  /// the screen reads top-to-bottom: microphone before Bluetooth.
+  final List<AppPermission> missing;
+
+  /// Pulls the user into the system settings app for re-grant. Defaults
+  /// to [DefaultOnboardingPermissionGateway.openAppSettings]; tests
+  /// inject a fake to assert it was invoked without spinning up the
+  /// platform channel.
+  final Future<void> Function() onOpenSettings;
+
+  /// Re-checks permissions immediately. Wired to
+  /// [FrequencySessionCubit.recheckPermissions] in production so the user
+  /// gets snappy feedback after toggling Settings.
+  final Future<void> Function() onRetry;
+
+  const FrequencyPermissionDeniedScreen({
+    super.key,
+    required this.missing,
+    required this.onOpenSettings,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Scaffold(
+      backgroundColor: c.bg,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 28),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const FrequencyWordmark(),
+              const SizedBox(height: 36),
+              Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  color: c.surface2,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                alignment: Alignment.center,
+                child: Icon(Icons.lock_outline, size: 26, color: c.danger),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                'Permissions revoked',
+                style: Theme.of(context).textTheme.displayLarge,
+              ),
+              const SizedBox(height: 10),
+              Text(
+                _explainerCopy(missing),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: c.ink2,
+                    ),
+              ),
+              const SizedBox(height: 22),
+              for (final perm in missing) ...[
+                _DeniedRow(perm: perm),
+                const SizedBox(height: 8),
+              ],
+              const Spacer(),
+              PrimaryButton(
+                label: 'Open settings',
+                block: true,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                fontSize: 15,
+                onPressed: () => unawaited(onOpenSettings()),
+              ),
+              const SizedBox(height: 8),
+              FreqButton(
+                label: 'Retry',
+                block: true,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                fontSize: 15,
+                onPressed: () => unawaited(onRetry()),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _explainerCopy(List<AppPermission> missing) {
+    final hasMic = missing.contains(AppPermission.microphone);
+    final hasBt = missing.contains(AppPermission.bluetooth);
+    if (hasMic && hasBt) {
+      return 'Frequency needs microphone and Bluetooth to keep you on the air. '
+          'Re-grant them in Settings to come back.';
+    }
+    if (hasMic) {
+      return 'Frequency needs the microphone to send your voice. '
+          'Re-grant it in Settings to come back.';
+    }
+    return 'Frequency needs Bluetooth to find nearby phones. '
+        'Re-grant it in Settings to come back.';
+  }
+}
+
+class _DeniedRow extends StatelessWidget {
+  final AppPermission perm;
+  const _DeniedRow({required this.perm});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return FreqCard(
+      padding: const EdgeInsets.all(14),
+      child: Row(
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: c.surface2,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            alignment: Alignment.center,
+            child: Icon(_icon(perm), size: 18, color: c.danger),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _title(perm),
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: c.ink,
+                  ),
+                ),
+                Text(
+                  'Blocked — re-enable in system settings',
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 12,
+                    color: c.danger,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static IconData _icon(AppPermission perm) => switch (perm) {
+        AppPermission.microphone => Icons.mic_off,
+        AppPermission.bluetooth => Icons.bluetooth_disabled,
+      };
+
+  static String _title(AppPermission perm) => switch (perm) {
+        AppPermission.microphone => 'Microphone',
+        AppPermission.bluetooth => 'Bluetooth nearby devices',
+      };
+}

--- a/lib/services/permission_watcher.dart
+++ b/lib/services/permission_watcher.dart
@@ -136,6 +136,12 @@ class DefaultPermissionWatcher
       onCancel: () async {
         await inner?.cancel();
         inner = null;
+        // Close the per-subscriber controller so we don't keep an open
+        // instance around after the caller has cancelled (e.g. consumers
+        // of `.first`, which auto-cancel as soon as the first event lands).
+        if (!out.isClosed) {
+          await out.close();
+        }
       },
     );
     return out.stream;

--- a/lib/services/permission_watcher.dart
+++ b/lib/services/permission_watcher.dart
@@ -87,6 +87,15 @@ class DefaultPermissionWatcher
   /// always reflect a fresh sample, even if a background tick is in flight.
   bool _backgroundCheckInFlight = false;
 
+  /// Monotonic counter incremented at the start of every [_sampleAndEmit].
+  /// A sample only writes to [_last] / [_controller] if it's still the
+  /// newest one when the platform reads complete. Without this, a slow
+  /// background tick that started before a fresh [checkNow] could finish
+  /// last with stale data and overwrite the newer reading — yanking the
+  /// UI back to the previous denied state and bouncing the user back to
+  /// Discovery on a brief flicker.
+  int _sampleGeneration = 0;
+
   @override
   Stream<List<AppPermission>> watch() {
     if (_disposed) {
@@ -167,8 +176,16 @@ class DefaultPermissionWatcher
   /// last emission, and push a new event onto the broadcast stream when it
   /// changed. Returns the freshly-sampled missing list (or [_last] when
   /// the platform read threw — see catch block).
+  ///
+  /// Multiple samplers can run concurrently (a background tick + a
+  /// [checkNow] from the Retry button, for example). Each one tags itself
+  /// with [_sampleGeneration]; only the newest-started sample updates
+  /// [_last] / [_controller]. Older samples that finish later return their
+  /// own reading to the caller but do not emit, so a slow background read
+  /// can't clobber a newer Retry result with stale data.
   Future<List<AppPermission>> _sampleAndEmit() async {
     if (_disposed) return _last;
+    final myGeneration = ++_sampleGeneration;
     final missing = <AppPermission>[];
     try {
       if (!await _isMicrophoneGranted()) {
@@ -186,6 +203,11 @@ class DefaultPermissionWatcher
       return _last;
     }
     final snapshot = List<AppPermission>.unmodifiable(missing);
+    if (_disposed) return snapshot;
+    // A newer sample started after us; let it apply its result. We still
+    // return our own reading to the caller (it's what we read), but we
+    // don't update shared state.
+    if (myGeneration != _sampleGeneration) return snapshot;
     if (!_hasEmitted || !_listEqual(_last, snapshot)) {
       _hasEmitted = true;
       _last = snapshot;

--- a/lib/services/permission_watcher.dart
+++ b/lib/services/permission_watcher.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:permission_handler/permission_handler.dart' as ph;
+
+/// Coarse-grained permission categories the app tracks at runtime.
+///
+/// Android's three Bluetooth runtime permissions ([ph.Permission.bluetoothScan],
+/// [ph.Permission.bluetoothConnect], [ph.Permission.bluetoothAdvertise]) are
+/// surfaced together in the system's user-facing toggle, so we collapse them
+/// into a single [bluetooth] entry. The user sees one switch in Settings; the
+/// UI should mirror that.
+enum AppPermission { microphone, bluetooth }
+
+/// Watches the runtime permissions the app needs to keep a room alive
+/// ([AppPermission.microphone] for the mic, [AppPermission.bluetooth] for
+/// the BLE control + L2CAP voice planes).
+///
+/// Emits a [List] of currently-missing permissions on the [watch] stream.
+/// The list is ordered (microphone before bluetooth) and de-duplicated, so
+/// listeners can compare with `==` (via [ListEquality]-style semantics) to
+/// detect a real change. The first event after subscription is the current
+/// snapshot — listeners don't need to seed state separately.
+///
+/// The default implementation re-checks on app resume (via
+/// [WidgetsBindingObserver]) and on a 5-second timer while the app is
+/// foregrounded. The timer keeps the watcher honest even if the user toggles
+/// the permission via the notification shade rather than the system Settings
+/// screen (which wouldn't always trigger an `AppLifecycleState.resumed`).
+abstract class PermissionWatcher {
+  /// Stream of currently-missing permissions. The first event is the initial
+  /// snapshot at subscription time; subsequent events fire only when the set
+  /// changes. Empty list means all permissions are granted.
+  Stream<List<AppPermission>> watch();
+
+  /// Re-check permissions immediately. Returns the current missing list and
+  /// also pushes it through [watch] if it differs from the last sample.
+  /// Useful after the user returns from app settings — call this from a
+  /// "Retry" button so the UI can react without waiting on the 5 s tick.
+  Future<List<AppPermission>> checkNow();
+
+  /// Releases timers, observers, and the underlying broadcast controller.
+  /// Safe to call more than once.
+  Future<void> dispose();
+}
+
+/// Production implementation backed by the `permission_handler` package and
+/// the Flutter [WidgetsBinding] lifecycle.
+class DefaultPermissionWatcher
+    with WidgetsBindingObserver
+    implements PermissionWatcher {
+  /// Foreground re-check cadence. Five seconds matches the issue's spec
+  /// (issue #57): short enough that toggling a permission feels responsive,
+  /// long enough that the OS doesn't notice the polling.
+  static const Duration pollInterval = Duration(seconds: 5);
+
+  final StreamController<List<AppPermission>> _controller =
+      StreamController<List<AppPermission>>.broadcast();
+  Timer? _timer;
+  bool _observerAdded = false;
+  bool _disposed = false;
+
+  /// Last emitted set, used to suppress duplicate events. Stored as an
+  /// unmodifiable list so subscribers can hold the reference safely.
+  List<AppPermission> _last = const [];
+  bool _hasEmitted = false;
+
+  /// Re-entrancy guard for *background* ticks (poll timer + lifecycle
+  /// resume). The poll timer and lifecycle hook can both fire while a
+  /// previous check is still awaiting platform calls; we drop overlapping
+  /// ticks rather than queueing them so a slow platform call doesn't fan
+  /// out into concurrent queries. The guard does **not** apply to
+  /// [checkNow] — that's a user-driven path (the Retry button) which must
+  /// always reflect a fresh sample, even if a background tick is in flight.
+  bool _backgroundCheckInFlight = false;
+
+  @override
+  Stream<List<AppPermission>> watch() {
+    if (_disposed) {
+      throw StateError('PermissionWatcher was disposed');
+    }
+    if (!_observerAdded) {
+      _observerAdded = true;
+      WidgetsBinding.instance.addObserver(this);
+      _timer ??= Timer.periodic(pollInterval, (_) => _backgroundCheck());
+      // Kick off the first check so subscribers get an initial snapshot
+      // shortly after subscribing rather than waiting up to pollInterval.
+      // Fire-and-forget — emission lands on the broadcast stream.
+      _backgroundCheck();
+    }
+    return _controller.stream;
+  }
+
+  @override
+  Future<List<AppPermission>> checkNow() async {
+    if (_disposed) {
+      throw StateError('PermissionWatcher was disposed');
+    }
+    return _sampleAndEmit();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (_disposed) return;
+    if (state == AppLifecycleState.resumed) {
+      _backgroundCheck();
+    }
+  }
+
+  /// Background-tick entry point: drops the call if a previous background
+  /// check is still awaiting platform answers. Lifecycle / poll timer use
+  /// this; user-driven [checkNow] does not.
+  void _backgroundCheck() {
+    if (_disposed) return;
+    if (_backgroundCheckInFlight) return;
+    _backgroundCheckInFlight = true;
+    unawaited(_sampleAndEmit().whenComplete(() {
+      _backgroundCheckInFlight = false;
+    }));
+  }
+
+  /// Read the current platform-side permission state, de-dup against the
+  /// last emission, and push a new event onto the broadcast stream when it
+  /// changed. Returns the freshly-sampled missing list (or [_last] when
+  /// the platform read threw — see catch block).
+  Future<List<AppPermission>> _sampleAndEmit() async {
+    if (_disposed) return _last;
+    final missing = <AppPermission>[];
+    try {
+      if (!await _isMicrophoneGranted()) {
+        missing.add(AppPermission.microphone);
+      }
+      if (!await _isBluetoothGranted()) {
+        missing.add(AppPermission.bluetooth);
+      }
+    } catch (error, stackTrace) {
+      // permission_handler throws MissingPluginException on platforms
+      // without a native bridge (web, desktop). Treat as "no answer" —
+      // don't emit a spurious denial, and don't crash the watcher.
+      debugPrint('PermissionWatcher check failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      return _last;
+    }
+    final snapshot = List<AppPermission>.unmodifiable(missing);
+    if (!_hasEmitted || !_listEqual(_last, snapshot)) {
+      _hasEmitted = true;
+      _last = snapshot;
+      if (!_controller.isClosed) {
+        _controller.add(snapshot);
+      }
+    }
+    return snapshot;
+  }
+
+  /// Hook for tests; production calls [ph.Permission.microphone.isGranted].
+  @visibleForTesting
+  Future<bool> isMicrophoneGranted() => _isMicrophoneGranted();
+
+  /// Hook for tests; production aggregates the three BT runtime permissions.
+  @visibleForTesting
+  Future<bool> isBluetoothGranted() => _isBluetoothGranted();
+
+  Future<bool> _isMicrophoneGranted() async {
+    final status = await ph.Permission.microphone.status;
+    return status.isGranted || status.isLimited;
+  }
+
+  Future<bool> _isBluetoothGranted() async {
+    // The three runtime perms must all be granted for BLE host + L2CAP voice
+    // to work; missing any of them collapses to a single "bluetooth denied"
+    // event for the UI.
+    final results = await Future.wait(<Future<ph.PermissionStatus>>[
+      ph.Permission.bluetoothScan.status,
+      ph.Permission.bluetoothConnect.status,
+      ph.Permission.bluetoothAdvertise.status,
+    ]);
+    return results.every((s) => s.isGranted || s.isLimited);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _timer?.cancel();
+    _timer = null;
+    if (_observerAdded) {
+      WidgetsBinding.instance.removeObserver(this);
+      _observerAdded = false;
+    }
+    if (!_controller.isClosed) {
+      await _controller.close();
+    }
+  }
+
+  static bool _listEqual(List<AppPermission> a, List<AppPermission> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}

--- a/lib/services/permission_watcher.dart
+++ b/lib/services/permission_watcher.dart
@@ -17,20 +17,24 @@ enum AppPermission { microphone, bluetooth }
 /// the BLE control + L2CAP voice planes).
 ///
 /// Emits a [List] of currently-missing permissions on the [watch] stream.
-/// The list is ordered (microphone before bluetooth) and de-duplicated, so
-/// listeners can compare with `==` (via [ListEquality]-style semantics) to
-/// detect a real change. The first event after subscription is the current
-/// snapshot — listeners don't need to seed state separately.
+/// The list is ordered (microphone before bluetooth) and de-duplicated by
+/// element-wise comparison — Dart's `List.==` is identity, so consumers
+/// that want value-semantics should use `listEquals` from `flutter/foundation`,
+/// or wrap the result in an `Equatable`-compatible value (which is what
+/// `SessionPermissionDenied` does). Each new subscriber sees the most
+/// recently emitted snapshot first, then change-only updates after that.
 ///
 /// The default implementation re-checks on app resume (via
 /// [WidgetsBindingObserver]) and on a 5-second timer while the app is
-/// foregrounded. The timer keeps the watcher honest even if the user toggles
-/// the permission via the notification shade rather than the system Settings
-/// screen (which wouldn't always trigger an `AppLifecycleState.resumed`).
+/// foregrounded. The timer is gated by the latest [AppLifecycleState]: when
+/// the app is paused / inactive / detached the polling falls silent so the
+/// app doesn't spend battery querying permissions while in the background.
+/// On resume the watcher re-samples immediately, which catches any change
+/// that happened during the gap.
 abstract class PermissionWatcher {
-  /// Stream of currently-missing permissions. The first event is the initial
-  /// snapshot at subscription time; subsequent events fire only when the set
-  /// changes. Empty list means all permissions are granted.
+  /// Stream of currently-missing permissions. New subscribers receive the
+  /// last sampled value (if any) first, then change-only updates after that.
+  /// Empty list means all permissions are granted.
   Stream<List<AppPermission>> watch();
 
   /// Re-check permissions immediately. Returns the current missing list and
@@ -60,10 +64,19 @@ class DefaultPermissionWatcher
   bool _observerAdded = false;
   bool _disposed = false;
 
-  /// Last emitted set, used to suppress duplicate events. Stored as an
-  /// unmodifiable list so subscribers can hold the reference safely.
+  /// Last emitted set, used to suppress duplicate events and to replay the
+  /// current snapshot to late subscribers. Stored as an unmodifiable list so
+  /// subscribers can hold the reference safely.
   List<AppPermission> _last = const [];
   bool _hasEmitted = false;
+
+  /// Tracks the app's foreground/background state. The timer fires every 5 s
+  /// regardless of foreground state, but [_backgroundCheck] short-circuits
+  /// when the app isn't resumed, so we don't waste a platform call (and
+  /// battery) querying permissions while the user is in another app. On
+  /// [AppLifecycleState.resumed] we re-sample immediately, which catches any
+  /// permission flip that happened during the gap.
+  AppLifecycleState _lifecycleState = AppLifecycleState.resumed;
 
   /// Re-entrancy guard for *background* ticks (poll timer + lifecycle
   /// resume). The poll timer and lifecycle hook can both fire while a
@@ -88,7 +101,35 @@ class DefaultPermissionWatcher
       // Fire-and-forget — emission lands on the broadcast stream.
       _backgroundCheck();
     }
-    return _controller.stream;
+    // Replay the last sampled value to each new subscriber so a late
+    // listener (e.g. cubit re-bootstrap on hot restart) doesn't miss a
+    // stable revoked state. Without this, a subscriber that attaches AFTER
+    // the kickoff sample wouldn't receive the current snapshot until the
+    // next change — and if the set never changes, never.
+    return _replayAndForward();
+  }
+
+  /// Stream wrapper that emits [_last] (when one has been sampled) before
+  /// forwarding subsequent events from [_controller]. Each subscriber gets
+  /// its own copy of the replay.
+  Stream<List<AppPermission>> _replayAndForward() {
+    late StreamController<List<AppPermission>> out;
+    StreamSubscription<List<AppPermission>>? inner;
+    out = StreamController<List<AppPermission>>(
+      onListen: () {
+        if (_hasEmitted) out.add(_last);
+        inner = _controller.stream.listen(
+          out.add,
+          onError: out.addError,
+          onDone: out.close,
+        );
+      },
+      onCancel: () async {
+        await inner?.cancel();
+        inner = null;
+      },
+    );
+    return out.stream;
   }
 
   @override
@@ -102,16 +143,19 @@ class DefaultPermissionWatcher
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (_disposed) return;
+    _lifecycleState = state;
     if (state == AppLifecycleState.resumed) {
       _backgroundCheck();
     }
   }
 
   /// Background-tick entry point: drops the call if a previous background
-  /// check is still awaiting platform answers. Lifecycle / poll timer use
-  /// this; user-driven [checkNow] does not.
+  /// check is still awaiting platform answers, or if the app isn't currently
+  /// foregrounded. Lifecycle resume / poll timer use this; user-driven
+  /// [checkNow] does not.
   void _backgroundCheck() {
     if (_disposed) return;
+    if (_lifecycleState != AppLifecycleState.resumed) return;
     if (_backgroundCheckInFlight) return;
     _backgroundCheckInFlight = true;
     unawaited(_sampleAndEmit().whenComplete(() {

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -127,6 +127,13 @@ FrequencySessionCubit _makeCubit({
 class _FakePermissionWatcher implements PermissionWatcher {
   final StreamController<List<AppPermission>> controller =
       StreamController<List<AppPermission>>.broadcast();
+
+  /// Result returned by [checkNow]. Tests that exercise the boot-time
+  /// revoked path set this to a non-empty list before calling [bootstrap]
+  /// so the cubit's defensive checkNow at the end of bootstrap surfaces
+  /// the denied state.
+  List<AppPermission> checkNowResult = const [];
+
   int checkNowCalls = 0;
   bool disposed = false;
 
@@ -139,7 +146,7 @@ class _FakePermissionWatcher implements PermissionWatcher {
   @override
   Future<List<AppPermission>> checkNow() async {
     checkNowCalls++;
-    return const [];
+    return checkNowResult;
   }
 
   @override
@@ -2315,9 +2322,15 @@ void main() {
         final watcher = _FakePermissionWatcher();
         final cubit = _makeCubit(permissionWatcher: watcher);
         await cubit.bootstrap();
+        // bootstrap performs a defensive checkNow() at the end so an
+        // initial revoked snapshot isn't dropped during Booting; let that
+        // call settle before counting recheckPermissions.
+        await Future<void>.delayed(Duration.zero);
+        final baseline = watcher.checkNowCalls;
+        expect(baseline, 1);
 
         await cubit.recheckPermissions();
-        expect(watcher.checkNowCalls, 1);
+        expect(watcher.checkNowCalls, baseline + 1);
 
         await cubit.close();
         await watcher.dispose();
@@ -2331,6 +2344,88 @@ void main() {
         await cubit.bootstrap();
         await expectLater(cubit.recheckPermissions(), completes);
         await cubit.close();
+      },
+    );
+
+    test(
+      'fresh launch with already-revoked perms lands on the denied screen',
+      () async {
+        // Models the case where the user revoked perms via the system
+        // notification shade or settings while the app was killed. The
+        // watcher's first sample reports a non-empty missing list before
+        // bootstrap finishes; the cubit's defensive checkNow at the end of
+        // bootstrap must apply it instead of swallowing it during Booting.
+        final watcher = _FakePermissionWatcher()
+          ..checkNowResult = const [AppPermission.microphone];
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          permissionWatcher: watcher,
+        );
+
+        await cubit.bootstrap();
+        // bootstrap fires the defensive checkNow asynchronously.
+        await Future<void>.delayed(Duration.zero);
+
+        final s = cubit.state;
+        expect(s, isA<SessionPermissionDenied>());
+        expect((s as SessionPermissionDenied).missing,
+            [AppPermission.microphone]);
+        expect(s.myName, 'Maya');
+
+        await cubit.close();
+        await watcher.dispose();
+      },
+    );
+
+    test(
+      'recover-from-denied does not clobber a fresh denied state during the '
+      'recent-frequencies disk-read await',
+      () async {
+        // Race: watcher reports all-granted → cubit starts
+        // _recoverFromPermissionDenied which awaits _loadRecentFrequencies.
+        // Mid-await, the user toggles a permission off again and the watcher
+        // pushes a fresh denied state. Recovery must not overwrite that.
+        final recent = _GatedRecentFrequenciesStore();
+        final watcher = _FakePermissionWatcher();
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+          permissionWatcher: watcher,
+        );
+        await cubit.bootstrap();
+
+        // Enter denied.
+        watcher.push([AppPermission.microphone]);
+        await Future<void>.delayed(Duration.zero);
+        expect(cubit.state, isA<SessionPermissionDenied>());
+
+        // Wedge the next getRecent call so recovery's await blocks.
+        final blocker = Completer<List<String>>();
+        recent.gate = blocker.future;
+
+        // User re-grants — recovery starts and awaits the slow disk read.
+        watcher.push(const []);
+        await Future<void>.delayed(Duration.zero);
+        // Still denied (recovery is mid-await).
+        expect(cubit.state, isA<SessionPermissionDenied>());
+
+        // Mid-await, user toggles bluetooth off — fresh denied state lands.
+        watcher.push([AppPermission.bluetooth]);
+        await Future<void>.delayed(Duration.zero);
+        expect((cubit.state as SessionPermissionDenied).missing,
+            [AppPermission.bluetooth]);
+
+        // Now the disk read completes. Recovery must NOT emit Discovery —
+        // a newer denied state took its place.
+        blocker.complete(const []);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(cubit.state, isA<SessionPermissionDenied>());
+        expect((cubit.state as SessionPermissionDenied).missing,
+            [AppPermission.bluetooth]);
+
+        await cubit.close();
+        await watcher.dispose();
       },
     );
   });
@@ -2356,6 +2451,32 @@ void main() {
       expect(r.roomIsHost, isTrue);
     });
   });
+}
+
+/// RecentFrequenciesStore whose `getRecent()` blocks on a caller-supplied
+/// future, letting a test wedge an awaiting cubit method mid-await to
+/// exercise races against state transitions that fire during the gap.
+///
+/// The first call always resolves immediately (so bootstrap can finish)
+/// and only later calls block. Tests that want to wedge mid-recovery set
+/// the gate before triggering the recovery path.
+class _GatedRecentFrequenciesStore implements RecentFrequenciesStore {
+  Future<List<String>>? gate;
+  int callCount = 0;
+
+  @override
+  Future<List<String>> getRecent() async {
+    callCount++;
+    final g = gate;
+    if (g == null) return const [];
+    return g;
+  }
+
+  @override
+  Future<void> record(String freq) async {}
+
+  @override
+  Future<void> clear() async {}
 }
 
 /// IdentityStore whose `getPeerId` blocks on a caller-supplied future.

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -12,6 +12,7 @@ import 'package:walkie_talkie/services/audio_service.dart';
 import 'package:walkie_talkie/services/ble_control_transport.dart';
 import 'package:walkie_talkie/services/heartbeat_scheduler.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
+import 'package:walkie_talkie/services/permission_watcher.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/services/signal_reporter.dart';
 import 'package:walkie_talkie/services/weak_signal_detector.dart';
@@ -99,6 +100,7 @@ FrequencySessionCubit _makeCubit({
   IdentityStore? identityStore,
   RecentFrequenciesStore? recentFrequenciesStore,
   AudioService? audio,
+  PermissionWatcher? permissionWatcher,
   List<Duration>? reconnectDelays,
   HeartbeatScheduler? heartbeats,
   BleControlTransport? transport,
@@ -110,12 +112,42 @@ FrequencySessionCubit _makeCubit({
       recentFrequenciesStore:
           recentFrequenciesStore ?? _FakeRecentFrequenciesStore(),
       audio: audio,
+      permissionWatcher: permissionWatcher,
       reconnectDelays: reconnectDelays,
       heartbeats: heartbeats,
       transport: transport,
       signalReporter: signalReporter,
       weakSignalDetector: weakSignalDetector,
     );
+
+/// Drives the cubit's permission-revoked branch under test. The default
+/// [DefaultPermissionWatcher] would talk to permission_handler over a
+/// MethodChannel; this fake just exposes a controller so tests can push
+/// arbitrary [AppPermission] lists in deterministic order.
+class _FakePermissionWatcher implements PermissionWatcher {
+  final StreamController<List<AppPermission>> controller =
+      StreamController<List<AppPermission>>.broadcast();
+  int checkNowCalls = 0;
+  bool disposed = false;
+
+  /// Push a missing list onto the watch stream.
+  void push(List<AppPermission> missing) => controller.add(missing);
+
+  @override
+  Stream<List<AppPermission>> watch() => controller.stream;
+
+  @override
+  Future<List<AppPermission>> checkNow() async {
+    checkNowCalls++;
+    return const [];
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+    await controller.close();
+  }
+}
 
 void main() {
   group('FrequencySessionCubit', () {
@@ -2089,6 +2121,218 @@ void main() {
       await t.inbox.close();
       t.transport.dispose();
     });
+  });
+
+  // ── Permission revocation (#57) ─────────────────────────────────────────
+
+  group('Permission revocation', () {
+    test(
+      'revoke from Discovery transitions to SessionPermissionDenied',
+      () async {
+        final watcher = _FakePermissionWatcher();
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          permissionWatcher: watcher,
+        );
+        await cubit.bootstrap(); // subscribe to watcher
+        expect(cubit.state, isA<SessionDiscovery>());
+
+        watcher.push([AppPermission.microphone]);
+        await Future<void>.delayed(Duration.zero);
+
+        final s = cubit.state;
+        expect(s, isA<SessionPermissionDenied>());
+        expect((s as SessionPermissionDenied).missing,
+            [AppPermission.microphone]);
+        expect(s.myName, 'Maya');
+
+        await cubit.close();
+        await watcher.dispose();
+      },
+    );
+
+    test(
+      'revoke from Room tears down BLE state and surfaces denied screen',
+      () async {
+        final watcher = _FakePermissionWatcher();
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        );
+        final t = (() {
+          final outbox = <Uint8List>[];
+          final inbox = StreamController<
+              ({String endpointId, Uint8List bytes})>.broadcast();
+          final transport = BleControlTransport.forTest(
+            controlBytes: inbox.stream,
+            writeBytes: (bytes) async {
+              outbox.add(bytes);
+            },
+          );
+          return (transport: transport, outbox: outbox, inbox: inbox);
+        })();
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          heartbeats: scheduler,
+          transport: t.transport,
+          permissionWatcher: watcher,
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        expect(scheduler.isRunning, isTrue);
+
+        watcher.push([
+          AppPermission.microphone,
+          AppPermission.bluetooth,
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        // Heartbeat scheduler must have been stopped (mirrors leaveRoom
+        // cleanup) so the cubit isn't pinging an absent transport.
+        expect(scheduler.isRunning, isFalse);
+        final s = cubit.state;
+        expect(s, isA<SessionPermissionDenied>());
+        expect((s as SessionPermissionDenied).missing, [
+          AppPermission.microphone,
+          AppPermission.bluetooth,
+        ]);
+        expect(s.myName, 'Maya');
+
+        await cubit.close();
+        await watcher.dispose();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'revoke from Onboarding is ignored (onboarding owns its own flow)',
+      () async {
+        final watcher = _FakePermissionWatcher();
+        final cubit = _makeCubit(permissionWatcher: watcher);
+        await cubit.bootstrap();
+        expect(cubit.state, isA<SessionOnboarding>());
+
+        watcher.push([AppPermission.microphone]);
+        await Future<void>.delayed(Duration.zero);
+
+        // Onboarding owns its own permission flow — the cubit must not
+        // yank the user out mid-grant.
+        expect(cubit.state, isA<SessionOnboarding>());
+
+        await cubit.close();
+        await watcher.dispose();
+      },
+    );
+
+    test(
+      'recover from denied returns to Discovery with the persisted name',
+      () async {
+        final watcher = _FakePermissionWatcher();
+        final recent = _FakeRecentFrequenciesStore(initial: const ['100.1']);
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+          permissionWatcher: watcher,
+        );
+        await cubit.bootstrap();
+        watcher.push([AppPermission.microphone]);
+        await Future<void>.delayed(Duration.zero);
+        expect(cubit.state, isA<SessionPermissionDenied>());
+
+        // User re-grants in Settings; watcher emits empty.
+        watcher.push(const []);
+        await Future<void>.delayed(Duration.zero);
+
+        final s = cubit.state;
+        expect(s, isA<SessionDiscovery>());
+        expect((s as SessionDiscovery).myName, 'Maya');
+        expect(s.recentHostedFrequencies, ['100.1']);
+
+        await cubit.close();
+        await watcher.dispose();
+      },
+    );
+
+    test(
+      'recover with no display name routes back to Onboarding',
+      () async {
+        final watcher = _FakePermissionWatcher();
+        final cubit = _makeCubit(permissionWatcher: watcher);
+
+        // Synthesize a denied state with no captured name (the watcher fires
+        // before bootstrap reads the store on a fresh install with revoked
+        // perms — defensive path).
+        cubit.emit(SessionPermissionDenied(
+          missing: const [AppPermission.microphone],
+        ));
+        await cubit.bootstrap();
+        // Bootstrap may have routed to Onboarding already; re-seed denied.
+        cubit.emit(SessionPermissionDenied(
+          missing: const [AppPermission.microphone],
+        ));
+
+        watcher.push(const []);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(cubit.state, isA<SessionOnboarding>());
+
+        await cubit.close();
+        await watcher.dispose();
+      },
+    );
+
+    test(
+      'changing missing list while denied refreshes the screen',
+      () async {
+        final watcher = _FakePermissionWatcher();
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          permissionWatcher: watcher,
+        );
+        await cubit.bootstrap();
+
+        watcher.push([AppPermission.microphone, AppPermission.bluetooth]);
+        await Future<void>.delayed(Duration.zero);
+        expect((cubit.state as SessionPermissionDenied).missing,
+            [AppPermission.microphone, AppPermission.bluetooth]);
+
+        // User re-grants mic but bluetooth still off.
+        watcher.push([AppPermission.bluetooth]);
+        await Future<void>.delayed(Duration.zero);
+        expect(cubit.state, isA<SessionPermissionDenied>());
+        expect((cubit.state as SessionPermissionDenied).missing,
+            [AppPermission.bluetooth]);
+
+        await cubit.close();
+        await watcher.dispose();
+      },
+    );
+
+    test(
+      'recheckPermissions delegates to the watcher',
+      () async {
+        final watcher = _FakePermissionWatcher();
+        final cubit = _makeCubit(permissionWatcher: watcher);
+        await cubit.bootstrap();
+
+        await cubit.recheckPermissions();
+        expect(watcher.checkNowCalls, 1);
+
+        await cubit.close();
+        await watcher.dispose();
+      },
+    );
+
+    test(
+      'recheckPermissions is a no-op when no watcher is wired',
+      () async {
+        final cubit = _makeCubit();
+        await cubit.bootstrap();
+        await expectLater(cubit.recheckPermissions(), completes);
+        await cubit.close();
+      },
+    );
   });
 
   group('FrequencySessionState', () {

--- a/test/screens/frequency_permission_denied_screen_test.dart
+++ b/test/screens/frequency_permission_denied_screen_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/screens/frequency_permission_denied_screen.dart';
+import 'package:walkie_talkie/services/permission_watcher.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: AppTheme.light(),
+    home: child,
+  );
+}
+
+void main() {
+  group('FrequencyPermissionDeniedScreen', () {
+    testWidgets('renders both denied perms when both are missing',
+        (tester) async {
+      await tester.pumpWidget(_wrap(FrequencyPermissionDeniedScreen(
+        missing: const [AppPermission.microphone, AppPermission.bluetooth],
+        onOpenSettings: () async {},
+        onRetry: () async {},
+      )));
+
+      expect(find.text('Permissions revoked'), findsOneWidget);
+      expect(find.text('Microphone'), findsOneWidget);
+      expect(find.text('Bluetooth nearby devices'), findsOneWidget);
+      // Both rows show the "blocked" hint.
+      expect(
+        find.text('Blocked — re-enable in system settings'),
+        findsNWidgets(2),
+      );
+      expect(find.text('Open settings'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+    });
+
+    testWidgets('shows mic-only copy when only microphone is denied',
+        (tester) async {
+      await tester.pumpWidget(_wrap(FrequencyPermissionDeniedScreen(
+        missing: const [AppPermission.microphone],
+        onOpenSettings: () async {},
+        onRetry: () async {},
+      )));
+      expect(find.text('Microphone'), findsOneWidget);
+      expect(find.text('Bluetooth nearby devices'), findsNothing);
+      expect(
+        find.textContaining('needs the microphone'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows bluetooth-only copy when only bluetooth is denied',
+        (tester) async {
+      await tester.pumpWidget(_wrap(FrequencyPermissionDeniedScreen(
+        missing: const [AppPermission.bluetooth],
+        onOpenSettings: () async {},
+        onRetry: () async {},
+      )));
+      expect(find.text('Bluetooth nearby devices'), findsOneWidget);
+      expect(find.text('Microphone'), findsNothing);
+      expect(
+        find.textContaining('needs Bluetooth'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('Open settings button invokes the callback', (tester) async {
+      var openCalls = 0;
+      await tester.pumpWidget(_wrap(FrequencyPermissionDeniedScreen(
+        missing: const [AppPermission.microphone],
+        onOpenSettings: () async {
+          openCalls++;
+        },
+        onRetry: () async {},
+      )));
+
+      await tester.tap(find.text('Open settings'));
+      await tester.pump();
+      expect(openCalls, 1);
+    });
+
+    testWidgets('Retry button invokes the callback', (tester) async {
+      var retryCalls = 0;
+      await tester.pumpWidget(_wrap(FrequencyPermissionDeniedScreen(
+        missing: const [AppPermission.microphone],
+        onOpenSettings: () async {},
+        onRetry: () async {
+          retryCalls++;
+        },
+      )));
+
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+      expect(retryCalls, 1);
+    });
+  });
+}

--- a/test/services/permission_watcher_test.dart
+++ b/test/services/permission_watcher_test.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/permission_watcher.dart';
+
+/// MethodChannel handler for `permission_handler`. The plugin uses
+/// `flutter.baseflow.com/permissions/methods` for queries; we reduce it to
+/// the two calls our watcher makes — `checkPermissionStatus` (used by
+/// `Permission.X.status`) and `requestPermissions` (unused here, but stubbed
+/// to avoid `MissingPluginException` if a future contributor adds a request
+/// path inside the watcher and forgets to mock it).
+///
+/// `permission_handler`'s [PermissionStatus] is encoded as an int across the
+/// MethodChannel in the order the enum is declared. The IDs we care about
+/// here:
+///   * `denied` = 0
+///   * `granted` = 1
+///   * `permanentlyDenied` = 4
+///
+/// These haven't moved across major versions (and the package is pinned in
+/// pubspec). If the plugin ever reorders them, the watcher tests will start
+/// failing fast — far better than the alternative (silent regression).
+class _FakePermissions {
+  /// Status to return per [Permission] integer code (see
+  /// `permission_handler_platform_interface`'s `Permission.byValue`):
+  ///   * 7  = microphone
+  ///   * 28 = bluetoothScan
+  ///   * 29 = bluetoothAdvertise
+  ///   * 30 = bluetoothConnect
+  final Map<int, int> statusByPermission;
+
+  /// MethodChannel call counter so tests can assert "watcher polled twice".
+  int checkCalls = 0;
+
+  _FakePermissions(this.statusByPermission);
+
+  Future<dynamic> handle(MethodCall call) async {
+    switch (call.method) {
+      case 'checkPermissionStatus':
+        checkCalls++;
+        final code = call.arguments as int;
+        return statusByPermission[code] ?? 0;
+      case 'requestPermissions':
+        // Not exercised by the watcher today; return granted for safety.
+        final List<int> codes = (call.arguments as List).cast<int>();
+        return {for (final c in codes) c: 1};
+      default:
+        return null;
+    }
+  }
+}
+
+const _kMicrophone = 7;
+const _kBluetoothScan = 28;
+const _kBluetoothAdvertise = 29;
+const _kBluetoothConnect = 30;
+
+const _kDenied = 0;
+const _kGranted = 1;
+
+void _setHandler(_FakePermissions perms) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel('flutter.baseflow.com/permissions/methods'),
+    perms.handle,
+  );
+}
+
+void _clearHandler() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel('flutter.baseflow.com/permissions/methods'),
+    null,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DefaultPermissionWatcher', () {
+    tearDown(_clearHandler);
+
+    test('emits empty list when all permissions granted', () async {
+      final perms = _FakePermissions({
+        _kMicrophone: _kGranted,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      });
+      _setHandler(perms);
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      final firstEvent = await watcher.watch().first;
+      expect(firstEvent, isEmpty);
+    });
+
+    test('emits microphone when microphone is denied', () async {
+      _setHandler(_FakePermissions({
+        _kMicrophone: _kDenied,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      }));
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      final event = await watcher.watch().first;
+      expect(event, [AppPermission.microphone]);
+    });
+
+    test('emits bluetooth when any of the three BT perms is denied',
+        () async {
+      _setHandler(_FakePermissions({
+        _kMicrophone: _kGranted,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kDenied, // only one denied
+        _kBluetoothAdvertise: _kGranted,
+      }));
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      final event = await watcher.watch().first;
+      expect(event, [AppPermission.bluetooth]);
+    });
+
+    test('emits both in order when both are denied', () async {
+      _setHandler(_FakePermissions({
+        _kMicrophone: _kDenied,
+        _kBluetoothScan: _kDenied,
+        _kBluetoothConnect: _kDenied,
+        _kBluetoothAdvertise: _kDenied,
+      }));
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      final event = await watcher.watch().first;
+      expect(event, [AppPermission.microphone, AppPermission.bluetooth]);
+    });
+
+    test('checkNow reflects an updated platform answer', () async {
+      final perms = _FakePermissions({
+        _kMicrophone: _kGranted,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      });
+      _setHandler(perms);
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      // Initial: all granted. Take the first stream event as an explicit
+      // signal that the kickoff sample completed; raw microtask flushes
+      // were flaky on slower CI workers (the platform-channel mock takes
+      // a few microtasks per call to round-trip).
+      final events = <List<AppPermission>>[];
+      final sub = watcher.watch().listen(events.add);
+      await watcher.watch().first;
+      expect(events, [const <AppPermission>[]]);
+
+      // Flip the mic to denied and trigger an immediate re-check.
+      perms.statusByPermission[_kMicrophone] = _kDenied;
+      final missing = await watcher.checkNow();
+      expect(missing, [AppPermission.microphone]);
+      // The new sample should also have been pushed through the stream.
+      // Broadcast-stream listeners fire on a later microtask than the
+      // [_controller.add] call inside `_sampleAndEmit`; yield once so the
+      // second emit lands in `events` before we read its last element.
+      await Future<void>.delayed(Duration.zero);
+      expect(events.last, [AppPermission.microphone]);
+
+      await sub.cancel();
+    });
+
+    test('does not re-emit when the missing set is unchanged', () async {
+      final perms = _FakePermissions({
+        _kMicrophone: _kDenied,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      });
+      _setHandler(perms);
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      final events = <List<AppPermission>>[];
+      final sub = watcher.watch().listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(events, [
+        [AppPermission.microphone],
+      ]);
+
+      // Same answer — should not fire a duplicate event.
+      await watcher.checkNow();
+      await Future<void>.delayed(Duration.zero);
+      expect(events, [
+        [AppPermission.microphone],
+      ]);
+
+      await sub.cancel();
+    });
+
+    test('lifecycle resume triggers an immediate re-check', () async {
+      final perms = _FakePermissions({
+        _kMicrophone: _kGranted,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      });
+      _setHandler(perms);
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      final events = <List<AppPermission>>[];
+      final sub = watcher.watch().listen(events.add);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      final initialCalls = perms.checkCalls;
+      expect(initialCalls, greaterThan(0));
+
+      // Flip a permission and synthesize a resume — the watcher must
+      // re-sample on resume rather than waiting for the 5 s tick.
+      perms.statusByPermission[_kMicrophone] = _kDenied;
+      watcher.didChangeAppLifecycleState(AppLifecycleState.resumed);
+
+      // Allow the awaited platform calls to land.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(perms.checkCalls, greaterThan(initialCalls));
+      expect(events.last, [AppPermission.microphone]);
+
+      await sub.cancel();
+    });
+
+    test('checkNow throws after dispose', () async {
+      _setHandler(_FakePermissions({
+        _kMicrophone: _kGranted,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      }));
+
+      final watcher = DefaultPermissionWatcher();
+      await watcher.dispose();
+      expect(
+        () => watcher.checkNow(),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('dispose is idempotent', () async {
+      _setHandler(_FakePermissions({
+        _kMicrophone: _kGranted,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      }));
+
+      final watcher = DefaultPermissionWatcher();
+      await watcher.dispose();
+      await watcher.dispose(); // must not throw
+    });
+
+    test('platform error during check does not crash the stream', () async {
+      // Handler that throws — simulate a malformed platform response.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('flutter.baseflow.com/permissions/methods'),
+        (MethodCall call) async {
+          throw PlatformException(code: 'boom');
+        },
+      );
+
+      final watcher = DefaultPermissionWatcher();
+      addTearDown(watcher.dispose);
+
+      // Even though the platform throws, watch() should not error out;
+      // the watcher logs and stays subscribed.
+      final stream = watcher.watch();
+      bool sawError = false;
+      final sub = stream.listen((_) {}, onError: (_) {
+        sawError = true;
+      });
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(sawError, isFalse);
+      await sub.cancel();
+    });
+  });
+}

--- a/test/services/permission_watcher_test.dart
+++ b/test/services/permission_watcher_test.dart
@@ -315,6 +315,22 @@ void main() {
       },
     );
 
+    test('watch() throws after dispose', () async {
+      _setHandler(_FakePermissions({
+        _kMicrophone: _kGranted,
+        _kBluetoothScan: _kGranted,
+        _kBluetoothConnect: _kGranted,
+        _kBluetoothAdvertise: _kGranted,
+      }));
+
+      final watcher = DefaultPermissionWatcher();
+      await watcher.dispose();
+      expect(
+        () => watcher.watch(),
+        throwsA(isA<StateError>()),
+      );
+    });
+
     test('checkNow throws after dispose', () async {
       _setHandler(_FakePermissions({
         _kMicrophone: _kGranted,

--- a/test/services/permission_watcher_test.dart
+++ b/test/services/permission_watcher_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -241,6 +243,77 @@ void main() {
 
       await sub.cancel();
     });
+
+    test(
+      'a slow background sample does not overwrite a newer checkNow result',
+      () async {
+        // Reproduces the race CodeRabbit flagged on PR #85: a background
+        // tick that started first finishes last. Without generation tagging
+        // its stale read would overwrite the newer Retry sample, yanking
+        // the UI back to the prior state and bouncing the user.
+        final perms = _FakePermissions({
+          _kMicrophone: _kDenied,
+          _kBluetoothScan: _kGranted,
+          _kBluetoothConnect: _kGranted,
+          _kBluetoothAdvertise: _kGranted,
+        });
+
+        // Only the very first platform call blocks; everything after it
+        // returns immediately. That wedges the kickoff (background) sample
+        // partway through its reads while the subsequent checkNow sample
+        // can run to completion against the freshly-granted map.
+        final firstCallGate = Completer<void>();
+        var consumedGate = false;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('flutter.baseflow.com/permissions/methods'),
+          (MethodCall call) async {
+            if (call.method != 'checkPermissionStatus') return null;
+            final code = call.arguments as int;
+            if (!consumedGate) {
+              consumedGate = true;
+              await firstCallGate.future;
+            }
+            return perms.statusByPermission[code] ?? 0;
+          },
+        );
+
+        final watcher = DefaultPermissionWatcher();
+        addTearDown(watcher.dispose);
+
+        final events = <List<AppPermission>>[];
+        final sub = watcher.watch().listen(events.add);
+        // Flush microtasks so the kickoff sample queues its first read
+        // and gets wedged on the gate.
+        for (var i = 0; i < 3; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        expect(events, isEmpty);
+
+        // Flip the answer to all-granted and run checkNow. Sample 2 goes
+        // through the unblocked handler and returns [].
+        perms.statusByPermission[_kMicrophone] = _kGranted;
+        final fresh = await watcher.checkNow();
+        expect(fresh, isEmpty);
+        await Future<void>.delayed(Duration.zero);
+        expect(events.last, isEmpty);
+
+        // Flip the answer back to denied right before releasing sample 1
+        // so its delayed read sees the stale value when it resumes —
+        // models "permissions changed underneath a slow read."
+        perms.statusByPermission[_kMicrophone] = _kDenied;
+        firstCallGate.complete();
+        for (var i = 0; i < 6; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        // Sample 1 (gen=1) is older than sample 2 (gen=2). Its emit must
+        // be suppressed even though it observed a [microphone]-denied
+        // reading — the newer sample's empty reading stands.
+        expect(events.last, isEmpty);
+
+        await sub.cancel();
+      },
+    );
 
     test('checkNow throws after dispose', () async {
       _setHandler(_FakePermissions({

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'package:walkie_talkie/main.dart';
 import 'package:walkie_talkie/protocol/discovery.dart';
 import 'package:walkie_talkie/services/bluetooth_discovery_service.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
+import 'package:walkie_talkie/services/permission_watcher.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 
 class _FakeIdentityStore implements IdentityStore {
@@ -67,12 +68,29 @@ class _FakeDiscoveryService implements DiscoveryService {
   Future<void> dispose() async {}
 }
 
+/// No-op watcher for widget tests. The production [DefaultPermissionWatcher]
+/// starts a [Timer.periodic] when the cubit subscribes, which trips Flutter's
+/// "A Timer is still pending after the widget tree was disposed" assertion
+/// at the end of the test. The fake's stream is empty, so the cubit's
+/// permission listener never fires and no transitions race the test.
+class _FakePermissionWatcher implements PermissionWatcher {
+  @override
+  Stream<List<AppPermission>> watch() => const Stream.empty();
+
+  @override
+  Future<List<AppPermission>> checkNow() async => const [];
+
+  @override
+  Future<void> dispose() async {}
+}
+
 void main() {
   testWidgets('first launch routes through onboarding', (tester) async {
     await tester.pumpWidget(WalkieTalkieApp(
       identityStore: _FakeIdentityStore(),
       recentFrequenciesStore: _FakeRecentFrequenciesStore(),
       discoveryService: _FakeDiscoveryService(),
+      permissionWatcher: _FakePermissionWatcher(),
     ));
     // Boot splash → microtask flush → onboarding welcome.
     await tester.pump();
@@ -90,6 +108,7 @@ void main() {
           identityStore: _FakeIdentityStore(initial: 'Maya'),
           recentFrequenciesStore: _FakeRecentFrequenciesStore(),
           discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: _FakePermissionWatcher(),
         ),
       );
       // Two frames: boot splash, then Discovery after the bootstrap setState.
@@ -113,6 +132,7 @@ void main() {
           recentFrequenciesStore:
               _FakeRecentFrequenciesStore(initial: const ['100.1', '92.4']),
           discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: _FakePermissionWatcher(),
         ),
       );
       // bootstrap awaits two reads (display name, recent frequencies); pump


### PR DESCRIPTION
## Summary

Closes #57.

Subscribe to a runtime permission watcher and route the cubit to a new `SessionPermissionDenied` stage when the user revokes Microphone or Bluetooth from system Settings while the app is running. Tears down voice + BLE state on revoke (mirrors `leaveRoom` cleanup) so the next OS callback can't fault on a missing permission, and recovers back to Discovery — or Onboarding for a fresh install — once everything is re-granted.

- New `AppPermission` enum + `PermissionWatcher` abstraction. `microphone` is one bucket; the three Android Bluetooth runtime perms collapse into a single `bluetooth` bucket (matches the system-Settings UX).
- `DefaultPermissionWatcher` polls on app resume (`WidgetsBindingObserver`) and every 5 s while foregrounded. Background ticks drop on overlap; the user-driven `checkNow` path always reflects a fresh sample.
- New `SessionPermissionDenied` state carries the missing list + the display name so recovery can route back to Discovery without re-reading the identity store.
- Cubit's revocation handler is role-aware: it leaves Onboarding alone (that screen owns its own permission flow) and only tears down BLE state when a Discovery / Room transition is required.
- New `FrequencyPermissionDeniedScreen` explains the missing perms and offers **Open settings** + **Retry**. Retry calls `cubit.recheckPermissions` so the user gets snappy feedback instead of waiting up to 5 s.
- `main.dart` wires the watcher as a `RepositoryProvider` for app lifetime.

## What this PR does NOT do

The issue's *Files* section lists native edits (Oboe error callback, BLE `onConnectionStateChange` with `GATT_INSUFFICIENT_AUTHORIZATION` → emit `permissionRevoked` event). Those land with the foreground-service / GATT issues that produce the events — the events have nowhere to be wired up yet. Until then the watcher's lifecycle resume + 5 s poll covers the user-facing case from the issue's acceptance criteria.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 341 passing, 1 pre-existing skip
- [x] New tests cover the watcher (emit / dedupe / lifecycle / dispose), all six revocation transitions on the cubit (Discovery/Room → denied, denied → Discovery/Onboarding, mid-denied refresh, ignore-on-Onboarding, `recheckPermissions` delegation/no-op), and the screen's copy-switching by missing-perm subset.
- [ ] Manual smoke test on a real device once the native event hooks land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime monitoring of microphone and Bluetooth permissions with immediate re-check on app start
  * New permission-denied screen explaining missing permissions and offering "Open settings" and "Retry"
  * App now stops voice/Bluetooth activity and surfaces the denied screen when permissions are revoked

* **Tests**
  * Comprehensive tests for permission monitoring, denial/recovery flows, denied-screen UI, and watcher lifecycle behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->