### PR TITLE
feat(#49): per-peer voice-frame seq tracking with stuck-producer prune

### DIFF
--- a/android/app/src/main/cpp/audio_mixer.cpp
+++ b/android/app/src/main/cpp/audio_mixer.cpp
@@ -4,6 +4,7 @@
 
 #define LOG_TAG "AudioMixer"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
+#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
 
 // Constructor (if needed - add to header too)
 AudioMixer::AudioMixer() {
@@ -48,12 +49,65 @@ void AudioMixer::updateDeviceAudio(int deviceId, const int16_t* audioData, int n
 
     if (device) {
         // Lock-free write to ring buffer
-        size_t written = device->ringBuffer.write(audioData, numFrames);
-        if (written < numFrames) {
+        size_t written = device->ringBuffer.write(audioData, static_cast<size_t>(numFrames));
+        if (written < static_cast<size_t>(numFrames)) {
             // Buffer full or near-full (normal during startup or if mixer tick is slow)
             // Don't log on every occurrence to avoid spam
         }
     }
+}
+
+void AudioMixer::onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, int numFrames) {
+    std::shared_ptr<DeviceAudioBuffer> device;
+    {
+        std::lock_guard<std::mutex> lock(deviceRegistryMutex);
+        auto it = devices.find(deviceId);
+        if (it != devices.end()) {
+            device = it->second;
+        }
+    }
+    if (!device) {
+        return;
+    }
+
+    const uint32_t prevSeq = device->lastSeq;
+
+    // Stuck-producer prune. `prevSeq == 0` means we have not seen any frame
+    // yet, so the first frame always passes regardless of value (the protocol
+    // says peers start at seq=1, but a fresh-session reset can land much later
+    // — see [docs/protocol.md] § Voice frame format).
+    if (prevSeq != 0 && seq > prevSeq + kPoisonThreshold) {
+        if (!device->poisoned.exchange(true, std::memory_order_relaxed)) {
+            LOGW("Device %d poisoned: seq jump %u -> %u (gap %u > %u)",
+                 deviceId, prevSeq, seq, seq - prevSeq, kPoisonThreshold);
+        }
+        // Update lastSeq so the *next* contiguous frame can recover. Drop the
+        // current frame's audio: we don't trust it, and the ring buffer's
+        // SPSC contract forbids producer-side `clear()` while the mixer-tick
+        // consumer is reading. Any in-flight buffered samples will drain
+        // naturally over the next mixer tick.
+        device->lastSeq = seq;
+        return;
+    }
+
+    if (device->poisoned.exchange(false, std::memory_order_relaxed)) {
+        LOGI("Device %d recovered at seq %u (prevSeq %u)", deviceId, seq, prevSeq);
+    }
+
+    device->ringBuffer.write(pcm, static_cast<size_t>(numFrames));
+    device->lastSeq = seq;
+}
+
+bool AudioMixer::isPoisoned(int deviceId) {
+    std::shared_ptr<DeviceAudioBuffer> device;
+    {
+        std::lock_guard<std::mutex> lock(deviceRegistryMutex);
+        auto it = devices.find(deviceId);
+        if (it != devices.end()) {
+            device = it->second;
+        }
+    }
+    return device && device->poisoned.load(std::memory_order_relaxed);
 }
 
 void AudioMixer::getMixedAudioForDevice(int deviceId, int16_t* outputBuffer, int numFrames) {

--- a/android/app/src/main/cpp/audio_mixer.cpp
+++ b/android/app/src/main/cpp/audio_mixer.cpp
@@ -72,22 +72,41 @@ void AudioMixer::onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, in
 
     const uint32_t prevSeq = device->lastSeq;
 
-    // Stuck-producer prune. `prevSeq == 0` means we have not seen any frame
-    // yet, so the first frame always passes regardless of value (the protocol
-    // says peers start at seq=1, but a fresh-session reset can land much later
-    // — see [docs/protocol.md] § Voice frame format).
-    if (prevSeq != 0 && seq > prevSeq + kPoisonThreshold) {
-        if (!device->poisoned.exchange(true, std::memory_order_relaxed)) {
-            LOGW("Device %d poisoned: seq jump %u -> %u (gap %u > %u)",
-                 deviceId, prevSeq, seq, seq - prevSeq, kPoisonThreshold);
+    // First frame from this peer (`prevSeq == 0` since seq starts at 1 per
+    // the protocol) always passes regardless of value: a fresh-session reset
+    // can land at any high seq, and the GATT join handshake bounds when the
+    // first frame is allowed to arrive.
+    if (prevSeq != 0) {
+        // Wrap-safe forward delta: cast the unsigned subtraction to int32_t.
+        // - diff > 0 and small  → in-order, normal flow
+        // - diff > kPoisonThreshold → big forward jump, poison
+        // - diff <= 0 → out-of-order or duplicate (older seq, or same seq)
+        //
+        // Using signed int32 here is what makes the comparison wrap-safe:
+        // near uint32 rollover the unsigned `prevSeq + 16` would overflow,
+        // but `static_cast<int32_t>(seq - prevSeq)` is the modular distance
+        // interpreted as signed, which is correct for any pair within ±2^31.
+        const int32_t diff = static_cast<int32_t>(seq - prevSeq);
+
+        if (diff <= 0) {
+            // Out-of-order or duplicate. Don't poison, don't write, don't
+            // touch lastSeq — the existing watermark stays authoritative.
+            return;
         }
-        // Update lastSeq so the *next* contiguous frame can recover. Drop the
-        // current frame's audio: we don't trust it, and the ring buffer's
-        // SPSC contract forbids producer-side `clear()` while the mixer-tick
-        // consumer is reading. Any in-flight buffered samples will drain
-        // naturally over the next mixer tick.
-        device->lastSeq = seq;
-        return;
+
+        if (diff > static_cast<int32_t>(kPoisonThreshold)) {
+            if (!device->poisoned.exchange(true, std::memory_order_relaxed)) {
+                LOGW("Device %d poisoned: seq jump %u -> %u (gap %d > %u)",
+                     deviceId, prevSeq, seq, diff, kPoisonThreshold);
+            }
+            // Advance lastSeq so the next valid frame within the threshold
+            // recovers. Drop the current frame's audio: we don't trust it,
+            // and the ring buffer's SPSC contract forbids producer-side
+            // `clear()` while the mixer-tick consumer is reading. Any
+            // in-flight buffered samples drain naturally over the next tick.
+            device->lastSeq = seq;
+            return;
+        }
     }
 
     if (device->poisoned.exchange(false, std::memory_order_relaxed)) {

--- a/android/app/src/main/cpp/audio_mixer.cpp
+++ b/android/app/src/main/cpp/audio_mixer.cpp
@@ -72,11 +72,13 @@ void AudioMixer::onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, in
 
     const uint32_t prevSeq = device->lastSeq;
 
-    // First frame from this peer (`prevSeq == 0` since seq starts at 1 per
-    // the protocol) always passes regardless of value: a fresh-session reset
-    // can land at any high seq, and the GATT join handshake bounds when the
-    // first frame is allowed to arrive.
-    if (prevSeq != 0) {
+    // First frame from this peer always passes regardless of value: a
+    // fresh-session reset can land at any high seq, and the GATT join
+    // handshake bounds when the first frame is allowed to arrive. We use a
+    // dedicated `hasSeenSeq` flag rather than `prevSeq != 0` because seq is
+    // uint32 and a legitimate wrap to 0 must not look like "unseen" to the
+    // next frame.
+    if (device->hasSeenSeq) {
         // Wrap-safe forward delta: cast the unsigned subtraction to int32_t.
         // - diff > 0 and small  → in-order, normal flow
         // - diff > kPoisonThreshold → big forward jump, poison
@@ -105,6 +107,7 @@ void AudioMixer::onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, in
             // `clear()` while the mixer-tick consumer is reading. Any
             // in-flight buffered samples drain naturally over the next tick.
             device->lastSeq = seq;
+            // hasSeenSeq is already true here (we're inside the `if`).
             return;
         }
     }
@@ -115,6 +118,7 @@ void AudioMixer::onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, in
 
     device->ringBuffer.write(pcm, static_cast<size_t>(numFrames));
     device->lastSeq = seq;
+    device->hasSeenSeq = true;
 }
 
 bool AudioMixer::isPoisoned(int deviceId) {

--- a/android/app/src/main/cpp/audio_mixer.cpp
+++ b/android/app/src/main/cpp/audio_mixer.cpp
@@ -116,7 +116,12 @@ void AudioMixer::onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, in
         LOGI("Device %d recovered at seq %u (prevSeq %u)", deviceId, seq, prevSeq);
     }
 
-    device->ringBuffer.write(pcm, static_cast<size_t>(numFrames));
+    size_t written = device->ringBuffer.write(pcm, static_cast<size_t>(numFrames));
+    if (written < static_cast<size_t>(numFrames)) {
+        // Buffer full or near-full (normal during startup or if mixer tick is slow).
+        // Mirrors the same don't-spam-the-log policy as updateDeviceAudio above —
+        // the seq is still accepted for tracking; only the trailing PCM is dropped.
+    }
     device->lastSeq = seq;
     device->hasSeenSeq = true;
 }

--- a/android/app/src/main/cpp/audio_mixer.h
+++ b/android/app/src/main/cpp/audio_mixer.h
@@ -10,10 +10,17 @@
 #include <algorithm>
 #include "ring_buffer.h"
 
-// Per-device audio buffer with lock-free ring buffer for real-time safety
+// Per-device audio buffer with lock-free ring buffer for real-time safety.
+//
+// `lastSeq` and `poisoned` track the per-peer voice-frame stream so a stuck
+// or wildly-skipping producer cannot poison the mix. Both fields are touched
+// from the L2CAP receive thread (single producer per device); mixer tick reads
+// `poisoned` only for telemetry/diagnostics, hence atomic on `poisoned` but a
+// plain `uint32_t` on `lastSeq`.
 struct DeviceAudioBuffer {
     AudioRingBuffer ringBuffer;
-    std::atomic<bool> active{true};  // Flag for stuck-producer detection (future use)
+    std::atomic<bool> poisoned{false};   // true while producer is being skipped
+    uint32_t lastSeq{0};                 // 0 = no frames seen yet
 };
 
 class AudioMixer {
@@ -30,6 +37,12 @@ private:
     static constexpr int kMaxFrames = 1024;  // Max frames for tempMixBuffer
 
 public:
+    // Stuck-producer prune threshold. A frame whose seq exceeds the previously
+    // accepted seq by more than this many positions is dropped and the peer is
+    // marked poisoned until a contiguous seq arrives. Matches the protocol
+    // spec ("after 16 missed sequence numbers ... stops mixing that peer").
+    static constexpr uint32_t kPoisonThreshold = 16;
+
     AudioMixer();
 
     // Add a device (peer) to the mixer. Returns true on success.
@@ -38,9 +51,23 @@ public:
     // Remove a device from the mixer
     void removeDevice(int deviceId);
 
-    // Update audio data for a device (called from L2CAP receive or mic capture).
+    // Update audio data for a device (called from local mic path).
     // Lock-free: writes to the device's ring buffer without blocking.
+    // Used for the local-mic device (id 0) which has no over-the-wire seq.
     void updateDeviceAudio(int deviceId, const int16_t* audioData, int numFrames);
+
+    // Feed a peer-arrived voice frame (with its over-the-wire seq) into the
+    // mixer. Implements the stuck-producer prune: if [seq] exceeds the last
+    // accepted seq by more than [kPoisonThreshold], the frame is dropped and
+    // the peer is marked poisoned; the next contiguous frame recovers.
+    // Lock-free for the audio path; the registry mutex is taken only briefly
+    // to look up the device.
+    void onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, int numFrames);
+
+    // Returns true if the device is currently being skipped due to a recent
+    // big seq gap. Returns false for unknown deviceIds. Intended for tests
+    // and diagnostics.
+    bool isPoisoned(int deviceId);
 
     // Get mixed audio for a specific device (mix-minus: all others except this device).
     // Lock-free: reads from ring buffers without blocking.

--- a/android/app/src/main/cpp/audio_mixer.h
+++ b/android/app/src/main/cpp/audio_mixer.h
@@ -57,9 +57,20 @@ public:
     void updateDeviceAudio(int deviceId, const int16_t* audioData, int numFrames);
 
     // Feed a peer-arrived voice frame (with its over-the-wire seq) into the
-    // mixer. Implements the stuck-producer prune: if [seq] exceeds the last
-    // accepted seq by more than [kPoisonThreshold], the frame is dropped and
-    // the peer is marked poisoned; the next contiguous frame recovers.
+    // mixer. Implements the stuck-producer prune from
+    // [docs/protocol.md] § Voice frame format:
+    //
+    //  - Forward delta > [kPoisonThreshold]: poison the peer, drop the frame,
+    //    advance the watermark to [seq] so the next within-threshold frame
+    //    recovers.
+    //  - Forward delta in (0, kPoisonThreshold]: accept, mix, clear poison
+    //    if it was set.
+    //  - Delta <= 0 (out-of-order or duplicate): silently drop without
+    //    touching the watermark or the poison flag.
+    //
+    // Comparison uses a wrap-safe int32 delta so the rule holds across the
+    // uint32 [seq] rollover at 2^32.
+    //
     // Lock-free for the audio path; the registry mutex is taken only briefly
     // to look up the device.
     void onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, int numFrames);

--- a/android/app/src/main/cpp/audio_mixer.h
+++ b/android/app/src/main/cpp/audio_mixer.h
@@ -12,15 +12,20 @@
 
 // Per-device audio buffer with lock-free ring buffer for real-time safety.
 //
-// `lastSeq` and `poisoned` track the per-peer voice-frame stream so a stuck
-// or wildly-skipping producer cannot poison the mix. Both fields are touched
-// from the L2CAP receive thread (single producer per device); mixer tick reads
-// `poisoned` only for telemetry/diagnostics, hence atomic on `poisoned` but a
-// plain `uint32_t` on `lastSeq`.
+// `hasSeenSeq` / `lastSeq` / `poisoned` track the per-peer voice-frame stream
+// so a stuck or wildly-skipping producer cannot poison the mix. The seq
+// fields are touched from the L2CAP receive thread (single producer per
+// device); mixer tick reads `poisoned` only for telemetry/diagnostics, hence
+// atomic on `poisoned` but plain on `lastSeq` / `hasSeenSeq`.
+//
+// `hasSeenSeq` is a separate flag rather than `lastSeq != 0` because seq is
+// uint32 and wraps: after a legitimate wrap to seq=0, that 0 is a valid
+// watermark that must still gate subsequent delta checks.
 struct DeviceAudioBuffer {
     AudioRingBuffer ringBuffer;
     std::atomic<bool> poisoned{false};   // true while producer is being skipped
-    uint32_t lastSeq{0};                 // 0 = no frames seen yet
+    bool hasSeenSeq{false};              // false until the first frame arrives
+    uint32_t lastSeq{0};                 // last accepted (or poison-advanced) seq
 };
 
 class AudioMixer {
@@ -37,10 +42,13 @@ private:
     static constexpr int kMaxFrames = 1024;  // Max frames for tempMixBuffer
 
 public:
-    // Stuck-producer prune threshold. A frame whose seq exceeds the previously
-    // accepted seq by more than this many positions is dropped and the peer is
-    // marked poisoned until a contiguous seq arrives. Matches the protocol
-    // spec ("after 16 missed sequence numbers ... stops mixing that peer").
+    // Stuck-producer prune threshold. A frame whose forward delta from the
+    // last accepted seq exceeds this value is dropped and the peer is marked
+    // poisoned. Recovery happens on the next frame whose forward delta from
+    // the (poison-advanced) watermark falls in (0, kPoisonThreshold] — see
+    // the [onVoiceFrame] contract below for the full state machine. Matches
+    // the protocol spec ("after 16 missed sequence numbers ... stops mixing
+    // that peer's stream until the next valid frame arrives").
     static constexpr uint32_t kPoisonThreshold = 16;
 
     AudioMixer();

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -342,10 +342,13 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeClear(JNIEnv *env, jobject
     }
 }
 
-// Method for receiving Opus frames from peers and feeding to mixer
+// Method for receiving Opus frames from peers and feeding to mixer.
+// `seq` is the per-link uint32 from the VoiceFrame header; the mixer uses it
+// to detect stuck producers (issue #49). It arrives as a jlong so Kotlin can
+// hand the unsigned value over without sign-extension surprises.
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeOnVoiceFrameReceived(
-        JNIEnv *env, jobject thiz, jstring macAddress, jbyteArray opusData) {
+        JNIEnv *env, jobject thiz, jstring macAddress, jbyteArray opusData, jlong seq) {
     if (!g_peerAudioManager || !g_audioMixer) return;
 
     const char* mac = env->GetStringUTFChars(macAddress, nullptr);
@@ -384,8 +387,9 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeOnVoiceFrameReceived(
     env->ReleaseByteArrayElements(opusData, encodedBuffer, JNI_ABORT);
 
     if (numSamples > 0) {
-        // Feed to mixer
-        g_audioMixer->updateDeviceAudio(deviceId, pcmBuffer, numSamples);
+        // Route through onVoiceFrame so the per-peer seq tracker can prune a
+        // stuck producer before the data reaches the mix.
+        g_audioMixer->onVoiceFrame(deviceId, static_cast<uint32_t>(seq), pcmBuffer, numSamples);
     }
 }
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
@@ -53,12 +53,17 @@ class PeerAudioManager {
      * Hand a peer-arrived Opus frame to the native mixer along with its
      * per-link [seq] from the VoiceFrame header. Native uses [seq] to detect
      * a stuck or wildly-skipping producer (issue #49) and mute that peer's
-     * stream until a contiguous frame arrives.
+     * stream until a frame within the protocol's threshold of the last
+     * accepted seq arrives.
      *
      * [seq] is the protocol's uint32; passed as a [Long] so the unsigned
-     * value survives the JNI hop without sign extension.
+     * value survives the JNI hop without sign extension. We range-check it
+     * here so a malformed VoiceFrame parse can't sneak a sign-extended
+     * negative through to native, where it would silently truncate to a
+     * different valid uint32 and either spuriously poison or recover the peer.
      */
     fun onVoiceFrameReceived(macAddress: String, opusData: ByteArray, seq: Long) {
+        require(seq in 0..0xFFFF_FFFFL) { "seq must fit in uint32, got $seq" }
         nativeOnVoiceFrameReceived(macAddress, opusData, seq)
     }
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
@@ -49,8 +49,17 @@ class PeerAudioManager {
         nativeSetCallback(this)
     }
 
-    fun onVoiceFrameReceived(macAddress: String, opusData: ByteArray) {
-        nativeOnVoiceFrameReceived(macAddress, opusData)
+    /**
+     * Hand a peer-arrived Opus frame to the native mixer along with its
+     * per-link [seq] from the VoiceFrame header. Native uses [seq] to detect
+     * a stuck or wildly-skipping producer (issue #49) and mute that peer's
+     * stream until a contiguous frame arrives.
+     *
+     * [seq] is the protocol's uint32; passed as a [Long] so the unsigned
+     * value survives the JNI hop without sign extension.
+     */
+    fun onVoiceFrameReceived(macAddress: String, opusData: ByteArray, seq: Long) {
+        nativeOnVoiceFrameReceived(macAddress, opusData, seq)
     }
 
     fun clear() {
@@ -71,5 +80,5 @@ class PeerAudioManager {
     private external fun nativeStopMixerThread()
     private external fun nativeSetCallback(callback: Any)
     private external fun nativeClear()
-    private external fun nativeOnVoiceFrameReceived(macAddress: String, opusData: ByteArray)
+    private external fun nativeOnVoiceFrameReceived(macAddress: String, opusData: ByteArray, seq: Long)
 }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
@@ -61,9 +61,15 @@ class PeerAudioManager {
      * here so a malformed VoiceFrame parse can't sneak a sign-extended
      * negative through to native, where it would silently truncate to a
      * different valid uint32 and either spuriously poison or recover the peer.
+     * Out-of-range values are dropped (logged + return) rather than thrown:
+     * this is an over-the-wire input boundary, and one bad packet must not
+     * crash the foreground service.
      */
     fun onVoiceFrameReceived(macAddress: String, opusData: ByteArray, seq: Long) {
-        require(seq in 0..0xFFFF_FFFFL) { "seq must fit in uint32, got $seq" }
+        if (seq !in 0..0xFFFF_FFFFL) {
+            Log.w(TAG, "Dropping voice frame from $macAddress: seq=$seq is not a valid uint32")
+            return
+        }
         nativeOnVoiceFrameReceived(macAddress, opusData, seq)
     }
 

--- a/test/cpp/mixer_test.cpp
+++ b/test/cpp/mixer_test.cpp
@@ -27,7 +27,8 @@ private:
     struct DeviceState {
         std::vector<int16_t> buffer;
         bool poisoned = false;
-        uint32_t lastSeq = 0;  // 0 = no frames seen yet
+        bool hasSeenSeq = false;  // separate flag — wrap to seq=0 is legitimate
+        uint32_t lastSeq = 0;
     };
 
     std::mutex mixerMutex;
@@ -88,7 +89,7 @@ public:
         DeviceState& s = it->second;
 
         const uint32_t prevSeq = s.lastSeq;
-        if (prevSeq != 0) {
+        if (s.hasSeenSeq) {
             const int32_t diff = static_cast<int32_t>(seq - prevSeq);
 
             if (diff <= 0) {
@@ -114,6 +115,7 @@ public:
         }
         s.buffer.assign(pcm, pcm + numFrames);
         s.lastSeq = seq;
+        s.hasSeenSeq = true;
     }
 
     bool isPoisoned(int deviceId) {
@@ -446,12 +448,19 @@ void testSeqWraparoundIsWrapSafe() {
     mixer.onVoiceFrame(1, 0x0u, audio, kFrames);
     assert(!mixer.isPoisoned(1));
 
-    // Continue past the wrap: 0x0 → 0x5 is +5, normal.
-    mixer.onVoiceFrame(1, 0x5u, audio, kFrames);
+    // Regression test for the "lastSeq == 0 means unseen" bug CodeRabbit
+    // caught on round 2: after legitimately accepting seq=0 (the wrap), the
+    // next frame MUST still go through the delta check. With the old sentinel
+    // a +0x20 jump would silently bypass poison detection.
+    mixer.onVoiceFrame(1, 0x20u, audio, kFrames);  // 0 → 32, gap 32 > 16
+    assert(mixer.isPoisoned(1));
+
+    // Recovery within threshold of the new (post-poison) baseline of 0x20.
+    mixer.onVoiceFrame(1, 0x21u, audio, kFrames);
     assert(!mixer.isPoisoned(1));
 
-    // Now a real big forward jump near the boundary should still poison.
-    mixer.onVoiceFrame(1, 0x100u, audio, kFrames);  // +0xFB = 251
+    // And a real big forward jump still poisons.
+    mixer.onVoiceFrame(1, 0x200u, audio, kFrames);  // +0x1DF = 479
     assert(mixer.isPoisoned(1));
 
     std::cout << "Test Seq Wraparound Is Wrap-Safe: PASSED" << std::endl;

--- a/test/cpp/mixer_test.cpp
+++ b/test/cpp/mixer_test.cpp
@@ -72,9 +72,12 @@ public:
     }
 
     // Feed a peer-arrived voice frame with its over-the-wire seq. Mirrors the
-    // production stuck-producer prune: a frame whose seq exceeds the previously
-    // accepted seq by more than [kPoisonThreshold] is dropped and the peer is
-    // marked poisoned; the next contiguous frame recovers.
+    // production stuck-producer prune: a frame whose forward delta from the
+    // last accepted seq exceeds [kPoisonThreshold] is dropped and the peer is
+    // marked poisoned; the next valid frame within the threshold recovers.
+    // Out-of-order / duplicate frames (delta <= 0) are silently dropped without
+    // affecting the watermark or the poison flag. Wrap-safe via signed int32
+    // delta (matches production audio_mixer.cpp).
     void onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, int numFrames) {
         std::lock_guard<std::mutex> lock(mixerMutex);
 
@@ -85,14 +88,24 @@ public:
         DeviceState& s = it->second;
 
         const uint32_t prevSeq = s.lastSeq;
-        if (prevSeq != 0 && seq > prevSeq + kPoisonThreshold) {
-            s.poisoned = true;
-            // Update lastSeq so the next contiguous frame can recover. Drop the
-            // current frame's audio (do not write to s.buffer) — production
-            // also avoids clearing the in-flight ring buffer here (SPSC contract).
-            s.lastSeq = seq;
-            LOGI("Device %d poisoned: seq jump %u -> %u", deviceId, prevSeq, seq);
-            return;
+        if (prevSeq != 0) {
+            const int32_t diff = static_cast<int32_t>(seq - prevSeq);
+
+            if (diff <= 0) {
+                // Out-of-order or duplicate — silently drop.
+                return;
+            }
+
+            if (diff > static_cast<int32_t>(kPoisonThreshold)) {
+                s.poisoned = true;
+                // Advance lastSeq so the next within-threshold frame recovers.
+                // Drop the current frame's audio (do not write to s.buffer) —
+                // production also avoids clearing the in-flight ring buffer
+                // here (SPSC contract).
+                s.lastSeq = seq;
+                LOGI("Device %d poisoned: seq jump %u -> %u (gap %d)", deviceId, prevSeq, seq, diff);
+                return;
+            }
         }
 
         if (s.poisoned) {
@@ -342,6 +355,108 @@ void testFirstFrameAlwaysPasses() {
     std::cout << "Test First Frame Always Passes: PASSED" << std::endl;
 }
 
+// Out-of-order or duplicate frames (delta <= 0 against the watermark) must
+// be silently dropped: don't poison, don't update lastSeq, don't write audio.
+// Without this rule a late-arriving older frame would lower the watermark
+// and the *next* in-order frame would look like a giant jump and falsely
+// poison the peer.
+void testOutOfOrderDoesNotPoisonOrAdvance() {
+    AudioMixer mixer;
+    mixer.addDevice(1);
+
+    const int kFrames = 4;
+    int16_t audio[kFrames] = {500, 500, 500, 500};
+
+    mixer.onVoiceFrame(1, 1, audio, kFrames);
+    mixer.onVoiceFrame(1, 5, audio, kFrames);  // watermark = 5
+
+    // Late arrival of an older seq must not poison.
+    mixer.onVoiceFrame(1, 3, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // Exact duplicate of the watermark must not poison either.
+    mixer.onVoiceFrame(1, 5, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // The watermark must still be 5: a small forward jump (5 → 10) stays
+    // within threshold. If the OOO frame had lowered it to 3, then 3 → 10
+    // would still be within threshold — so prove the invariant a different
+    // way: 5 → 22 is exactly 17 ahead and MUST poison; if the OOO frame
+    // had lowered the watermark to 3, then 3 → 22 = 19 also poisons, so
+    // that's not discriminating. Use the duplicate path instead: jump from
+    // 5 by exactly kPoisonThreshold (= 16) → 21, which must NOT poison.
+    mixer.onVoiceFrame(1, 5 + AudioMixer::kPoisonThreshold, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    std::cout << "Test Out-of-Order Does Not Poison Or Advance: PASSED" << std::endl;
+}
+
+// Recovery rule per [docs/protocol.md] § Voice frame format: "stops mixing
+// that peer's stream until the next valid frame arrives." A valid frame is
+// any frame within kPoisonThreshold of the (advanced-on-poison) watermark —
+// it does NOT have to be strictly seq+1. A non-contiguous-but-within-threshold
+// frame after poisoning recovers the peer, and a frame that is *itself* a
+// big-jump keeps it poisoned. This test pins both behaviors.
+void testRecoveryAcceptsAnyWithinThresholdFrame() {
+    AudioMixer mixer;
+    mixer.addDevice(1);
+
+    const int kFrames = 4;
+    int16_t audio[kFrames] = {100, 100, 100, 100};
+
+    mixer.onVoiceFrame(1, 1, audio, kFrames);
+    mixer.onVoiceFrame(1, 2, audio, kFrames);
+
+    // Big jump: poison. Watermark advances to 20.
+    mixer.onVoiceFrame(1, 20, audio, kFrames);
+    assert(mixer.isPoisoned(1));
+
+    // Another big jump while poisoned (20 → 40, gap 20 > 16) must keep the
+    // peer poisoned and advance the watermark to 40.
+    mixer.onVoiceFrame(1, 40, audio, kFrames);
+    assert(mixer.isPoisoned(1));
+
+    // Non-contiguous-but-within-threshold frame (40 → 50, gap 10 ≤ 16) must
+    // recover. (The protocol's "next valid frame" rule, not "next contiguous".)
+    mixer.onVoiceFrame(1, 50, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    std::cout << "Test Recovery Accepts Any Within-Threshold Frame: PASSED" << std::endl;
+}
+
+// uint32 wraparound. Comparison MUST be wrap-safe: a small forward jump
+// across the rollover is normal flow, not a 4-billion-frame gap. Mirrors
+// the same fix in production audio_mixer.cpp.
+void testSeqWraparoundIsWrapSafe() {
+    AudioMixer mixer;
+    mixer.addDevice(1);
+
+    const int kFrames = 4;
+    int16_t audio[kFrames] = {100, 100, 100, 100};
+
+    // Seed near rollover.
+    mixer.onVoiceFrame(1, 0xFFFFFFF0u, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // Tiny forward jump straight across uint32 max: gap of 1, must NOT poison.
+    mixer.onVoiceFrame(1, 0xFFFFFFF1u, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // Wrap forward: 0xFFFFFFF1 → 0x0 is exactly +15 modular, within threshold.
+    mixer.onVoiceFrame(1, 0x0u, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // Continue past the wrap: 0x0 → 0x5 is +5, normal.
+    mixer.onVoiceFrame(1, 0x5u, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // Now a real big forward jump near the boundary should still poison.
+    mixer.onVoiceFrame(1, 0x100u, audio, kFrames);  // +0xFB = 251
+    assert(mixer.isPoisoned(1));
+
+    std::cout << "Test Seq Wraparound Is Wrap-Safe: PASSED" << std::endl;
+}
+
 int main() {
     try {
         testMixMinus();
@@ -351,6 +466,9 @@ int main() {
         testPoisonThresholdBoundary();
         testPoisonIsPerPeer();
         testFirstFrameAlwaysPasses();
+        testOutOfOrderDoesNotPoisonOrAdvance();
+        testRecoveryAcceptsAnyWithinThresholdFrame();
+        testSeqWraparoundIsWrapSafe();
         std::cout << "All C++ Mixer tests passed!" << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;

--- a/test/cpp/mixer_test.cpp
+++ b/test/cpp/mixer_test.cpp
@@ -13,63 +13,116 @@
 /**
  * AudioMixer implements the "Mix-Minus" routing logic.
  * Each device hears all other devices except themselves.
+ *
+ * Standalone CI mirror of android/app/src/main/cpp/audio_mixer.{cpp,h}.
+ * Keep the [onVoiceFrame] / poison logic in lock-step with production —
+ * this file is what CI exercises (production needs the Android NDK).
  */
 class AudioMixer {
+public:
+    // Mirrors production AudioMixer::kPoisonThreshold (audio_mixer.h).
+    static constexpr uint32_t kPoisonThreshold = 16;
+
 private:
+    struct DeviceState {
+        std::vector<int16_t> buffer;
+        bool poisoned = false;
+        uint32_t lastSeq = 0;  // 0 = no frames seen yet
+    };
+
     std::mutex mixerMutex;
-    
-    // Map of device ID to their audio buffers
-    std::map<int, std::vector<int16_t>> deviceBuffers;
-    
+
+    // Map of device ID to their per-peer state
+    std::map<int, DeviceState> devices;
+
     // Maximum number of simultaneous devices
     static constexpr int kMaxDevices = 3;
-    
+
 public:
     // Add a device to the mixer
     bool addDevice(int deviceId) {
         std::lock_guard<std::mutex> lock(mixerMutex);
-        
-        if (deviceBuffers.size() >= kMaxDevices) {
+
+        if (devices.size() >= kMaxDevices) {
             LOGI("Maximum devices reached (%d)", kMaxDevices);
             return false;
         }
-        
-        deviceBuffers[deviceId] = std::vector<int16_t>();
+
+        devices[deviceId] = DeviceState{};
         LOGI("Device %d added to mixer", deviceId);
         return true;
     }
-    
+
     // Remove a device from the mixer
     void removeDevice(int deviceId) {
         std::lock_guard<std::mutex> lock(mixerMutex);
-        deviceBuffers.erase(deviceId);
+        devices.erase(deviceId);
         LOGI("Device %d removed from mixer", deviceId);
     }
-    
-    // Update audio data for a device
+
+    // Update audio data for a device (local-mic style, no seq).
+    // The peer-receive path goes through [onVoiceFrame] instead.
     void updateDeviceAudio(int deviceId, const int16_t* audioData, int numFrames) {
         std::lock_guard<std::mutex> lock(mixerMutex);
-        
-        auto it = deviceBuffers.find(deviceId);
-        if (it != deviceBuffers.end()) {
-            it->second.assign(audioData, audioData + numFrames);
+
+        auto it = devices.find(deviceId);
+        if (it != devices.end()) {
+            it->second.buffer.assign(audioData, audioData + numFrames);
         }
     }
-    
+
+    // Feed a peer-arrived voice frame with its over-the-wire seq. Mirrors the
+    // production stuck-producer prune: a frame whose seq exceeds the previously
+    // accepted seq by more than [kPoisonThreshold] is dropped and the peer is
+    // marked poisoned; the next contiguous frame recovers.
+    void onVoiceFrame(int deviceId, uint32_t seq, const int16_t* pcm, int numFrames) {
+        std::lock_guard<std::mutex> lock(mixerMutex);
+
+        auto it = devices.find(deviceId);
+        if (it == devices.end()) {
+            return;
+        }
+        DeviceState& s = it->second;
+
+        const uint32_t prevSeq = s.lastSeq;
+        if (prevSeq != 0 && seq > prevSeq + kPoisonThreshold) {
+            s.poisoned = true;
+            // Update lastSeq so the next contiguous frame can recover. Drop the
+            // current frame's audio (do not write to s.buffer) — production
+            // also avoids clearing the in-flight ring buffer here (SPSC contract).
+            s.lastSeq = seq;
+            LOGI("Device %d poisoned: seq jump %u -> %u", deviceId, prevSeq, seq);
+            return;
+        }
+
+        if (s.poisoned) {
+            s.poisoned = false;
+            LOGI("Device %d recovered at seq %u", deviceId, seq);
+        }
+        s.buffer.assign(pcm, pcm + numFrames);
+        s.lastSeq = seq;
+    }
+
+    bool isPoisoned(int deviceId) {
+        std::lock_guard<std::mutex> lock(mixerMutex);
+        auto it = devices.find(deviceId);
+        return it != devices.end() && it->second.poisoned;
+    }
+
     // Get mixed audio for a specific device (all others except this device)
     void getMixedAudioForDevice(int deviceId, int16_t* outputBuffer, int numFrames) {
         std::lock_guard<std::mutex> lock(mixerMutex);
-        
+
         // Initialize output buffer to zero
         std::memset(outputBuffer, 0, numFrames * sizeof(int16_t));
-        
+
         // Mix all devices except the target device
-        for (const auto& [id, buffer] : deviceBuffers) {
-            if (id != deviceId && !buffer.empty()) {
-                int framesToMix = std::min(numFrames, static_cast<int>(buffer.size()));
+        for (const auto& [id, state] : devices) {
+            if (id != deviceId && !state.buffer.empty()) {
+                int framesToMix = std::min(numFrames, static_cast<int>(state.buffer.size()));
                 for (int i = 0; i < framesToMix; i++) {
                     // Simple mixing with clipping prevention
-                    int32_t mixed = outputBuffer[i] + buffer[i];
+                    int32_t mixed = outputBuffer[i] + state.buffer[i];
                     outputBuffer[i] = static_cast<int16_t>(
                         std::max<int32_t>(-32768, std::min<int32_t>(32767, mixed))
                     );
@@ -77,18 +130,18 @@ public:
             }
         }
     }
-    
+
     // Clear all device buffers
     void clear() {
         std::lock_guard<std::mutex> lock(mixerMutex);
-        deviceBuffers.clear();
+        devices.clear();
         LOGI("Mixer cleared");
     }
 
     // Helper for testing: get number of devices
     size_t getDeviceCount() {
         std::lock_guard<std::mutex> lock(mixerMutex);
-        return deviceBuffers.size();
+        return devices.size();
     }
 };
 
@@ -185,11 +238,119 @@ void testMaxDevices() {
     std::cout << "Test Max Devices: PASSED" << std::endl;
 }
 
+// Issue #49: a peer whose seq jumps by > kPoisonThreshold is muted until a
+// contiguous seq arrives. This is the test the issue's acceptance criteria
+// names explicitly: "feed seqs 1, 2, 20 → mixer poisons; feed seq 21 → mixer
+// recovers."
+void testStuckProducerPrune() {
+    AudioMixer mixer;
+    mixer.addDevice(1);
+
+    const int kFrames = 8;
+    int16_t audio[kFrames];
+    for (int i = 0; i < kFrames; i++) audio[i] = 1000;
+
+    // Normal flow: contiguous low seqs.
+    mixer.onVoiceFrame(1, 1, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+    mixer.onVoiceFrame(1, 2, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // Big seq jump: 20 - 2 = 18 > kPoisonThreshold (16). Poison.
+    mixer.onVoiceFrame(1, 20, audio, kFrames);
+    assert(mixer.isPoisoned(1));
+
+    // Contiguous next frame recovers (21 - 20 = 1, well within threshold).
+    mixer.onVoiceFrame(1, 21, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    std::cout << "Test Stuck Producer Prune: PASSED" << std::endl;
+}
+
+// Boundary: a frame exactly at lastSeq + kPoisonThreshold MUST NOT poison
+// (the check is strictly `>`, so a 16-frame gap is the largest that still
+// passes). One past that does. Locks the threshold semantics so a future
+// drift in the constant gets caught.
+void testPoisonThresholdBoundary() {
+    AudioMixer mixer;
+    mixer.addDevice(1);
+
+    const int kFrames = 4;
+    int16_t audio[kFrames] = {500, 500, 500, 500};
+
+    // Establish lastSeq = 1.
+    mixer.onVoiceFrame(1, 1, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // seq = 1 + kPoisonThreshold (= 17): inside the window, must not poison.
+    mixer.onVoiceFrame(1, 1 + AudioMixer::kPoisonThreshold, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // seq = 17 + kPoisonThreshold + 1 (= 34): just past the window, must poison.
+    mixer.onVoiceFrame(1, 17 + AudioMixer::kPoisonThreshold + 1, audio, kFrames);
+    assert(mixer.isPoisoned(1));
+
+    std::cout << "Test Poison Threshold Boundary: PASSED" << std::endl;
+}
+
+// Per-peer independence: poisoning one device must not affect another. Real
+// rooms can have any subset of peers misbehaving at any given moment.
+void testPoisonIsPerPeer() {
+    AudioMixer mixer;
+    mixer.addDevice(1);
+    mixer.addDevice(2);
+
+    const int kFrames = 4;
+    int16_t audio[kFrames] = {2000, 2000, 2000, 2000};
+
+    mixer.onVoiceFrame(1, 1, audio, kFrames);
+    mixer.onVoiceFrame(2, 1, audio, kFrames);
+
+    // Poison only device 1.
+    mixer.onVoiceFrame(1, 100, audio, kFrames);
+    assert(mixer.isPoisoned(1));
+    assert(!mixer.isPoisoned(2));
+
+    // Continue feeding device 2 normally — it stays healthy.
+    mixer.onVoiceFrame(2, 2, audio, kFrames);
+    mixer.onVoiceFrame(2, 3, audio, kFrames);
+    assert(!mixer.isPoisoned(2));
+    assert(mixer.isPoisoned(1));
+
+    std::cout << "Test Poison Is Per-Peer: PASSED" << std::endl;
+}
+
+// First-frame edge case: lastSeq starts at 0, so the very first frame must
+// always pass regardless of value. The protocol says peers start at seq=1
+// but a fresh-session reset can land at any value; we trust the GATT join
+// handshake to bound that.
+void testFirstFrameAlwaysPasses() {
+    AudioMixer mixer;
+    mixer.addDevice(1);
+
+    const int kFrames = 4;
+    int16_t audio[kFrames] = {100, 100, 100, 100};
+
+    // First frame at a high seq — should still pass.
+    mixer.onVoiceFrame(1, 9999, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    // Now contiguous seq 10000 is fine (the high seq is the new baseline).
+    mixer.onVoiceFrame(1, 10000, audio, kFrames);
+    assert(!mixer.isPoisoned(1));
+
+    std::cout << "Test First Frame Always Passes: PASSED" << std::endl;
+}
+
 int main() {
     try {
         testMixMinus();
         testClipping();
         testMaxDevices();
+        testStuckProducerPrune();
+        testPoisonThresholdBoundary();
+        testPoisonIsPerPeer();
+        testFirstFrameAlwaysPasses();
         std::cout << "All C++ Mixer tests passed!" << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;


### PR DESCRIPTION
## Summary

Closes #49.

Implements the producer-poison rule from [docs/protocol.md](docs/protocol.md) § *Voice frame format*: after a peer's seq jumps by more than 16 from the last accepted frame, the host marks that peer poisoned and drops the offending frame. The next contiguous frame recovers. Protects the mix from a stuck or wildly-skipping sender (network glitch, codec wedge, runaway timer).

## Changes

- **`audio_mixer.{h,cpp}`** — `DeviceAudioBuffer` now carries `lastSeq` (uint32, plain — single-producer per device) and `poisoned` (atomic, read by mixer-tick / tests for telemetry). New `onVoiceFrame(deviceId, seq, pcm, n)` for the peer receive path. The existing `updateDeviceAudio` stays untouched for the local-mic path (deviceId 0, no over-the-wire seq).
- **Why we don't call `ringBuffer.clear()` on poison**: the ring buffer is SPSC with the mixer-tick consumer; producer-side `clear()` mid-read violates the contract (the existing `clear()` doc-comment warns about this). Letting any in-flight buffered samples drain over the next tick is the cheaper trade and matches the intent of "stop *new* mixing from this peer."
- **`peer_audio_manager.cpp`** — `nativeOnVoiceFrameReceived` now takes `seq` as `jlong` (so the protocol's uint32 survives the JNI hop without sign-extension surprises) and routes through `onVoiceFrame`.
- **`PeerAudioManager.kt`** — matching Kotlin signature change on `onVoiceFrameReceived(macAddress, opusData, seq: Long)`.
- **`test/cpp/mixer_test.cpp`** — the standalone CI mock mirrors the new poison logic (CI runs on `ubuntu-latest` without the Android NDK, so the mock is what the workflow actually exercises). Adds four new tests:
  - `testStuckProducerPrune` — the issue's named acceptance case: feed 1, 2, 20 → poisoned; feed 21 → recovered.
  - `testPoisonThresholdBoundary` — locks the strict-`>` threshold semantics (gap of exactly 16 passes, 17 poisons), so a future drift in `kPoisonThreshold` gets caught.
  - `testPoisonIsPerPeer` — poisoning one device must not affect another.
  - `testFirstFrameAlwaysPasses` — a fresh device with `lastSeq == 0` accepts any first seq (a fresh-session reset can land far from 1).

## What this PR does NOT do

The L2CAP receive loop in `MainActivity.kt` (lines 224, 255) is still a placeholder pending the next PR. This PR completes the **JNI / Kotlin surface** so the producer side can call `peerAudioManager.onVoiceFrameReceived(mac, opus, seq)` once wired — there is no behavior change at runtime today, only the readiness for it.

## Test plan

- [x] `flutter analyze` — clean (0 issues)
- [x] `flutter test` — 318 passing, 1 pre-existing skip
- [x] Native `mixer_test` builds and passes locally with the same `g++ -std=c++17 -Wall -Wextra -pthread` invocation CI uses
- [x] All four new tests pass; existing three (mix-minus, clipping, max-devices) continue to pass

## Acceptance (from issue)

> Unit test in `test/cpp/mixer_test.cpp`: feed seqs 1, 2, 20 → mixer poisons; feed seq 21 → mixer recovers.

✅ — `testStuckProducerPrune`.

> Test runs in CI per the native-mixer-test issue.

✅ — the existing `Build & run native mixer test` step in [.github/workflows/flutter.yml](.github/workflows/flutter.yml) compiles the standalone test and runs all seven cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust handling of incoming peer audio: out-of-order or duplicate frames are ignored and large sequence jumps are quarantined to reduce audible glitches.

* **New Features**
  * Per-peer stream quarantine (poison) with automatic recovery to prevent unstable sources from degrading mixed audio.

* **Bug Fixes**
  * Prevents stuck or advancing faulty streams from polluting the mixer; normal streams resume automatically once stable.

* **Tests**
  * Added unit tests covering quarantine, recovery, threshold boundaries and sequence wraparound.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->