### PR TITLE
feat(#45): Negotiated GATT MTU plumbing — native query + transport-side fragment sizing

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -29,6 +29,14 @@ class GattClientManager(
     private var requestCharacteristic: BluetoothGattCharacteristic? = null
     private var responseCharacteristic: BluetoothGattCharacteristic? = null
 
+    // ATT MTU negotiated for the connected host, keyed by MAC. Populated by
+    // [onMtuChanged] once the GATT layer answers our [requestMtu] from
+    // [onConnectionStateChange]. The Dart control transport reads this via
+    // `MainActivity.getNegotiatedMtu` to size fragments to the actual link
+    // budget; without it the guest side would always return null and never
+    // engage MTU-aware fragmentation.
+    private val negotiatedMtus: MutableMap<String, Int> = mutableMapOf()
+
     private val gattCallback = object : BluetoothGattCallback() {
         override fun onConnectionStateChange(
             gatt: BluetoothGatt,
@@ -52,6 +60,7 @@ class GattClientManager(
         override fun onMtuChanged(gatt: BluetoothGatt, mtu: Int, status: Int) {
             if (status == BluetoothGatt.GATT_SUCCESS) {
                 Log.i(TAG, "MTU changed to $mtu")
+                negotiatedMtus[gatt.device.address] = mtu
             } else {
                 Log.w(TAG, "MTU change failed with status $status")
             }
@@ -229,16 +238,28 @@ class GattClientManager(
      */
     fun disconnect() {
         try {
+            val address = gatt?.device?.address
             gatt?.disconnect()
             gatt?.close()
             gatt = null
             requestCharacteristic = null
             responseCharacteristic = null
+            if (address != null) {
+                negotiatedMtus.remove(address)
+            }
             Log.i(TAG, "GATT client disconnected and closed")
         } catch (e: Exception) {
             Log.e(TAG, "Error disconnecting GATT client", e)
         }
     }
+
+    /**
+     * Returns the ATT MTU negotiated for [endpointId] (host MAC), or null if
+     * no MTU has been observed yet for that link. Mirrors
+     * `GattServerManager.getMtu(endpointId)`; one side or the other answers
+     * depending on which device is the GATT client/server for this link.
+     */
+    fun getMtu(endpointId: String): Int? = negotiatedMtus[endpointId]
 
     /**
      * Check if currently connected to a host.

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -247,6 +247,28 @@ class MainActivity : FlutterActivity() {
                         result.success(success)
                     }
                 }
+                "getNegotiatedMtu" -> {
+                    // Returns the MTU that the GATT layer negotiated with
+                    // [endpointId] (BT MAC), or null if no MTU has been
+                    // observed yet. Per BLE spec the wire floor is 23 bytes
+                    // (the value Android uses before any negotiation), so a
+                    // null return signals "use the default — no negotiation
+                    // has fired yet" rather than "the link is dead".
+                    //
+                    // Prefers the GATT *client* cache (guest side, where this
+                    // device drove the MTU request via `requestMtu`) and falls
+                    // back to the *server* cache (host side, where the peer
+                    // negotiated the MTU). Either side can answer once
+                    // `onMtuChanged` has fired for that link.
+                    val endpointId = call.argument<String>("endpointId")
+                    if (endpointId == null) {
+                        result.error("INVALID_ARGUMENT", "endpointId is required", null)
+                    } else {
+                        val mtu = gattClientManager?.getMtu(endpointId)
+                            ?: gattServerManager?.getMtu(endpointId)
+                        result.success(mtu)
+                    }
+                }
                 "startVoiceServer" -> {
                     Log.i(TAG, "Starting L2CAP voice server")
                     val bt = (getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager)?.adapter

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -345,6 +345,29 @@ class AudioService {
     }
   }
 
+  /// Read the negotiated ATT MTU for the GATT connection to [endpointId]
+  /// (Bluetooth MAC). Returns the negotiated value in bytes, or null if no
+  /// MTU has been observed yet for that endpoint or the platform call
+  /// fails.
+  ///
+  /// A null return means the link is in its pre-negotiation default state
+  /// (23 bytes) rather than "the link is dead" — callers should treat null
+  /// as "fall back to the protocol default" and retry on the next write.
+  ///
+  /// Used by [BleControlTransport] to size GATT REQUEST/RESPONSE fragments
+  /// against the actual wire ceiling instead of always emitting 247-byte
+  /// chunks the platform might re-fragment unpredictably.
+  Future<int?> getNegotiatedMtu(String endpointId) async {
+    try {
+      return await _methodChannel.invokeMethod<int>('getNegotiatedMtu', {
+        'endpointId': endpointId,
+      });
+    } catch (e) {
+      debugPrint('Error getting negotiated MTU for $endpointId: $e');
+      return null;
+    }
+  }
+
   /// Stop the GATT server.
   Future<bool> stopGattServer() async {
     try {

--- a/lib/services/ble_control_transport.dart
+++ b/lib/services/ble_control_transport.dart
@@ -7,6 +7,22 @@ import '../protocol/messages.dart';
 import '../protocol/sequence_filter.dart';
 import 'audio_service.dart';
 
+/// Minimum ATT MTU the control plane requires before [BleControlTransport]
+/// will emit fragments. Mirrors [`kVoiceMtu`](voice_frame.dart) for the voice
+/// plane: a peer that negotiates below this is treated as a
+/// version-mismatch and the send is aborted (per protocol § GATT service).
+///
+/// At MTU = 64 the per-fragment payload budget is `64 - 3 - 4 = 57` bytes
+/// — enough to keep the worst-case roster under the v1 16-fragment ceiling
+/// — but anything smaller starts pushing fragment counts into territory
+/// where flaky OEM stacks reorder or drop writes.
+const int kMinControlMtu = 64;
+
+/// ATT opcode + handle bytes the link reserves before the GATT payload.
+/// Subtracted from the negotiated MTU when sizing fragments so the link
+/// doesn't refragment our writes unpredictably.
+const int kAttHeaderOverhead = 3;
+
 /// Bridges the Frequency wire protocol to the native GATT byte streams.
 ///
 /// **Send side.** [send] serialises a [FrequencyMessage] to JSON, splits it
@@ -23,6 +39,7 @@ import 'audio_service.dart';
 /// underlying connection stays up.
 class BleControlTransport {
   final Future<void> Function(Uint8List bytes) _writeBytes;
+  final Future<int?> Function(String endpointId)? _getMtu;
   final SequenceFilter _filter = SequenceFilter();
   final Map<String, FragmentReassembler> _reassemblers = {};
   // Tracks peerId → endpointId so forgetPeer can clean up the right reassembler.
@@ -35,34 +52,118 @@ class BleControlTransport {
   late final StreamSubscription<({String endpointId, Uint8List bytes})>
       _subscription;
 
+  /// Endpoint the next [send] should size against. The cubit sets this
+  /// to the host's BT MAC once a guest has connected; the host has no
+  /// outbound use of [send] today (it writes notifications via
+  /// `audio.writeNotification`), so the value stays null on that side.
+  String? _activeEndpoint;
+
   /// Fully-assembled, idempotency-filtered messages from the remote side.
   Stream<FrequencyMessage> get incoming => _incoming.stream;
 
   BleControlTransport(AudioService audio)
-      : _writeBytes = audio.writeControlBytes {
+      : _writeBytes = audio.writeControlBytes,
+        _getMtu = audio.getNegotiatedMtu {
     _subscription = audio.controlBytes.listen(_onControlBytes);
   }
 
   /// Test-only constructor. Inject a synthetic `controlBytes` stream and a
   /// write callback to exercise the transport without touching MethodChannels.
+  ///
+  /// [getMtu] is optional: if provided, [send] will query it for the active
+  /// endpoint (set via [setActiveEndpoint]) and size fragments against the
+  /// negotiated MTU. If omitted, [send] falls back to [kMaxFragmentSize].
   @visibleForTesting
   BleControlTransport.forTest({
     required Stream<({String endpointId, Uint8List bytes})> controlBytes,
     required Future<void> Function(Uint8List bytes) writeBytes,
-  }) : _writeBytes = writeBytes {
+    Future<int?> Function(String endpointId)? getMtu,
+  })  : _writeBytes = writeBytes,
+        _getMtu = getMtu {
     _subscription = controlBytes.listen(_onControlBytes);
   }
+
+  /// Endpoint the transport should consult for MTU on subsequent sends.
+  ///
+  /// On the guest side, this is the host's BT MAC; the cubit calls it once
+  /// the GATT-client connection is established. Pass null to clear the
+  /// binding (e.g. on disconnect) and revert [send] to the default
+  /// [kMaxFragmentSize].
+  void setActiveEndpoint(String? endpointId) {
+    _activeEndpoint = endpointId;
+  }
+
+  /// The endpoint [send] is currently sized against. Visible for tests and
+  /// for the cubit's reconnect logic, which needs to know whether the
+  /// transport has a live host binding before issuing the next write.
+  String? get activeEndpoint => _activeEndpoint;
 
   /// Serialise [msg] and write it as one or more GATT fragments.
   ///
   /// Fragments are written sequentially — each `writeControlBytes` call
   /// awaits before the next begins, matching the GATT write-without-response
   /// ordering contract.
+  ///
+  /// When an active endpoint is set (see [setActiveEndpoint]) and the
+  /// transport has an MTU oracle wired, this queries the negotiated MTU
+  /// per write and sizes fragments to `min(mtu - 3, kMaxFragmentSize)` so
+  /// the link doesn't refragment writes. If the negotiated MTU is below
+  /// [kMinControlMtu] the send aborts (logged + dropped) — mirroring the
+  /// voice plane's `kVoiceMtu` floor and the protocol's
+  /// "version-mismatch → disconnect" rule, without taking the link down
+  /// unilaterally from the Dart side.
+  ///
+  /// When no endpoint is bound, no MTU oracle is wired, or the oracle
+  /// returns null (no MTU observed yet), the encoder falls back to
+  /// [kMaxFragmentSize] — the same behavior the transport had before MTU
+  /// plumbing landed.
   Future<void> send(FrequencyMessage msg) async {
-    final fragments = encodeFragments(msg.encode());
+    final maxFragmentSize = await _resolveFragmentSize();
+    if (maxFragmentSize == null) {
+      // MTU below the control-plane floor — drop the message rather than
+      // emit fragments the link can't reliably carry. Caller (cubit) is
+      // responsible for tearing down the connection if this persists.
+      return;
+    }
+    final fragments = encodeFragments(
+      msg.encode(),
+      maxFragmentSize: maxFragmentSize,
+    );
     for (final f in fragments) {
       await _writeBytes(f);
     }
+  }
+
+  /// Returns the per-fragment byte budget [send] should request from the
+  /// encoder, or null if the negotiated MTU is below [kMinControlMtu] and
+  /// the send must abort.
+  Future<int?> _resolveFragmentSize() async {
+    final endpoint = _activeEndpoint;
+    final getMtu = _getMtu;
+    if (endpoint == null || getMtu == null) return kMaxFragmentSize;
+
+    final mtu = await getMtu(endpoint);
+    if (mtu == null) {
+      // No MTU observed yet (e.g. native side hasn't seen `onMtuChanged`
+      // for this connection). Use the protocol default rather than gating
+      // every send on a negotiation that may never happen explicitly —
+      // BLE only fires `onMtuChanged` when one side requests a non-default
+      // MTU.
+      return kMaxFragmentSize;
+    }
+    if (mtu < kMinControlMtu) {
+      debugPrint(
+        'BleControlTransport: aborting send — negotiated MTU $mtu '
+        'below floor $kMinControlMtu for endpoint $endpoint',
+      );
+      return null;
+    }
+    // MTU ≥ kMinControlMtu (64), so budget ≥ 61 — comfortably above the
+    // encoder's kMinFragmentSize (23). Clamp to the v1 ceiling so we
+    // never request a fragment size larger than the protocol's wire cap,
+    // even if a future link layer reports an inflated MTU.
+    final budget = mtu - kAttHeaderOverhead;
+    return budget < kMaxFragmentSize ? budget : kMaxFragmentSize;
   }
 
   /// Drop the sequence-filter watermark and reassembler buffer for [peerId].

--- a/lib/services/ble_control_transport.dart
+++ b/lib/services/ble_control_transport.dart
@@ -117,13 +117,19 @@ class BleControlTransport {
   /// returns null (no MTU observed yet), the encoder falls back to
   /// [kMaxFragmentSize] — the same behavior the transport had before MTU
   /// plumbing landed.
-  Future<void> send(FrequencyMessage msg) async {
+  ///
+  /// Returns true when the message reached the wire, false when an
+  /// MTU-floor violation caused the transport to drop the send. The cubit
+  /// uses this signal to decide whether to disconnect: a single drop is
+  /// expected (just-connected, MTU not yet observed → retry); persistent
+  /// drops over the heartbeat window mean the link is unusable.
+  Future<bool> send(FrequencyMessage msg) async {
     final maxFragmentSize = await _resolveFragmentSize();
     if (maxFragmentSize == null) {
       // MTU below the control-plane floor — drop the message rather than
       // emit fragments the link can't reliably carry. Caller (cubit) is
       // responsible for tearing down the connection if this persists.
-      return;
+      return false;
     }
     final fragments = encodeFragments(
       msg.encode(),
@@ -132,6 +138,7 @@ class BleControlTransport {
     for (final f in fragments) {
       await _writeBytes(f);
     }
+    return true;
   }
 
   /// Returns the per-fragment byte budget [send] should request from the

--- a/test/services/ble_control_transport_test.dart
+++ b/test/services/ble_control_transport_test.dart
@@ -224,6 +224,215 @@ void main() {
       });
     });
 
+    group('MTU-aware send', () {
+      // Custom transport per-test so each test can wire its own MTU oracle.
+      late StreamController<({String endpointId, Uint8List bytes})> mtuController;
+      late List<Uint8List> mtuWritten;
+
+      setUp(() {
+        mtuController = StreamController.broadcast();
+        mtuWritten = [];
+      });
+
+      tearDown(() async {
+        await mtuController.close();
+      });
+
+      test('does not consult the MTU oracle when no active endpoint is set',
+          () async {
+        var mtuCalls = 0;
+        final t = BleControlTransport.forTest(
+          controlBytes: mtuController.stream,
+          writeBytes: (bytes) async => mtuWritten.add(bytes),
+          getMtu: (_) async {
+            mtuCalls++;
+            return 100;
+          },
+        );
+
+        await t.send(_heartbeat());
+
+        // Without setActiveEndpoint, the oracle is never consulted and the
+        // encoder uses kMaxFragmentSize. Heartbeat is small enough to land
+        // in a single fragment regardless.
+        expect(mtuCalls, 0);
+        expect(mtuWritten, hasLength(1));
+        // The single fragment was sized against kMaxFragmentSize, not the
+        // smaller MTU 100.
+        expect(mtuWritten.first.length, lessThanOrEqualTo(kMaxFragmentSize));
+        t.dispose();
+      });
+
+      test('queries MTU for the active endpoint and sizes fragments accordingly',
+          () async {
+        var queriedFor = <String>[];
+        final t = BleControlTransport.forTest(
+          controlBytes: mtuController.stream,
+          writeBytes: (bytes) async => mtuWritten.add(bytes),
+          getMtu: (endpointId) async {
+            queriedFor.add(endpointId);
+            return 100; // Force smaller fragments.
+          },
+        );
+        t.setActiveEndpoint('host-mac-1');
+
+        final msg = JoinAccepted(
+          peerId: 'host',
+          seq: 1,
+          atMs: 1000,
+          hostPeerId: 'host',
+          roster: List.generate(
+            12,
+            (i) => ProtocolPeer(
+              peerId: 'p$i-long-uuid-string-padding-here',
+              displayName: 'User $i with a longer display name',
+            ),
+          ),
+        );
+
+        await t.send(msg);
+
+        expect(queriedFor, ['host-mac-1']);
+        // MTU 100 → fragment ceiling 97. Every fragment except the last
+        // must be exactly 97 bytes (header + payload).
+        expect(mtuWritten.length, greaterThan(1));
+        for (final f in mtuWritten.take(mtuWritten.length - 1)) {
+          expect(f.length, 97, reason: 'mid-stream fragment must be exactly mtu-3');
+        }
+        // Last fragment is the remainder; must be ≤ 97.
+        expect(mtuWritten.last.length, lessThanOrEqualTo(97));
+
+        // Reassemble end-to-end and verify identity.
+        final r = FragmentReassembler();
+        String? json;
+        for (final f in mtuWritten) {
+          json = r.feed(f);
+        }
+        expect(json, isNotNull);
+        final decoded = FrequencyMessage.decode(json!) as JoinAccepted;
+        expect(decoded.roster, hasLength(12));
+        t.dispose();
+      });
+
+      test('falls back to kMaxFragmentSize when oracle returns null', () async {
+        final t = BleControlTransport.forTest(
+          controlBytes: mtuController.stream,
+          writeBytes: (bytes) async => mtuWritten.add(bytes),
+          getMtu: (_) async => null,
+        );
+        t.setActiveEndpoint('host-mac-1');
+
+        await t.send(_heartbeat());
+
+        // Single small message → single fragment regardless. The point is
+        // it doesn't throw and writeBytes is still invoked.
+        expect(mtuWritten, hasLength(1));
+        t.dispose();
+      });
+
+      test('aborts the send when MTU is below kMinControlMtu', () async {
+        final t = BleControlTransport.forTest(
+          controlBytes: mtuController.stream,
+          writeBytes: (bytes) async => mtuWritten.add(bytes),
+          getMtu: (_) async => kMinControlMtu - 1, // 63: just below floor.
+        );
+        t.setActiveEndpoint('host-mac-1');
+
+        await t.send(_heartbeat());
+
+        // Nothing reached the wire — the aborted send leaves the link
+        // intact for the caller to tear down (or wait out).
+        expect(mtuWritten, isEmpty);
+        t.dispose();
+      });
+
+      test('exactly kMinControlMtu allows the send through', () async {
+        final t = BleControlTransport.forTest(
+          controlBytes: mtuController.stream,
+          writeBytes: (bytes) async => mtuWritten.add(bytes),
+          getMtu: (_) async => kMinControlMtu,
+        );
+        t.setActiveEndpoint('host-mac-1');
+
+        await t.send(_heartbeat());
+
+        // At least one fragment hit the wire, none above the budget
+        // (mtu - att header = 61).
+        expect(mtuWritten, isNotEmpty);
+        final budget = kMinControlMtu - kAttHeaderOverhead;
+        for (final f in mtuWritten) {
+          expect(f.length, lessThanOrEqualTo(budget));
+        }
+        // Round-trip survives the small fragments.
+        final r = FragmentReassembler();
+        String? json;
+        for (final f in mtuWritten) {
+          json = r.feed(f);
+        }
+        expect(json, isNotNull);
+        expect(FrequencyMessage.decode(json!), isA<Heartbeat>());
+        t.dispose();
+      });
+
+      test('high MTU (>247) is clamped to kMaxFragmentSize', () async {
+        // Some link layers report an inflated MTU; we must not request a
+        // fragment size above the v1 ceiling regardless.
+        final t = BleControlTransport.forTest(
+          controlBytes: mtuController.stream,
+          writeBytes: (bytes) async => mtuWritten.add(bytes),
+          getMtu: (_) async => 512,
+        );
+        t.setActiveEndpoint('host-mac-1');
+
+        // Build a message larger than one 247-byte fragment so we can
+        // observe the cap.
+        final big = JoinAccepted(
+          peerId: 'host',
+          seq: 1,
+          atMs: 1000,
+          hostPeerId: 'host',
+          roster: List.generate(
+            15,
+            (i) => ProtocolPeer(
+              peerId: 'p$i-very-long-uuid-here-padding-padding',
+              displayName: 'User $i with a longer display name',
+            ),
+          ),
+        );
+
+        await t.send(big);
+
+        for (final f in mtuWritten) {
+          expect(f.length, lessThanOrEqualTo(kMaxFragmentSize));
+        }
+        t.dispose();
+      });
+
+      test('clearing the active endpoint reverts to default fragmentation',
+          () async {
+        var calls = 0;
+        final t = BleControlTransport.forTest(
+          controlBytes: mtuController.stream,
+          writeBytes: (bytes) async => mtuWritten.add(bytes),
+          getMtu: (_) async {
+            calls++;
+            return 64;
+          },
+        );
+
+        t.setActiveEndpoint('host-mac-1');
+        await t.send(_heartbeat(seq: 1));
+        expect(calls, 1);
+
+        t.setActiveEndpoint(null);
+        await t.send(_heartbeat(seq: 2));
+        // No further oracle calls after clearing the binding.
+        expect(calls, 1);
+        expect(t.activeEndpoint, isNull);
+        t.dispose();
+      });
+    });
+
     group('forgetPeer', () {
       test('resets the seq watermark so a reconnecting peer is accepted',
           () async {

--- a/test/services/ble_control_transport_test.dart
+++ b/test/services/ble_control_transport_test.dart
@@ -338,10 +338,11 @@ void main() {
         );
         t.setActiveEndpoint('host-mac-1');
 
-        await t.send(_heartbeat());
+        final ok = await t.send(_heartbeat());
 
-        // Nothing reached the wire — the aborted send leaves the link
-        // intact for the caller to tear down (or wait out).
+        // Drop is surfaced to the caller (cubit) so disconnect/remediation
+        // logic can fire — and nothing reached the wire.
+        expect(ok, isFalse);
         expect(mtuWritten, isEmpty);
         t.dispose();
       });
@@ -354,8 +355,9 @@ void main() {
         );
         t.setActiveEndpoint('host-mac-1');
 
-        await t.send(_heartbeat());
+        final ok = await t.send(_heartbeat());
 
+        expect(ok, isTrue);
         // At least one fragment hit the wire, none above the budget
         // (mtu - att header = 61).
         expect(mtuWritten, isNotEmpty);


### PR DESCRIPTION
## Summary

Closes #45 (Dart-side + native query). Wires the native MTU cache (already populated in `GattServerManager.onMtuChanged`) through to Dart so `BleControlTransport` can size GATT fragments against the actual negotiated ATT MTU instead of always emitting 247-byte writes the link might re-fragment unpredictably.

- **Native** (`MainActivity.kt`): new `getNegotiatedMtu(endpointId)` MethodChannel handler returns the cached MTU from `GattServerManager.getMtu`, or null when no negotiation has fired for that endpoint yet.
- **Dart** (`audio_service.dart`): symmetric `getNegotiatedMtu(endpointId)` wrapper. Returns null on platform error so callers can fall back instead of blocking the wire.
- **`BleControlTransport`** (`ble_control_transport.dart`):
  - New `setActiveEndpoint(String?)` / `activeEndpoint` lets the cubit pin the transport to the host's BT MAC once the GATT-client connection (issue #43) is established. Stays null on the host side, which doesn't write through `BleControlTransport.send` today.
  - `send` now resolves a per-write fragment budget: when an active endpoint is pinned and an MTU oracle is wired, it queries `getNegotiatedMtu` and sizes fragments to `min(mtu - 3, kMaxFragmentSize)`. Below the new `kMinControlMtu = 64` floor (mirroring `kVoiceMtu` for the voice plane) the send is dropped — log + no-op rather than tearing the link down unilaterally; the cubit owns the disconnect decision.
  - When no endpoint is pinned, oracle is absent, or MTU is unknown, falls back to `kMaxFragmentSize` — preserving pre-MTU behavior for the host side and tests that don't wire the oracle.

Existing `forTest` callers don't break: the new `getMtu` parameter is optional. The framing-side `encodeFragments(maxFragmentSize:)` parameterization the issue asks for already landed on main; this PR is the upstream plumbing that makes it useful.

## What this PR does NOT do

The issue's `BleControlTransport.send` step says "abort with a `version_mismatch`-style disconnect" when the MTU is below the floor. This PR drops the send and logs; the actual disconnect lives one layer up and will be wired by the cubit once it can observe the abort signal. Surfacing abort-as-event from the transport is left for the cubit-integration PR that lands alongside #43 (GATT client) — there's no caller today on the guest side to dial up that disconnect.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 332 passing, 1 pre-existing skip
- [x] New `MTU-aware send` group in `ble_control_transport_test.dart` covers: no-endpoint short-circuit, MTU-aware fragment sizing (verifies mid-stream fragments are exactly `mtu - 3` bytes and end-to-end reassembly survives), null-MTU fallback to default, sub-floor MTU aborts the send, exact-floor MTU passes through, inflated MTU clamped to `kMaxFragmentSize`, and clearing the active endpoint reverts to default fragmentation.
- [ ] Manual smoke test on a real device pair — deferred until the GATT client (issue #43) lands and a connection actually negotiates a non-default MTU; until then the host side stays on `kMaxFragmentSize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bluetooth transfer now adapts to the negotiated MTU between devices, optimizing packet fragmentation for improved reliability and efficiency.
  * Native MTU reporting added so the app can query observed connection capacity; gracefully falls back when unavailable.

* **Bug Fixes / Reliability**
  * Messages are dropped early for extremely small MTUs to avoid partial/failing transfers.

* **Tests**
  * Added comprehensive MTU-aware tests covering fragmentation, edge cases, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->