### PR TITLE
feat(#39): Host-side session bootstrap (mint sessionUuid, self-seed JoinAccepted)

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../protocol/frequency_session.dart';
 import '../protocol/messages.dart';
 import '../protocol/peer.dart';
+import '../protocol/uuid.dart';
 import '../services/audio_service.dart';
 import '../services/ble_control_transport.dart';
 import '../services/heartbeat_scheduler.dart';
@@ -71,6 +73,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// Delay schedule injected into [ReconnectController]. Defaults to the
   /// production schedule; tests pass short delays to avoid slow test runs.
   final List<Duration>? _reconnectDelays;
+
+  /// Mint the per-session UUID on the host bootstrap path. Indirection so
+  /// tests can pin a deterministic UUID and assert the derived `roomFreq`.
+  /// Defaults to the cryptographic [generateUuidV4] for production builds.
+  final String Function() _mintSessionUuid;
 
   /// Drives the protocol's `ping` plane. Started on room entry, stopped
   /// on leave / close. The cubit owns the role-specific reaction to a
@@ -141,12 +148,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     HeartbeatScheduler? heartbeats,
     SignalReporter? signalReporter,
     WeakSignalDetector? weakSignalDetector,
+    String Function()? mintSessionUuid,
   })  : _transport = transport,
         _audio = audio,
         _reconnectDelays = reconnectDelays,
         _heartbeats = heartbeats ?? HeartbeatScheduler(),
         _signalReporter = signalReporter ?? SignalReporter(),
         _weakSignalDetector = weakSignalDetector ?? WeakSignalDetector(),
+        _mintSessionUuid = mintSessionUuid ?? generateUuidV4,
         super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
@@ -572,47 +581,112 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// the user isn't on Discovery (shouldn't happen — Discovery is the
   /// only screen that triggers it).
   ///
-  /// On the guest side, the caller passes [macAddress] and
-  /// [sessionUuidLow8] from the discovered advertisement. Both are stored
-  /// on `SessionRoom` so the GATT-client transport can dial the host
-  /// later (the actual `connectToHost` call lands in the GATT-client
-  /// issue). On the host side both are null — the local user *is* the
-  /// host, so there's no remote to dial.
+  /// **Host path.** Mints a fresh `sessionUuid`, derives the room's
+  /// cosmetic [roomFreq] from its low 12 bits (the same mapping guests
+  /// use when decoding the advertisement), self-seeds the roster with
+  /// the local user, and asks the audio service to start LE advertising
+  /// + the GATT server so other phones can see and dial the room. The
+  /// [freq] argument is ignored on this path — the freshly-minted UUID
+  /// is the source of truth for both the cosmetic display and what
+  /// guests will eventually see in their discovery list. Recorded to
+  /// the recent-hosted list as a side-effect.
+  ///
+  /// **Guest path.** Uses [freq] as the room's cosmetic display (it
+  /// already matches the advertised UUID's mhzDisplay since both flow
+  /// from the same protocol mapping). [macAddress] and [sessionUuidLow8]
+  /// come from the discovered advertisement and are stored on
+  /// `SessionRoom` so the GATT-client transport can dial the host later
+  /// (the actual `connectToHost` call lands in #43). On the host path
+  /// both are null — the local user *is* the host, so there's no remote
+  /// to dial.
   ///
   /// Resets the per-link sequence counter to 0 so the next sent message
   /// starts at `seq = 1` per the protocol's reconnect rule.
   ///
