### PR TITLE
feat(#55): Android Audio Focus management — pause/duck on call + Spotify

### DIFF
--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -364,8 +364,12 @@ Java_com_elodin_walkie_1talkie_AudioEngineManager_nativePauseStreams(
 JNIEXPORT jboolean JNICALL
 Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeResumeStreams(
         JNIEnv *env, jobject thiz) {
+    // Pause and ducking are orthogonal — the caller is responsible for
+    // restoring full volume via setDuckingVolume(1.0) when appropriate.
+    // Keeps the contract symmetric with pauseStreams (which doesn't touch
+    // ducking either) and avoids surprising a duck-then-pause sequence
+    // by silently restoring volume on the wrong event.
     g_focusPaused.store(false, std::memory_order_relaxed);
-    g_duckingVolume.store(1.0f, std::memory_order_relaxed);
     if (g_audioEngine != nullptr) {
         return g_audioEngine->resumeStreams() ? JNI_TRUE : JNI_FALSE;
     }

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -17,6 +17,17 @@
 // in the class body) can reference it without a forward declaration.
 static std::atomic<bool> g_muted{false};
 
+// Audio-focus pause flag. When true, mic frames are zeroed before reaching
+// the mixer / transport, mirroring the mute path. Streams themselves are
+// also requestPause()'d (see pauseStreams()) — the flag is a belt-and-braces
+// guard for the brief window where a callback is already in flight when
+// pause is issued.
+static std::atomic<bool> g_focusPaused{false};
+
+// Output volume multiplier driven by AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK.
+// 1.0 = full volume; 0.3 ≈ -10 dB which is what most media apps duck to.
+static std::atomic<float> g_duckingVolume{1.0f};
+
 // Global JNI references for voice activity callbacks
 static std::mutex g_jniMutex;
 static JavaVM* g_jvm = nullptr;
@@ -157,6 +168,50 @@ public:
         LOGI("Audio engine stopped");
     }
 
+    // Pause both streams without tearing them down. Used for transient
+    // audio focus losses (incoming calls) so a phone call doesn't fight
+    // the Oboe streams for the audio path. Counterpart to resumeStreams().
+    bool pauseStreams() {
+        bool ok = true;
+        if (recordingStream) {
+            oboe::Result r = recordingStream->requestPause();
+            if (r != oboe::Result::OK) {
+                LOGE("Failed to pause recording stream: %s", oboe::convertToText(r));
+                ok = false;
+            }
+        }
+        if (playbackStream) {
+            oboe::Result r = playbackStream->requestPause();
+            if (r != oboe::Result::OK) {
+                LOGE("Failed to pause playback stream: %s", oboe::convertToText(r));
+                ok = false;
+            }
+        }
+        LOGI("Audio streams paused (ok=%d)", ok ? 1 : 0);
+        return ok;
+    }
+
+    // Resume both streams after a transient pause.
+    bool resumeStreams() {
+        bool ok = true;
+        if (recordingStream) {
+            oboe::Result r = recordingStream->requestStart();
+            if (r != oboe::Result::OK) {
+                LOGE("Failed to resume recording stream: %s", oboe::convertToText(r));
+                ok = false;
+            }
+        }
+        if (playbackStream) {
+            oboe::Result r = playbackStream->requestStart();
+            if (r != oboe::Result::OK) {
+                LOGE("Failed to resume playback stream: %s", oboe::convertToText(r));
+                ok = false;
+            }
+        }
+        LOGI("Audio streams resumed (ok=%d)", ok ? 1 : 0);
+        return ok;
+    }
+
     // Oboe callback for audio data
     oboe::DataCallbackResult onAudioReady(
             oboe::AudioStream *audioStream,
@@ -168,6 +223,7 @@ public:
             auto *inputData = static_cast<int16_t *>(audioData);
 
             bool isMuted = g_muted.load(std::memory_order_relaxed);
+            bool isFocusPaused = g_focusPaused.load(std::memory_order_relaxed);
 
             // Voice activity detection (compute RMS before mute gate, so we
             // detect talking state even when muted for UI feedback)
@@ -193,10 +249,14 @@ public:
                 }
             }
 
-            // When muted, zero the mic frames so they don't reach the mixer
-            // or any future BLE transport. The streams stay warm so unmuting
-            // is instant — no codec reinit round-trip.
-            if (isMuted) {
+            // When muted or focus-paused, zero the mic frames so they don't
+            // reach the mixer or any future BLE transport. The streams stay
+            // warm so unmuting / focus-gain is instant — no codec reinit
+            // round-trip. Focus-pause should normally also halt the callback
+            // via requestPause(), but a callback already in flight at the
+            // moment pause is issued can still run once; this gate keeps a
+            // mid-call audio chunk from leaking out.
+            if (isMuted || isFocusPaused) {
                 std::memset(inputData, 0, numFrames * sizeof(int16_t));
             }
 
@@ -208,6 +268,16 @@ public:
                 // For demonstration: mix for device 0 (hearing others) and play it back
                 std::vector<int16_t> mixedOutput(numFrames);
                 g_audioMixer->getMixedAudioForDevice(0, mixedOutput.data(), numFrames);
+
+                // Apply ducking volume for AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK.
+                // Skip the multiply when at full volume to keep the hot path
+                // branch-free for the common case.
+                float duckVol = g_duckingVolume.load(std::memory_order_relaxed);
+                if (duckVol < 1.0f) {
+                    for (int32_t i = 0; i < numFrames; ++i) {
+                        mixedOutput[i] = static_cast<int16_t>(mixedOutput[i] * duckVol);
+                    }
+                }
 
                 if (playbackStream && playbackStream->getState() == oboe::StreamState::Started) {
                     playbackStream->write(mixedOutput.data(), numFrames, 0);
@@ -276,6 +346,37 @@ Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeSetMuted(
         JNIEnv *env, jobject thiz, jboolean muted) {
     g_muted.store(muted, std::memory_order_relaxed);
     return JNI_TRUE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_elodin_walkie_1talkie_AudioEngineManager_nativePauseStreams(
+        JNIEnv *env, jobject thiz) {
+    g_focusPaused.store(true, std::memory_order_relaxed);
+    if (g_audioEngine != nullptr) {
+        return g_audioEngine->pauseStreams() ? JNI_TRUE : JNI_FALSE;
+    }
+    // No engine running — flag stored, nothing else to pause. Treat as
+    // success so callers that always pause on focus loss don't see a
+    // spurious failure when voice hasn't been started yet.
+    return JNI_TRUE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeResumeStreams(
+        JNIEnv *env, jobject thiz) {
+    g_focusPaused.store(false, std::memory_order_relaxed);
+    g_duckingVolume.store(1.0f, std::memory_order_relaxed);
+    if (g_audioEngine != nullptr) {
+        return g_audioEngine->resumeStreams() ? JNI_TRUE : JNI_FALSE;
+    }
+    return JNI_TRUE;
+}
+
+JNIEXPORT void JNICALL
+Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeSetDuckingVolume(
+        JNIEnv *env, jobject thiz, jfloat volume) {
+    float clamped = volume < 0.0f ? 0.0f : (volume > 1.0f ? 1.0f : volume);
+    g_duckingVolume.store(clamped, std::memory_order_relaxed);
 }
 
 // These methods can now be used for manual injection if needed,

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -222,8 +222,17 @@ public:
             // Recording: feed to mixer directly
             auto *inputData = static_cast<int16_t *>(audioData);
 
+            // Focus-pause short-circuit. requestPause() halts new callbacks
+            // but a callback already in flight when pause was issued still
+            // runs once. Drop its audio entirely instead of running VAD,
+            // mixer, and playback for a chunk that's already lost the
+            // audio path — saves CPU and prevents a mid-call blip.
+            if (g_focusPaused.load(std::memory_order_relaxed)) {
+                std::memset(inputData, 0, numFrames * sizeof(int16_t));
+                return oboe::DataCallbackResult::Continue;
+            }
+
             bool isMuted = g_muted.load(std::memory_order_relaxed);
-            bool isFocusPaused = g_focusPaused.load(std::memory_order_relaxed);
 
             // Voice activity detection (compute RMS before mute gate, so we
             // detect talking state even when muted for UI feedback)
@@ -249,14 +258,10 @@ public:
                 }
             }
 
-            // When muted or focus-paused, zero the mic frames so they don't
-            // reach the mixer or any future BLE transport. The streams stay
-            // warm so unmuting / focus-gain is instant — no codec reinit
-            // round-trip. Focus-pause should normally also halt the callback
-            // via requestPause(), but a callback already in flight at the
-            // moment pause is issued can still run once; this gate keeps a
-            // mid-call audio chunk from leaking out.
-            if (isMuted || isFocusPaused) {
+            // When muted, zero the mic frames so they don't reach the mixer
+            // or any future BLE transport. The streams stay warm so unmuting
+            // is instant — no codec reinit round-trip.
+            if (isMuted) {
                 std::memset(inputData, 0, numFrames * sizeof(int16_t));
             }
 
@@ -289,7 +294,17 @@ public:
     }
 };
 
-// Global audio engine instance
+// Global audio engine instance + mutex.
+//
+// nativeStop deletes the engine and nulls the pointer; nativePauseStreams /
+// nativeResumeStreams read the pointer and dispatch to it. Without
+// serialization a stop racing with pause/resume can either tear down the
+// engine mid-call (use-after-free) or null the pointer between the load and
+// the dereference. In practice the JNI calls usually serialize on the
+// service / main thread, but Android focus-change listeners can be
+// dispatched on other threads; the mutex makes the contract explicit so
+// future call sites can't introduce a UAF by accident.
+static std::mutex g_engineMutex;
 static AudioEngine* g_audioEngine = nullptr;
 
 extern "C" {
@@ -326,6 +341,7 @@ Java_com_elodin_walkie_1talkie_MainActivity_nativeUnregisterCallbacks(JNIEnv *en
 
 JNIEXPORT jboolean JNICALL
 Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeStart(JNIEnv *env, jobject thiz) {
+    std::lock_guard<std::mutex> lock(g_engineMutex);
     if (g_audioEngine == nullptr) {
         g_audioEngine = new AudioEngine();
     }
@@ -334,6 +350,7 @@ Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeStart(JNIEnv *env, jobje
 
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeStop(JNIEnv *env, jobject thiz) {
+    std::lock_guard<std::mutex> lock(g_engineMutex);
     if (g_audioEngine != nullptr) {
         g_audioEngine->stop();
         delete g_audioEngine;
@@ -352,6 +369,7 @@ JNIEXPORT jboolean JNICALL
 Java_com_elodin_walkie_1talkie_AudioEngineManager_nativePauseStreams(
         JNIEnv *env, jobject thiz) {
     g_focusPaused.store(true, std::memory_order_relaxed);
+    std::lock_guard<std::mutex> lock(g_engineMutex);
     if (g_audioEngine != nullptr) {
         return g_audioEngine->pauseStreams() ? JNI_TRUE : JNI_FALSE;
     }
@@ -370,6 +388,7 @@ Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeResumeStreams(
     // ducking either) and avoids surprising a duck-then-pause sequence
     // by silently restoring volume on the wrong event.
     g_focusPaused.store(false, std::memory_order_relaxed);
+    std::lock_guard<std::mutex> lock(g_engineMutex);
     if (g_audioEngine != nullptr) {
         return g_audioEngine->resumeStreams() ? JNI_TRUE : JNI_FALSE;
     }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioEngineManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioEngineManager.kt
@@ -60,10 +60,51 @@ class AudioEngineManager {
         return nativeSetMuted(muted)
     }
 
+    /**
+     * Pause both Oboe streams without tearing them down. Used on
+     * AUDIOFOCUS_LOSS_TRANSIENT (e.g. an incoming call) so the OS can
+     * reclaim the audio path without the engine fighting it. Counterpart
+     * to [resumeStreams]; safe to call when the engine isn't started
+     * (resolves to a no-op flag flip).
+     *
+     * @return true if pause succeeded for all live streams (or no engine
+     *   was running); false if Oboe rejected a requestPause call.
+     */
+    fun pauseStreams(): Boolean {
+        Log.i(TAG, "Pausing audio streams (audio focus loss)")
+        return nativePauseStreams()
+    }
+
+    /**
+     * Resume the streams paused by [pauseStreams] and clear any active
+     * ducking. Called on AUDIOFOCUS_GAIN.
+     *
+     * @return true if resume succeeded for all live streams (or no engine
+     *   was running); false if Oboe rejected a requestStart call.
+     */
+    fun resumeStreams(): Boolean {
+        Log.i(TAG, "Resuming audio streams (audio focus gain)")
+        return nativeResumeStreams()
+    }
+
+    /**
+     * Apply an output volume multiplier in [0.0, 1.0]. Driven by
+     * AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK so a media app's nav prompt
+     * doesn't drown out walkie audio. Values outside the range are
+     * clamped on the native side.
+     */
+    fun setDuckingVolume(volume: Float) {
+        Log.i(TAG, "Setting ducking volume: $volume")
+        nativeSetDuckingVolume(volume)
+    }
+
     // Native methods
     private external fun nativeStart(): Boolean
     private external fun nativeStop()
     private external fun nativeGetAudioData(numFrames: Int): ShortArray?
     private external fun nativePlayAudioData(audioData: ShortArray)
     private external fun nativeSetMuted(muted: Boolean): Boolean
+    private external fun nativePauseStreams(): Boolean
+    private external fun nativeResumeStreams(): Boolean
+    private external fun nativeSetDuckingVolume(volume: Float)
 }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioEngineManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioEngineManager.kt
@@ -76,8 +76,12 @@ class AudioEngineManager {
     }
 
     /**
-     * Resume the streams paused by [pauseStreams] and clear any active
-     * ducking. Called on AUDIOFOCUS_GAIN.
+     * Resume the streams paused by [pauseStreams]. Called on AUDIOFOCUS_GAIN.
+     *
+     * Note: does **not** restore the ducking volume. Pause and ducking are
+     * orthogonal at the native layer — callers that want to clear ducking
+     * (e.g. on focus gain after a transient duck) must explicitly call
+     * [setDuckingVolume] with [AudioFocusManager.FULL_VOLUME].
      *
      * @return true if resume succeeded for all live streams (or no engine
      *   was running); false if Oboe rejected a requestStart call.

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioFocusManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioFocusManager.kt
@@ -1,0 +1,103 @@
+package com.elodin.walkie_talkie
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.util.Log
+
+/**
+ * Requests Android Audio Focus for the walkie-talkie voice stream so the
+ * Oboe engine doesn't fight phone calls or media apps for the audio path.
+ *
+ * Lifecycle: one focus request per service start. The returned focus-change
+ * callback is what the service uses to drive [AudioEngineManager.pauseStreams]
+ * / [AudioEngineManager.resumeStreams] / [AudioEngineManager.setDuckingVolume].
+ *
+ * Mapping of focus-change codes to action (handled by the caller):
+ *   - AUDIOFOCUS_LOSS_TRANSIENT (incoming call): pause both streams.
+ *   - AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK (Spotify nav prompt): drop volume.
+ *   - AUDIOFOCUS_GAIN: resume + clear ducking.
+ *   - AUDIOFOCUS_LOSS (long-lived): pause; per #55's acceptance criteria we
+ *     don't auto-leave the room (the user can come back and re-tune).
+ */
+class AudioFocusManager(ctx: Context) {
+    companion object {
+        private const val TAG = "AudioFocusManager"
+
+        /** Output multiplier when ducking. -10 dB matches OEM media defaults. */
+        const val DUCK_VOLUME = 0.3f
+
+        /** Full volume — pass to setDuckingVolume to clear ducking. */
+        const val FULL_VOLUME = 1.0f
+    }
+
+    private val audioManager =
+        ctx.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private var request: AudioFocusRequest? = null
+
+    /**
+     * Request audio focus. The same listener stays attached to the request
+     * for its lifetime; calling [requestFocus] a second time without an
+     * intervening [abandon] is a no-op and returns true.
+     *
+     * @param onFocusChange Invoked with the AudioManager focus-change codes
+     *   (AUDIOFOCUS_GAIN, AUDIOFOCUS_LOSS, AUDIOFOCUS_LOSS_TRANSIENT,
+     *   AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK). Always invoked on the main
+     *   thread (AudioManager guarantees this for the listener variant we use).
+     * @return true if focus was granted (or accepted as delayed grant),
+     *   false if the system denied the request.
+     */
+    fun requestFocus(onFocusChange: (Int) -> Unit): Boolean {
+        if (request != null) {
+            Log.w(TAG, "Audio focus already held; ignoring duplicate request")
+            return true
+        }
+
+        val attrs = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+
+        val req = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+            .setAudioAttributes(attrs)
+            .setAcceptsDelayedFocusGain(true)
+            .setOnAudioFocusChangeListener { focusChange ->
+                Log.i(TAG, "Audio focus change: $focusChange")
+                onFocusChange(focusChange)
+            }
+            .build()
+
+        return when (val result = audioManager.requestAudioFocus(req)) {
+            AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
+                Log.i(TAG, "Audio focus granted")
+                request = req
+                true
+            }
+            AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> {
+                // A higher-priority stream (e.g. an active call) is holding
+                // focus; the system will deliver AUDIOFOCUS_GAIN to the
+                // listener once it's free. Hang on to the request so abandon
+                // can release the pending grant.
+                Log.i(TAG, "Audio focus delayed (will be granted later)")
+                request = req
+                true
+            }
+            else -> {
+                Log.w(TAG, "Audio focus denied: result=$result")
+                false
+            }
+        }
+    }
+
+    /**
+     * Release any focus held by [requestFocus]. Safe to call when no focus
+     * is held — resolves to a no-op.
+     */
+    fun abandon() {
+        val req = request ?: return
+        val result = audioManager.abandonAudioFocusRequest(req)
+        Log.i(TAG, "Audio focus abandoned: result=$result")
+        request = null
+    }
+}

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.media.AudioManager
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -19,6 +20,11 @@ import androidx.core.app.ServiceCompat
  *
  * Audio engine lifecycle is handled separately via the startVoice / stopVoice
  * MethodChannel calls so the engine only runs while the user is in a room.
+ *
+ * The service also owns the Audio Focus request (#55): when a phone call
+ * comes in or another media app starts playing, the listener routes the
+ * focus-change events into [AudioEngineManager] so streams pause / duck
+ * instead of fighting the system for the audio path.
  */
 class WalkieTalkieService : Service() {
     companion object {
@@ -31,12 +37,15 @@ class WalkieTalkieService : Service() {
     }
 
     private var currentFreq: String? = null
+    private var audioFocusManager: AudioFocusManager? = null
+    private val audioEngineManager: AudioEngineManager by lazy { AudioEngineManager() }
 
     override fun onCreate() {
         super.onCreate()
         Log.i(TAG, "Service created")
         createNotificationChannel()
         startForegroundWithNotification(freq = null)
+        requestAudioFocus()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -54,6 +63,53 @@ class WalkieTalkieService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         Log.i(TAG, "Service destroyed")
+        audioFocusManager?.abandon()
+        audioFocusManager = null
+    }
+
+    /**
+     * Request audio focus and route focus-change callbacks into the
+     * native audio engine. Failure to acquire focus is non-fatal — the
+     * walkie still works, it just won't pause / duck cleanly when the
+     * system reclaims audio.
+     */
+    private fun requestAudioFocus() {
+        val mgr = AudioFocusManager(this)
+        val granted = mgr.requestFocus { focusChange ->
+            handleAudioFocusChange(focusChange)
+        }
+        audioFocusManager = mgr
+        if (!granted) {
+            Log.w(TAG, "Audio focus request denied; phone-call/Spotify clashes will not be handled")
+        }
+    }
+
+    /**
+     * Translate AudioManager focus-change codes to engine actions. Mapping
+     * is documented in [AudioFocusManager]. Per #55 we deliberately don't
+     * auto-leave the room on AUDIOFOCUS_LOSS — the user can return to a
+     * paused room rather than losing their tune-in entirely.
+     */
+    private fun handleAudioFocusChange(focusChange: Int) {
+        when (focusChange) {
+            AudioManager.AUDIOFOCUS_GAIN -> {
+                audioEngineManager.setDuckingVolume(AudioFocusManager.FULL_VOLUME)
+                audioEngineManager.resumeStreams()
+            }
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
+                audioEngineManager.pauseStreams()
+            }
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
+                audioEngineManager.setDuckingVolume(AudioFocusManager.DUCK_VOLUME)
+            }
+            AudioManager.AUDIOFOCUS_LOSS -> {
+                Log.w(TAG, "Long-lived audio focus loss — pausing; user must re-tune to recover")
+                audioEngineManager.pauseStreams()
+            }
+            else -> {
+                Log.w(TAG, "Unhandled audio focus change: $focusChange")
+            }
+        }
     }
 
     private fun createNotificationChannel() {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt
@@ -89,22 +89,32 @@ class WalkieTalkieService : Service() {
      * is documented in [AudioFocusManager]. Per #55 we deliberately don't
      * auto-leave the room on AUDIOFOCUS_LOSS — the user can return to a
      * paused room rather than losing their tune-in entirely.
+     *
+     * Pause / resume return values are non-fatal but worth surfacing in
+     * logcat: an Oboe failure here means the system audio path is in an
+     * unexpected state, and the next bug report should include it.
      */
     private fun handleAudioFocusChange(focusChange: Int) {
         when (focusChange) {
             AudioManager.AUDIOFOCUS_GAIN -> {
                 audioEngineManager.setDuckingVolume(AudioFocusManager.FULL_VOLUME)
-                audioEngineManager.resumeStreams()
+                if (!audioEngineManager.resumeStreams()) {
+                    Log.w(TAG, "resumeStreams() reported failure on AUDIOFOCUS_GAIN")
+                }
             }
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
-                audioEngineManager.pauseStreams()
+                if (!audioEngineManager.pauseStreams()) {
+                    Log.w(TAG, "pauseStreams() reported failure on AUDIOFOCUS_LOSS_TRANSIENT")
+                }
             }
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
                 audioEngineManager.setDuckingVolume(AudioFocusManager.DUCK_VOLUME)
             }
             AudioManager.AUDIOFOCUS_LOSS -> {
                 Log.w(TAG, "Long-lived audio focus loss — pausing; user must re-tune to recover")
-                audioEngineManager.pauseStreams()
+                if (!audioEngineManager.pauseStreams()) {
+                    Log.w(TAG, "pauseStreams() reported failure on AUDIOFOCUS_LOSS")
+                }
             }
             else -> {
                 Log.w(TAG, "Unhandled audio focus change: $focusChange")


### PR DESCRIPTION
## Summary

Closes #55.

The Oboe engine currently has no idea when the OS reclaims the audio path: an incoming phone call and a Spotify track playing both clash with our streams, with no graceful pause / duck / resume. This PR threads Android Audio Focus through the foreground service so the engine cooperates with the system instead of fighting for the path.

- **New `AudioFocusManager.kt`** — wraps `AudioFocusRequest` with `USAGE_VOICE_COMMUNICATION` + `CONTENT_TYPE_SPEECH` attributes and `acceptsDelayedFocusGain`. `requestFocus(onFocusChange)` returns true on grant or delayed-grant; `abandon()` releases.
- **`WalkieTalkieService`** requests focus in `onCreate` and abandons it in `onDestroy`. The focus-change listener routes codes into the engine:
  * `AUDIOFOCUS_LOSS_TRANSIENT` (incoming call) → `pauseStreams()`
  * `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` (Spotify nav prompt) → `setDuckingVolume(0.3)`
  * `AUDIOFOCUS_GAIN` → `resumeStreams()` + clear ducking
  * `AUDIOFOCUS_LOSS` (long-lived) → `pauseStreams()` + log warning; per #55's acceptance criteria we don't auto-leave the room (the user can return to a paused session rather than losing their tune-in entirely)
- **Native `AudioEngine::pauseStreams()` / `::resumeStreams()`** call `requestPause` / `requestStart` on both Oboe streams. A `g_focusPaused` atomic also gates the input callback as a belt-and-braces guard for the brief window where a callback may already be in flight when pause is issued — `memset`s the mic frames so a mid-call audio chunk can't leak to the mixer / future BLE transport.
- **`g_duckingVolume`** atomic float is multiplied into the mixed output buffer before write. Skipped when at 1.0 so the common case stays branch-free in the hot path.

## What this PR does NOT do

The issue's pseudocode mentions \"AUDIOFOCUS_LOSS (long-lived): leave the room with a toast.\" The acceptance criteria don't actually require auto-leave (they only require pause-resume on call and ducking with Spotify), and emitting a `leaveRoom` event from a service back to Flutter requires routing through `MainActivity` (the existing pattern uses `PendingIntent.getActivity` with an extra). I left long-lived loss as pause + log to keep this PR scoped to the verifiable acceptance criteria. The user can re-enter the room when they come back; it's a less destructive default than tearing down their session.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 318 passing, 1 pre-existing skip
- [x] Native mixer test (`g++` build of `test/cpp/mixer_test.cpp`) — passes
- [ ] Manual smoke test on a real device: incoming call → voice pauses, resumes after; Spotify nav → walkie audio ducks while the prompt plays. Native code paths can't be validated in CI (no Android build there yet) so this is the next gate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio stream pause and resume controls for better audio management during interruptions
  * Implemented automatic audio ducking that reduces volume when other applications require audio
  * Enhanced audio focus handling to properly respond to system-level audio focus changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->