-  /// When [isHost] is true, the freq is recorded to the recent-hosted
-  /// list as a side-effect. Persistence runs in the background — a
-  /// failure or slow disk shouldn't block the transition into the room.
-  /// The updated list shows up the next time the user lands on
-  /// Discovery (via [leaveRoom]'s re-read).
+  /// Recent-frequency persistence runs in the background — a failure or
+  /// slow disk shouldn't block the transition into the room. The updated
+  /// list shows up the next time the user lands on Discovery (via
+  /// [leaveRoom]'s re-read).
   Future<void> joinRoom({
-    required String freq,
     required bool isHost,
+    String? freq,
     String? macAddress,
     String? sessionUuidLow8,
   }) async {
     final current = state;
     if (current is! SessionDiscovery) return;
     _seq = 0;
+    final SessionRoom room;
     if (isHost) {
+      // Mint the canonical session identity. Everything else on the host
+      // path (advertised manufacturer payload, cosmetic mhz, hostPeerId
+      // self-seed) flows from this UUID + the local peerId.
+      final sessionUuid = _mintSessionUuid();
+      // Resolve the local peerId for the self-seed. Falls back to the
+      // store on a cache miss (bootstrap may not have run, e.g. in a
+      // direct-seeded test); a hard failure is logged and we proceed
+      // with an empty hostPeerId rather than blocking the user — they've
+      // already committed to entering the room.
+      String? hostPeerId = _localPeerId;
+      if (hostPeerId == null) {
+        try {
+          hostPeerId = await identityStore.getPeerId();
+          _localPeerId = hostPeerId;
+        } catch (error, stackTrace) {
+          debugPrint('Failed to load peerId for host bootstrap: $error');
+          debugPrintStack(stackTrace: stackTrace);
+        }
+      }
+      if (isClosed) return;
+      final session = FrequencySession(
+        sessionUuid: sessionUuid,
+        hostPeerId: hostPeerId ?? '',
+      );
+      final roomFreq = session.mhzDisplay;
       // Fire-and-forget: the user has already committed to entering the
       // room, so we shouldn't await disk I/O before emitting. Errors are
       // logged on the future and surfaced on next launch as a missing
       // entry; nothing else depends on success here.
-      unawaited(_recordRecentFrequency(freq));
+      unawaited(_recordRecentFrequency(roomFreq));
+      final selfRoster = hostPeerId == null
+          ? const <ProtocolPeer>[]
+          : [ProtocolPeer(peerId: hostPeerId, displayName: current.myName)];
+      room = SessionRoom(
+        myName: current.myName,
+        roomFreq: roomFreq,
+        roomIsHost: true,
+        hostPeerId: hostPeerId,
+        roster: selfRoster,
+      );
+      emit(room);
+      // Kick off the BLE side. Both calls return false on permission /
+      // OEM rejection; we don't block the room transition on either,
+      // matching the existing pattern for non-fatal native-side failures.
+      // The native implementations land in #41 (advertiser) and the
+      // existing #38 (GATT server, already wired).
+      final audio = _audio;
+      if (audio != null) {
+        unawaited(audio.startAdvertising(
+          sessionUuid: sessionUuid,
+          displayName: current.myName,
+        ));
+        unawaited(audio.startGattServer());
+      }
+    } else {
+      if (freq == null) {
+        debugPrint(
+            'joinRoom guest path requires a freq; refusing to enter the room.');
+        return;
+      }
+      room = SessionRoom(
+        myName: current.myName,
+        roomFreq: freq,
+        roomIsHost: false,
+        macAddress: macAddress,
+        sessionUuidLow8: sessionUuidLow8,
+      );
+      emit(room);
     }
-    emit(SessionRoom(
-      myName: current.myName,
-      roomFreq: freq,
-      roomIsHost: isHost,
-      // Guest path threads MAC + session UUID through to the room state so
-      // the GATT-client transport can dial the host. Host path leaves them
-      // null — the local user is the host.
-      macAddress: isHost ? null : macAddress,
-      sessionUuidLow8: isHost ? null : sessionUuidLow8,
-    ));
     // Begin the heartbeat plane for the lifetime of the room. Pings the
     // wire every interval and watches inbound activity for silent peers
     // (host) / a silent host (guest). Calling start() is idempotent —

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -576,10 +576,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     }
   }
 
-  /// Enters Room on [freq]. [isHost] is true when the user created the
-  /// frequency, false when they tuned in to an existing one. No-op if
-  /// the user isn't on Discovery (shouldn't happen — Discovery is the
-  /// only screen that triggers it).
+  /// Enters Room. [isHost] is true when the user created the frequency,
+  /// false when they tuned in to an existing one. The [freq] argument is
+  /// required on the guest path (it carries the discovered MHz string)
+  /// and ignored on the host path (the room frequency is derived from a
+  /// freshly-minted sessionUuid). No-op if the user isn't on Discovery
+  /// (shouldn't happen — Discovery is the only screen that triggers it).
   ///
   /// **Host path.** Mints a fresh `sessionUuid`, derives the room's
   /// cosmetic [roomFreq] from its low 12 bits (the same mapping guests
@@ -622,11 +624,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // path (advertised manufacturer payload, cosmetic mhz, hostPeerId
       // self-seed) flows from this UUID + the local peerId.
       final sessionUuid = _mintSessionUuid();
-      // Resolve the local peerId for the self-seed. Falls back to the
-      // store on a cache miss (bootstrap may not have run, e.g. in a
-      // direct-seeded test); a hard failure is logged and we proceed
-      // with an empty hostPeerId rather than blocking the user — they've
-      // already committed to entering the room.
+      // Resolve the local peerId for the self-seed. The cache covers
+      // the common case where bootstrap has already run; falls back to
+      // the store otherwise. A hard failure aborts the host path —
+      // hostPeerId is load-bearing for the protocol's message
+      // attribution, and seeding the room without it would just put the
+      // user into a broken state they'd have to leave anyway.
       String? hostPeerId = _localPeerId;
       if (hostPeerId == null) {
         try {
@@ -635,12 +638,21 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         } catch (error, stackTrace) {
           debugPrint('Failed to load peerId for host bootstrap: $error');
           debugPrintStack(stackTrace: stackTrace);
+          return;
         }
       }
       if (isClosed) return;
+      // Re-read state after the await — `rename()` could have fired in
+      // the gap, and the captured `current.myName` would be stale.
+      // `leaveRoom()` isn't possible from Discovery, but a state
+      // transition out of Discovery still means the user no longer wants
+      // this room and we should bail.
+      final afterAwait = state;
+      if (afterAwait is! SessionDiscovery) return;
+      final myName = afterAwait.myName;
       final session = FrequencySession(
         sessionUuid: sessionUuid,
-        hostPeerId: hostPeerId ?? '',
+        hostPeerId: hostPeerId,
       );
       final roomFreq = session.mhzDisplay;
       // Fire-and-forget: the user has already committed to entering the
@@ -648,27 +660,25 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // logged on the future and surfaced on next launch as a missing
       // entry; nothing else depends on success here.
       unawaited(_recordRecentFrequency(roomFreq));
-      final selfRoster = hostPeerId == null
-          ? const <ProtocolPeer>[]
-          : [ProtocolPeer(peerId: hostPeerId, displayName: current.myName)];
       room = SessionRoom(
-        myName: current.myName,
+        myName: myName,
         roomFreq: roomFreq,
         roomIsHost: true,
         hostPeerId: hostPeerId,
-        roster: selfRoster,
+        roster: [ProtocolPeer(peerId: hostPeerId, displayName: myName)],
       );
       emit(room);
       // Kick off the BLE side. Both calls return false on permission /
       // OEM rejection; we don't block the room transition on either,
       // matching the existing pattern for non-fatal native-side failures.
       // The native implementations land in #41 (advertiser) and the
-      // existing #38 (GATT server, already wired).
+      // existing #38 (GATT server, already wired). Symmetric teardown
+      // happens in [leaveRoom] and [close].
       final audio = _audio;
       if (audio != null) {
         unawaited(audio.startAdvertising(
           sessionUuid: sessionUuid,
-          displayName: current.myName,
+          displayName: myName,
         ));
         unawaited(audio.startGattServer());
       }
@@ -723,6 +733,19 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Future<void> leaveRoom() async {
     final current = state;
     if (current is! SessionRoom) return;
+    // Symmetric teardown of the host BLE surfaces booted in joinRoom.
+    // Without this the device keeps advertising and serving GATT after
+    // the host backs out — strangers nearby would still see the room and
+    // could connect to a phantom session. Guests don't own these so we
+    // gate on roomIsHost. Both calls are unawaited to mirror the start
+    // pattern; failures log on the audio service.
+    if (current.roomIsHost) {
+      final audio = _audio;
+      if (audio != null) {
+        unawaited(audio.stopAdvertising());
+        unawaited(audio.stopGattServer());
+      }
+    }
     // Stop any in-progress reconnect so BLE retries halt promptly when
     // the user manually leaves rather than waiting for the next delay tick.
     _reconnectController?.cancel();
@@ -959,6 +982,20 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
 
   @override
   Future<void> close() async {
+    // Tear down the host BLE surfaces if the cubit is closing while the
+    // local user is still the host. Without this, killing the cubit
+    // (e.g. test teardown, app disposal mid-session) leaves the platform
+    // advertiser + GATT server running until the OS reaps the
+    // foreground service. Mirrors the leaveRoom path; same gating on
+    // roomIsHost.
+    final current = state;
+    if (current is SessionRoom && current.roomIsHost) {
+      final audio = _audio;
+      if (audio != null) {
+        unawaited(audio.stopAdvertising());
+        unawaited(audio.stopGattServer());
+      }
+    }
     // Cancel an in-progress reconnect before closing so the attempt loop
     // won't call emit() or leaveRoom() after the cubit is disposed.
     _reconnectController?.cancel();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -152,8 +152,12 @@ class FrequencyApp extends StatelessWidget {
           onPick: (result) {
             unawaited(
               cubit.joinRoom(
-                freq: result.freq,
                 isHost: result.isHost,
+                // Host path ignores `freq` — the cubit derives it from a
+                // freshly-minted sessionUuid (#39). Pass it through anyway
+                // for the guest path, where it carries the discovered
+                // session's cosmetic mhzDisplay.
+                freq: result.isHost ? null : result.freq,
                 macAddress: result.macAddress,
                 sessionUuidLow8: result.sessionUuidLow8,
               ),

--- a/lib/protocol/uuid.dart
+++ b/lib/protocol/uuid.dart
@@ -1,0 +1,28 @@
+import 'dart:math';
+
+/// Generates a UUID v4 string in canonical `8-4-4-4-12` hex form using
+/// `Random.secure()`. Avoids pulling in the `uuid` package for ~15 lines
+/// of work; the format follows RFC 4122 §4.4 (random bits with the
+/// version nibble pinned to 4 and the variant top bits to `10`).
+///
+/// Shared by [IdentityStore] (per-install peerId) and the host-side session
+/// bootstrap in [FrequencySessionCubit] (per-session sessionUuid).
+String generateUuidV4() {
+  final rng = Random.secure();
+  final bytes = List<int>.generate(16, (_) => rng.nextInt(256));
+  // Version 4 (random) marker.
+  bytes[6] = (bytes[6] & 0x0F) | 0x40;
+  // RFC 4122 variant marker (10xx).
+  bytes[8] = (bytes[8] & 0x3F) | 0x80;
+
+  String segment(int from, int to) {
+    final sb = StringBuffer();
+    for (var i = from; i < to; i++) {
+      sb.write(bytes[i].toRadixString(16).padLeft(2, '0'));
+    }
+    return sb.toString();
+  }
+
+  return '${segment(0, 4)}-${segment(4, 6)}-${segment(6, 8)}-'
+      '${segment(8, 10)}-${segment(10, 16)}';
+}

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -238,6 +238,52 @@ class AudioService {
         .map((e) => e['talking'] == true);
   }
 
+  /// Start LE advertising for the host.
+  ///
+  /// Broadcasts the walkie-talkie service UUID plus a 16-byte manufacturer
+  /// payload that encodes the protocol version, role, and low 8 bytes of
+  /// [sessionUuid] (see [docs/protocol.md] § "Bluetooth LE advertising").
+  /// Other phones running the discovery service pick this up and surface
+  /// the host as a tunable frequency.
+  ///
+  /// [displayName] is included in the advertisement (LE device-name field)
+  /// so the discovery row can render the host's name without an extra
+  /// GATT round-trip. [sessionUuid] is the canonical full UUID minted by
+  /// the host on session start; the advertiser truncates it to the low
+  /// 8 bytes per the wire spec.
+  ///
+  /// Returns true if advertising started successfully, false otherwise.
+  /// The native implementation lands in issue #41; until then this is a
+  /// no-op stub on the platform side.
+  Future<bool> startAdvertising({
+    required String sessionUuid,
+    required String displayName,
+  }) async {
+    try {
+      final result = await _methodChannel.invokeMethod('startAdvertising', {
+        'sessionUuid': sessionUuid,
+        'displayName': displayName,
+      });
+      return result == true;
+    } catch (e) {
+      debugPrint('Error starting advertising: $e');
+      return false;
+    }
+  }
+
+  /// Stop LE advertising. Counterpart to [startAdvertising]; safe to call
+  /// when advertising isn't running (the native side resolves it as a
+  /// no-op rather than throwing).
+  Future<bool> stopAdvertising() async {
+    try {
+      final result = await _methodChannel.invokeMethod('stopAdvertising');
+      return result == true;
+    } catch (e) {
+      debugPrint('Error stopping advertising: $e');
+      return false;
+    }
+  }
+
   /// Start the GATT server for the host.
   ///
   /// Exposes REQUEST (write) and RESPONSE (notify) characteristics over

--- a/lib/services/identity_store.dart
+++ b/lib/services/identity_store.dart
@@ -1,6 +1,6 @@
-import 'dart:math';
-
 import 'package:hive/hive.dart';
+
+import '../protocol/uuid.dart';
 
 /// Persisted user identity that survives app restarts.
 ///
@@ -75,32 +75,8 @@ class HiveIdentityStore implements IdentityStore {
     final box = await _open();
     final existing = box.get(_peerIdKey);
     if (existing != null && existing.isNotEmpty) return existing;
-    final fresh = _generateUuidV4();
+    final fresh = generateUuidV4();
     await box.put(_peerIdKey, fresh);
     return fresh;
   }
-}
-
-/// Generates a UUID v4 string in canonical `8-4-4-4-12` hex form using
-/// `Random.secure()`. Avoids pulling in the `uuid` package for ~15 lines
-/// of work; the format follows RFC 4122 §4.4 (random bits with the
-/// version nibble pinned to 4 and the variant top bits to `10`).
-String _generateUuidV4() {
-  final rng = Random.secure();
-  final bytes = List<int>.generate(16, (_) => rng.nextInt(256));
-  // Version 4 (random) marker.
-  bytes[6] = (bytes[6] & 0x0F) | 0x40;
-  // RFC 4122 variant marker (10xx).
-  bytes[8] = (bytes[8] & 0x3F) | 0x80;
-
-  String segment(int from, int to) {
-    final sb = StringBuffer();
-    for (var i = from; i < to; i++) {
-      sb.write(bytes[i].toRadixString(16).padLeft(2, '0'));
-    }
-    return sb.toString();
-  }
-
-  return '${segment(0, 4)}-${segment(4, 6)}-${segment(6, 8)}-'
-      '${segment(8, 10)}-${segment(10, 16)}';
 }

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -95,6 +95,13 @@ const _testReconnectDelays = [
   Duration.zero,
 ];
 
+/// Deterministic UUID whose low 12 bits map to mhzDisplay '104.3' via
+/// `FrequencySession`'s 880 + (low12 % 200) tenths formula
+/// (low 3 nibbles = 0x0a3 = 163; 880 + 163 = 1043 → "104.3"). Pinning it
+/// here means existing host-path tests can keep asserting `roomFreq:
+/// '104.3'` without each one having to wire up its own mint stub.
+const _testHostSessionUuid = '00000000-0000-4000-8000-0000000000a3';
+
 FrequencySessionCubit _makeCubit({
   IdentityStore? identityStore,
   RecentFrequenciesStore? recentFrequenciesStore,
@@ -104,6 +111,7 @@ FrequencySessionCubit _makeCubit({
   BleControlTransport? transport,
   SignalReporter? signalReporter,
   WeakSignalDetector? weakSignalDetector,
+  String Function()? mintSessionUuid,
 }) =>
     FrequencySessionCubit(
       identityStore: identityStore ?? _FakeStore(),
@@ -115,6 +123,7 @@ FrequencySessionCubit _makeCubit({
       transport: transport,
       signalReporter: signalReporter,
       weakSignalDetector: weakSignalDetector,
+      mintSessionUuid: mintSessionUuid ?? (() => _testHostSessionUuid),
     );
 
 void main() {
@@ -218,15 +227,23 @@ void main() {
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
-      'joinRoom from Discovery enters the Room with freq + host flag',
+      'joinRoom from Discovery enters the Room with derived freq, host flag, '
+      'and a self-seeded roster',
+      // Host bootstrap: minted UUID drives roomFreq via the same low-12-bit
+      // mapping guests use, hostPeerId is pinned to the local peerId, and
+      // the roster carries a single entry — the local user.
       build: () => _makeCubit(),
       seed: () => const SessionDiscovery(myName: 'Maya'),
-      act: (cubit) => cubit.joinRoom(freq: '104.3', isHost: true),
+      act: (cubit) => cubit.joinRoom(isHost: true),
       expect: () => [
         const SessionRoom(
           myName: 'Maya',
           roomFreq: '104.3',
           roomIsHost: true,
+          hostPeerId: 'fake-peer-id',
+          roster: [
+            ProtocolPeer(peerId: 'fake-peer-id', displayName: 'Maya'),
+          ],
         ),
       ],
     );
@@ -235,7 +252,7 @@ void main() {
       'joinRoom outside Discovery is a no-op',
       build: () => _makeCubit(),
       seed: () => const SessionOnboarding(),
-      act: (cubit) => cubit.joinRoom(freq: '104.3', isHost: true),
+      act: (cubit) => cubit.joinRoom(isHost: true),
       expect: () => const <FrequencySessionState>[],
     );
 
@@ -272,8 +289,8 @@ void main() {
       build: () => _makeCubit(),
       seed: () => const SessionDiscovery(myName: 'Maya'),
       act: (cubit) => cubit.joinRoom(
-        freq: '104.3',
         isHost: true,
+        freq: '104.3',
         macAddress: 'AA:BB:CC:DD:EE:FF',
         sessionUuidLow8: '0011223344556677',
       ),
@@ -282,8 +299,110 @@ void main() {
           myName: 'Maya',
           roomFreq: '104.3',
           roomIsHost: true,
+          hostPeerId: 'fake-peer-id',
+          roster: [
+            ProtocolPeer(peerId: 'fake-peer-id', displayName: 'Maya'),
+          ],
         ),
       ],
+    );
+
+    test(
+      'joinRoom as host derives roomFreq from the freshly-minted sessionUuid',
+      () async {
+        // Decouple the test's mhz check from any specific UUID by minting
+        // a different one and asserting the derived value matches the same
+        // formula `FrequencySession.mhzDisplay` uses.
+        // Low 3 nibbles = 0x123 = 291; 880 + (291 % 200) = 880 + 91 = 971
+        // → '97.1'.
+        const sessionUuid = '11111111-1111-4111-8111-111111111123';
+        final cubit = _makeCubit(mintSessionUuid: () => sessionUuid);
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(isHost: true);
+        // Let the bootstrap's async peerId resolution settle.
+        await Future<void>.delayed(Duration.zero);
+
+        final room = cubit.state as SessionRoom;
+        expect(room.roomFreq, '97.1');
+        expect(room.hostPeerId, 'fake-peer-id');
+        expect(room.roster, hasLength(1));
+        expect(room.roster.single.peerId, 'fake-peer-id');
+        expect(room.roster.single.displayName, 'Maya');
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'joinRoom as host calls startAdvertising and startGattServer on audio '
+      'with the minted sessionUuid + display name',
+      () async {
+        // Per issue #39's acceptance: a unit test verifies the host
+        // bootstrap calls into the audio service with the right args. We
+        // intercept the underlying MethodChannel rather than mocking the
+        // service so this test stays anchored on the contract callers
+        // depend on (the platform method names + arg map).
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          // Both methods nominally return bool on the native side.
+          return true;
+        });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        const sessionUuid = '00000000-0000-4000-8000-0000000000a3';
+        final cubit = _makeCubit(
+          audio: AudioService(),
+          mintSessionUuid: () => sessionUuid,
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(isHost: true);
+        // The cubit fires both calls unawaited; let the event loop drain.
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        final advertise = calls.firstWhere((c) => c.method == 'startAdvertising');
+        expect(advertise.arguments, {
+          'sessionUuid': sessionUuid,
+          'displayName': 'Maya',
+        });
+        expect(
+          calls.where((c) => c.method == 'startGattServer'),
+          hasLength(1),
+        );
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'joinRoom as host without an audio service still self-seeds the room',
+      () async {
+        // The native bootstrap is best-effort; without audio injected we
+        // should still emit a host SessionRoom so the UI advances. The
+        // cubit constructor allows audio == null for tests / loopback
+        // builds; this guards that path.
+        final cubit = _makeCubit(); // no audio
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(isHost: true);
+        await Future<void>.delayed(Duration.zero);
+
+        final room = cubit.state as SessionRoom;
+        expect(room.roomIsHost, isTrue);
+        expect(room.hostPeerId, 'fake-peer-id');
+        expect(room.roster.single.peerId, 'fake-peer-id');
+
+        await cubit.close();
+      },
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -405,6 +405,134 @@ void main() {
       },
     );
 
+    test(
+      'joinRoom as host bails out when peerId resolution fails — '
+      'no broken room is emitted',
+      () async {
+        // hostPeerId is load-bearing for the protocol's message
+        // attribution; seeding a room without it would just put the user
+        // into a broken state they'd have to leave manually. Stay on
+        // Discovery so the UI can retry.
+        final store = _FakeStore(initial: 'Maya')..throwOnGetPeerId = true;
+        final cubit = _makeCubit(identityStore: store);
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(isHost: true);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(cubit.state, isA<SessionDiscovery>());
+        await cubit.close();
+      },
+    );
+
+    test(
+      'leaveRoom on a host room calls stopAdvertising + stopGattServer',
+      () async {
+        // Symmetric teardown: the host kicks off advertising + GATT in
+        // joinRoom, so backing out of the room must close both surfaces.
+        // Otherwise nearby phones keep seeing a phantom session.
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return true;
+        });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        final cubit = _makeCubit(audio: AudioService());
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(isHost: true);
+        await Future<void>.delayed(Duration.zero);
+
+        calls.clear();
+        await cubit.leaveRoom();
+        await Future<void>.delayed(Duration.zero);
+
+        final methods = calls.map((c) => c.method).toSet();
+        expect(methods, containsAll(<String>{'stopAdvertising', 'stopGattServer'}));
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'leaveRoom on a guest room does NOT call host-side stop methods',
+      () async {
+        // Guests don't own the advertiser / GATT server, so leaving a
+        // guest-role room mustn't tear down a (possibly co-hosted) room
+        // on the same device.
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return true;
+        });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        final cubit = _makeCubit(audio: AudioService());
+        cubit.emit(const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: false,
+        ));
+
+        calls.clear();
+        await cubit.leaveRoom();
+        await Future<void>.delayed(Duration.zero);
+
+        final methods = calls.map((c) => c.method).toSet();
+        expect(methods, isNot(contains('stopAdvertising')));
+        expect(methods, isNot(contains('stopGattServer')));
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'close() while in a host room tears down host BLE surfaces',
+      () async {
+        // Same teardown as leaveRoom — without it, killing the cubit
+        // mid-session leaks the advertiser + GATT server.
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return true;
+        });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        final cubit = _makeCubit(audio: AudioService());
+        cubit.emit(const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: true,
+        ));
+
+        calls.clear();
+        await cubit.close();
+        await Future<void>.delayed(Duration.zero);
+
+        final methods = calls.map((c) => c.method).toSet();
+        expect(methods, containsAll(<String>{'stopAdvertising', 'stopGattServer'}));
+      },
+    );
+
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'leaveRoom drops back to Discovery with the prior name',
       build: () => _makeCubit(),


### PR DESCRIPTION
## Summary

Closes #39.

When a user taps **Start a new Frequency**, `FrequencySessionCubit.joinRoom(isHost: true)` now:

1. Mints a fresh `sessionUuid` (UUID v4, `Random.secure()`) — cached behind a `mintSessionUuid` hook so tests can pin a deterministic value.
2. Resolves the local `peerId` from `IdentityStore` (using the `_localPeerId` cache when warm).
3. Wraps both in `FrequencySession` and uses its `mhzDisplay` as the room's `roomFreq` (the same low-12-bit mapping guests use when decoding the advertisement, so host and guest see the same MHz string).
4. Self-seeds `SessionRoom.hostPeerId` and `roster` (one entry: the local user) so the room renders the host immediately instead of as an empty room.
5. Calls `_audio.startAdvertising(sessionUuid:, displayName:)` and `_audio.startGattServer()` so other phones can discover and dial the room. Both are fire-and-forget — a permission/OEM rejection should not block the room transition.

The host path now ignores the caller's `freq` argument; the freshly-minted UUID is the source of truth. The guest path is unchanged: the discovered MHz is still threaded through to `roomFreq`.

### Other changes

- Extracts `_generateUuidV4` from [identity_store.dart](lib/services/identity_store.dart) into a shared [lib/protocol/uuid.dart](lib/protocol/uuid.dart) helper now that both the per-install peerId and the per-session sessionUuid mint from it.
- Adds `startAdvertising` / `stopAdvertising` stubs to [audio_service.dart](lib/services/audio_service.dart) (matching the existing `startGattServer` pattern). The native Android implementation lands in #41; until then these are no-ops on the platform side.

## Test plan

- [x] `flutter analyze` clean (0 issues)
- [x] `flutter test` — all 321 tests pass, including:
  - New: host bootstrap derives `roomFreq` from minted sessionUuid (`97.1` for a UUID with low-3 nibbles `0x123`)
  - New: host bootstrap calls `startAdvertising` with `{sessionUuid, displayName}` and `startGattServer` on the platform `MethodChannel`
  - New: host bootstrap without an audio service still self-seeds the room (UI must advance regardless)
  - Updated: existing host-path tests now assert the self-seeded `hostPeerId: 'fake-peer-id'` and 1-element roster

## Depends on

- ✅ Discovery MAC propagation (`macAddress` + `sessionUuidLow8` already on `joinRoom`)
- ✅ GATT server (`startGattServer` already on `AudioService`, native side wired)
- ⏳ LE advertiser (#41) — implements the native side of `startAdvertising`. The Dart-side stub is wired so #41 can drop in the Kotlin `HostAdvertiser` without touching this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audio advertising capabilities for host sessions.
  * Centralized UUID generation system for improved session reliability.

* **Bug Fixes**
  * Improved session management with distinct handling for host and guest roles.

* **Refactor**
  * Streamlined UUID generation across the application for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->