### PR TITLE
feat(#41): Native LE advertiser for the host

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -51,20 +51,55 @@ class HostAdvertiser(private val context: Context) {
         context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
     private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager?.adapter
 
+    // The advertiser handle and state flags are touched from both the caller
+    // thread (start/stop on the platform main thread) and the OS-issued
+    // AdvertiseCallback thread. Mark them @Volatile so the callback can't
+    // observe a partially-published state and the caller can't race the
+    // callback on the success/failure transition.
+    @Volatile
     private var advertiser: BluetoothLeAdvertiser? = null
+
+    @Volatile
     private var isAdvertising = false
+
+    // Tracks the gap between issuing startAdvertising and the OS calling
+    // back with success/failure. Without it, a fast caller could observe
+    // isAdvertising=false right after a successful start() and re-issue,
+    // tripping ADVERTISE_FAILED_ALREADY_STARTED on the second call.
+    @Volatile
+    private var isStarting = false
+
+    // Captured before adapter.setName() so stop() can put the user's
+    // device-wide BT name back. Null means we never changed it (start
+    // bailed before mutating) or we already restored.
+    @Volatile
+    private var savedAdapterName: String? = null
 
     private val advertiseCallback = object : AdvertiseCallback() {
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
-            Log.i(TAG, "Advertising started: $settingsInEffect")
+            // Promote isStarting → isAdvertising only when the OS confirms
+            // the radio is on the air. A premature flip in start() would let
+            // a fire-and-forget caller (the cubit uses unawaited) treat a
+            // later onStartFailure as success and never retry.
+            isStarting = false
+            isAdvertising = true
+            Log.i(TAG, "Advertising started")
         }
 
         override fun onStartFailure(errorCode: Int) {
-            // Reset the flag so a retry can re-issue startAdvertising. The
-            // BluetoothLeAdvertiser doesn't surface the error any other way;
-            // OEM-specific causes (chipset stuck, too many advertisers) just
-            // log here and the caller observes a quiet wire.
+            // Reset both flags + clear the advertiser handle so a retry can
+            // re-issue startAdvertising. The BluetoothLeAdvertiser doesn't
+            // surface the error any other way; OEM-specific causes (chipset
+            // stuck, too many advertisers) just log here and the caller
+            // observes a quiet wire.
+            isStarting = false
             isAdvertising = false
+            advertiser = null
+            // Best-effort restore of the user's BT name on async failure —
+            // we may have set it already in the caller and the OS just
+            // refused to advertise. Same SecurityException swallow as
+            // restoreAdapterName().
+            restoreAdapterName()
             val reason = when (errorCode) {
                 ADVERTISE_FAILED_ALREADY_STARTED -> "already started"
                 ADVERTISE_FAILED_DATA_TOO_LARGE -> "data too large"
@@ -80,20 +115,24 @@ class HostAdvertiser(private val context: Context) {
     /**
      * Start LE advertising the host's session.
      *
-     * Idempotent: a second call while already advertising returns true
-     * without re-issuing — the underlying [BluetoothLeAdvertiser] would
-     * reject it with [AdvertiseCallback.ADVERTISE_FAILED_ALREADY_STARTED]
-     * anyway, and treating that as success here matches the rest of the
-     * native surface (start GATT server, start voice server).
+     * Idempotent: a second call while already advertising (or while the
+     * first start is awaiting OS confirmation) returns true without
+     * re-issuing — the underlying [BluetoothLeAdvertiser] would reject it
+     * with [AdvertiseCallback.ADVERTISE_FAILED_ALREADY_STARTED] anyway,
+     * and treating that as success here matches the rest of the native
+     * surface (start GATT server, start voice server).
      *
      * Returns false on any pre-flight failure: Bluetooth off, advertising
      * unsupported on the chipset, malformed [sessionUuid], or a
      * [SecurityException] from the missing BLUETOOTH_ADVERTISE permission.
      * Async failures from the OS arrive on the [advertiseCallback] and are
-     * logged; callers see them indirectly through a quiet wire.
+     * logged; callers see them indirectly through a quiet wire. A `true`
+     * return therefore only means *the request was accepted* — the
+     * [advertiseCallback] is the single source of truth for whether the
+     * radio is actually on the air.
      */
     fun start(sessionUuid: String, displayName: String): Boolean {
-        if (isAdvertising) {
+        if (isAdvertising || isStarting) {
             Log.i(TAG, "Already advertising; ignoring start request")
             return true
         }
@@ -113,19 +152,29 @@ class HostAdvertiser(private val context: Context) {
         val payload = try {
             buildManufacturerPayload(sessionUuid)
         } catch (e: IllegalArgumentException) {
-            Log.e(TAG, "Invalid sessionUuid: $sessionUuid", e)
+            Log.e(TAG, "Invalid sessionUuid", e)
             return false
         }
 
-        // Including the device name pushes us close to the 31-byte legacy
-        // adv frame budget when the user's name is long. Set it on the
-        // adapter (the system truncates to fit) and let setIncludeDeviceName
-        // handle the rest. Failing to set the name is non-fatal — guests
-        // fall back to the manufacturer payload + host's BT MAC.
-        try {
-            adapter.setName(displayName)
+        // Setting setIncludeDeviceName(true) below pulls the *adapter* name
+        // into the adv frame; that's a system-wide setting that survives
+        // process death. Capture the current value so stop() can put it
+        // back — otherwise a Frequency host session would permanently
+        // rename the user's phone in their Bluetooth settings. Skipping
+        // the rename if it already matches avoids touching the adapter
+        // when the user's existing BT name is already their display name.
+        val previousName = try {
+            adapter.name
         } catch (e: SecurityException) {
-            Log.w(TAG, "Could not set adapter name (BLUETOOTH_CONNECT missing)", e)
+            null
+        }
+        if (previousName != displayName) {
+            try {
+                adapter.setName(displayName)
+                savedAdapterName = previousName
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Could not set adapter name (BLUETOOTH_CONNECT missing)", e)
+            }
         }
 
         val data = AdvertiseData.Builder()
@@ -142,35 +191,73 @@ class HostAdvertiser(private val context: Context) {
             .build()
 
         return try {
-            leAdvertiser.startAdvertising(settings, data, advertiseCallback)
+            // Order matters: claim isStarting *before* the platform call so
+            // a callback that fires synchronously on the same thread sees a
+            // consistent state and the success transition lands on top.
+            isStarting = true
             advertiser = leAdvertiser
-            isAdvertising = true
-            Log.i(TAG, "Advertising start requested for session=$sessionUuid name=$displayName")
+            leAdvertiser.startAdvertising(settings, data, advertiseCallback)
+            Log.i(TAG, "Advertising start requested")
             true
         } catch (e: SecurityException) {
+            isStarting = false
+            advertiser = null
+            restoreAdapterName()
             Log.e(TAG, "Missing BLUETOOTH_ADVERTISE permission", e)
             false
         } catch (e: Exception) {
+            isStarting = false
+            advertiser = null
+            restoreAdapterName()
             Log.e(TAG, "Error starting advertising", e)
             false
         }
     }
 
     /**
-     * Stop LE advertising. Safe to call when not running.
+     * Stop LE advertising and restore the user's previous Bluetooth name.
+     * Safe to call when not running.
+     *
+     * Returns true on a clean stop (or when nothing was running), false if
+     * the platform threw — letting the MethodChannel caller surface the
+     * failure to Dart instead of pretending everything went green.
      */
-    fun stop() {
-        val leAdvertiser = advertiser ?: return
+    fun stop(): Boolean {
+        val leAdvertiser = advertiser
+        // Always clear local state, even if the underlying call throws or
+        // there's nothing to stop — leaving stale flags would block a
+        // subsequent start().
+        advertiser = null
+        isAdvertising = false
+        isStarting = false
+
+        var success = true
+        if (leAdvertiser != null) {
+            try {
+                leAdvertiser.stopAdvertising(advertiseCallback)
+                Log.i(TAG, "Advertising stopped")
+            } catch (e: SecurityException) {
+                success = false
+                Log.e(TAG, "Missing Bluetooth permissions for stopAdvertising", e)
+            } catch (e: Exception) {
+                success = false
+                Log.e(TAG, "Error stopping advertising", e)
+            }
+        }
+        // Restore even if stopAdvertising threw — we don't want a stuck
+        // SecurityException to permanently keep the user's phone renamed.
+        restoreAdapterName()
+        return success
+    }
+
+    private fun restoreAdapterName() {
+        val saved = savedAdapterName ?: return
+        savedAdapterName = null
+        val adapter = bluetoothAdapter ?: return
         try {
-            leAdvertiser.stopAdvertising(advertiseCallback)
-            Log.i(TAG, "Advertising stopped")
+            adapter.setName(saved)
         } catch (e: SecurityException) {
-            Log.e(TAG, "Missing Bluetooth permissions for stopAdvertising", e)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error stopping advertising", e)
-        } finally {
-            advertiser = null
-            isAdvertising = false
+            Log.w(TAG, "Could not restore adapter name", e)
         }
     }
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -1,0 +1,203 @@
+package com.elodin.walkie_talkie
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.content.Context
+import android.os.ParcelUuid
+import android.util.Log
+import java.util.UUID
+
+/**
+ * Host-side LE advertiser for the Frequency control plane.
+ *
+ * Broadcasts the walkie-talkie service UUID and a 16-byte manufacturer
+ * payload (protocol version, role, low 8 bytes of sessionUuid, reserved
+ * flags). Guests scanning with the same service UUID parse the payload
+ * Dart-side in lib/protocol/discovery.dart.
+ *
+ * Per docs/protocol.md § "Bluetooth LE advertising".
+ */
+class HostAdvertiser(private val context: Context) {
+    companion object {
+        private const val TAG = "HostAdvertiser"
+
+        // Same 128-bit UUID Dart guests filter on (see kWalkieTalkieServiceUuid
+        // in lib/protocol/discovery.dart). Kept in sync with
+        // GattServerManager.SERVICE_UUID — they're the same wire identifier.
+        val SERVICE_UUID: UUID = GattServerManager.SERVICE_UUID
+
+        // Test/internal manufacturer ID range (0xFFFF). Fine for v1; if we
+        // ever ship with a real Bluetooth SIG company ID this is the single
+        // place to swap it.
+        private const val MANUFACTURER_ID = 0xFFFF
+
+        private const val PROTOCOL_VERSION_V1: Byte = 0x01
+        private const val ROLE_HOST: Byte = 0x01
+
+        // Payload layout from docs/protocol.md § "Bluetooth LE advertising":
+        //   [0]    protocol version (0x01 for v1)
+        //   [1]    role (0x01 = host)
+        //   [2..9] low 8 bytes of sessionUuid (big-endian)
+        //   [10,11] flags (reserved, zero in v1)
+        //   [12..15] reserved
+        const val MANUFACTURER_PAYLOAD_SIZE = 16
+    }
+
+    private val bluetoothManager: BluetoothManager? =
+        context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager?.adapter
+
+    private var advertiser: BluetoothLeAdvertiser? = null
+    private var isAdvertising = false
+
+    private val advertiseCallback = object : AdvertiseCallback() {
+        override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
+            Log.i(TAG, "Advertising started: $settingsInEffect")
+        }
+
+        override fun onStartFailure(errorCode: Int) {
+            // Reset the flag so a retry can re-issue startAdvertising. The
+            // BluetoothLeAdvertiser doesn't surface the error any other way;
+            // OEM-specific causes (chipset stuck, too many advertisers) just
+            // log here and the caller observes a quiet wire.
+            isAdvertising = false
+            val reason = when (errorCode) {
+                ADVERTISE_FAILED_ALREADY_STARTED -> "already started"
+                ADVERTISE_FAILED_DATA_TOO_LARGE -> "data too large"
+                ADVERTISE_FAILED_FEATURE_UNSUPPORTED -> "feature unsupported"
+                ADVERTISE_FAILED_INTERNAL_ERROR -> "internal error"
+                ADVERTISE_FAILED_TOO_MANY_ADVERTISERS -> "too many advertisers"
+                else -> "unknown ($errorCode)"
+            }
+            Log.e(TAG, "Advertising failed: $reason")
+        }
+    }
+
+    /**
+     * Start LE advertising the host's session.
+     *
+     * Idempotent: a second call while already advertising returns true
+     * without re-issuing — the underlying [BluetoothLeAdvertiser] would
+     * reject it with [AdvertiseCallback.ADVERTISE_FAILED_ALREADY_STARTED]
+     * anyway, and treating that as success here matches the rest of the
+     * native surface (start GATT server, start voice server).
+     *
+     * Returns false on any pre-flight failure: Bluetooth off, advertising
+     * unsupported on the chipset, malformed [sessionUuid], or a
+     * [SecurityException] from the missing BLUETOOTH_ADVERTISE permission.
+     * Async failures from the OS arrive on the [advertiseCallback] and are
+     * logged; callers see them indirectly through a quiet wire.
+     */
+    fun start(sessionUuid: String, displayName: String): Boolean {
+        if (isAdvertising) {
+            Log.i(TAG, "Already advertising; ignoring start request")
+            return true
+        }
+
+        val adapter = bluetoothAdapter
+        if (adapter == null || !adapter.isEnabled) {
+            Log.e(TAG, "Bluetooth adapter unavailable or disabled")
+            return false
+        }
+
+        val leAdvertiser = adapter.bluetoothLeAdvertiser
+        if (leAdvertiser == null) {
+            Log.e(TAG, "BluetoothLeAdvertiser unavailable (peripheral mode unsupported?)")
+            return false
+        }
+
+        val payload = try {
+            buildManufacturerPayload(sessionUuid)
+        } catch (e: IllegalArgumentException) {
+            Log.e(TAG, "Invalid sessionUuid: $sessionUuid", e)
+            return false
+        }
+
+        // Including the device name pushes us close to the 31-byte legacy
+        // adv frame budget when the user's name is long. Set it on the
+        // adapter (the system truncates to fit) and let setIncludeDeviceName
+        // handle the rest. Failing to set the name is non-fatal — guests
+        // fall back to the manufacturer payload + host's BT MAC.
+        try {
+            adapter.setName(displayName)
+        } catch (e: SecurityException) {
+            Log.w(TAG, "Could not set adapter name (BLUETOOTH_CONNECT missing)", e)
+        }
+
+        val data = AdvertiseData.Builder()
+            .addServiceUuid(ParcelUuid(SERVICE_UUID))
+            .addManufacturerData(MANUFACTURER_ID, payload)
+            .setIncludeDeviceName(true)
+            .build()
+
+        val settings = AdvertiseSettings.Builder()
+            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+            .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+            .setConnectable(true)
+            .setTimeout(0)
+            .build()
+
+        return try {
+            leAdvertiser.startAdvertising(settings, data, advertiseCallback)
+            advertiser = leAdvertiser
+            isAdvertising = true
+            Log.i(TAG, "Advertising start requested for session=$sessionUuid name=$displayName")
+            true
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Missing BLUETOOTH_ADVERTISE permission", e)
+            false
+        } catch (e: Exception) {
+            Log.e(TAG, "Error starting advertising", e)
+            false
+        }
+    }
+
+    /**
+     * Stop LE advertising. Safe to call when not running.
+     */
+    fun stop() {
+        val leAdvertiser = advertiser ?: return
+        try {
+            leAdvertiser.stopAdvertising(advertiseCallback)
+            Log.i(TAG, "Advertising stopped")
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Missing Bluetooth permissions for stopAdvertising", e)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error stopping advertising", e)
+        } finally {
+            advertiser = null
+            isAdvertising = false
+        }
+    }
+
+    /**
+     * Build the 16-byte manufacturer payload from the canonical session UUID
+     * string. Throws [IllegalArgumentException] if [sessionUuid] is not a
+     * valid UUID — callers should treat this as a programmer error
+     * (the host cubit mints the UUID; a bad value means a regression upstream).
+     *
+     * Visible for the MainActivity wiring path; not part of the public API.
+     */
+    internal fun buildManufacturerPayload(sessionUuid: String): ByteArray {
+        // UUID.fromString rejects any other shape; an IllegalArgumentException
+        // bubbles to start() and turns into a logged false return.
+        val uuid = UUID.fromString(sessionUuid)
+        // The 64-bit "least significant bits" of a UUID *are* the low 8 bytes
+        // in canonical big-endian order — that's how the docs/protocol.md
+        // mhz derivation reads them on the guest side. Encode high byte first.
+        val lsb = uuid.leastSignificantBits
+
+        val payload = ByteArray(MANUFACTURER_PAYLOAD_SIZE)
+        payload[0] = PROTOCOL_VERSION_V1
+        payload[1] = ROLE_HOST
+        for (i in 0..7) {
+            payload[2 + i] = ((lsb ushr (56 - i * 8)) and 0xFFL).toByte()
+        }
+        // payload[10..15] stay zero: reserved flags + reserved bytes per spec.
+        return payload
+    }
+}

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -188,6 +188,10 @@ class HostAdvertiser(private val context: Context) {
         val previousName = try {
             adapter.name
         } catch (e: SecurityException) {
+            // Read failure means we can't capture-then-restore — the rename
+            // path will skip and the user's adapter name stays untouched.
+            // Worth logging since silent restore-skips are otherwise invisible.
+            Log.w(TAG, "Could not read adapter name; restore will be skipped", e)
             null
         }
         if (previousName != displayName) {
@@ -199,8 +203,21 @@ class HostAdvertiser(private val context: Context) {
             }
         }
 
-        val data = AdvertiseData.Builder()
+        // The 31-byte legacy ADV_IND budget can't fit *all* of: flags (auto),
+        // 128-bit service UUID (18 bytes including header), 16-byte
+        // manufacturer payload (20 bytes including header), and the adapter
+        // device name. 18 + 20 alone overflows. Split across primary adv
+        // (service UUID — keeps passive scanners able to filter) and scan
+        // response (manufacturer payload + device name — only fetched on the
+        // SCAN_REQ that active scanners issue, which is what the Dart
+        // DiscoveryService does). The Android stack merges both records into
+        // ScanRecord, so DiscoveredSession.fromManufacturerData reassembles
+        // them transparently.
+        val advData = AdvertiseData.Builder()
             .addServiceUuid(ParcelUuid(SERVICE_UUID))
+            .build()
+
+        val scanResponse = AdvertiseData.Builder()
             .addManufacturerData(MANUFACTURER_ID, payload)
             .setIncludeDeviceName(true)
             .build()
@@ -224,7 +241,7 @@ class HostAdvertiser(private val context: Context) {
             isStarting = true
             advertiser = leAdvertiser
             currentCallback = cb
-            leAdvertiser.startAdvertising(settings, data, cb)
+            leAdvertiser.startAdvertising(settings, advData, scanResponse, cb)
             Log.i(TAG, "Advertising start requested")
             true
         } catch (e: SecurityException) {
@@ -286,12 +303,17 @@ class HostAdvertiser(private val context: Context) {
 
     private fun restoreAdapterName() {
         val saved = savedAdapterName ?: return
-        savedAdapterName = null
         val adapter = bluetoothAdapter ?: return
         try {
             adapter.setName(saved)
+            // Only drop the rollback value once the OS confirmed it stuck.
+            // If setName throws (e.g., BLUETOOTH_CONNECT revoked between
+            // start and stop), keep savedAdapterName so a subsequent stop()
+            // or onDestroy() can retry the restore — losing the original
+            // here would leave the user's phone permanently renamed.
+            savedAdapterName = null
         } catch (e: SecurityException) {
-            Log.w(TAG, "Could not restore adapter name", e)
+            Log.w(TAG, "Could not restore adapter name; will retry on next stop", e)
         }
     }
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -75,8 +75,23 @@ class HostAdvertiser(private val context: Context) {
     @Volatile
     private var savedAdapterName: String? = null
 
-    private val advertiseCallback = object : AdvertiseCallback() {
+    // The currently-active AdvertiseCallback. Each start() builds a fresh
+    // callback (see [makeCallback]) and stores it here; stop() and any
+    // failure path nulls it out. The callback's own methods compare
+    // `currentCallback === this` before mutating any state so a late
+    // event from a previous attempt — e.g. an onStartFailure that arrives
+    // after the user has already left and rejoined — can't clobber the
+    // new attempt's flags.
+    @Volatile
+    private var currentCallback: AdvertiseCallback? = null
+
+    private fun makeCallback(): AdvertiseCallback = object : AdvertiseCallback() {
         override fun onStartSuccess(settingsInEffect: AdvertiseSettings?) {
+            // Drop late events from a superseded attempt. Without this guard
+            // a stale onStartSuccess could promote isAdvertising for the
+            // *current* attempt that's still in its isStarting window, or
+            // worse, after stop() already cleared everything.
+            if (currentCallback !== this) return
             // Promote isStarting → isAdvertising only when the OS confirms
             // the radio is on the air. A premature flip in start() would let
             // a fire-and-forget caller (the cubit uses unawaited) treat a
@@ -87,6 +102,12 @@ class HostAdvertiser(private val context: Context) {
         }
 
         override fun onStartFailure(errorCode: Int) {
+            if (currentCallback !== this) {
+                // Swallow stale failures silently — the new attempt owns
+                // state now. Logging the reason is fine, but only as debug.
+                Log.d(TAG, "Stale advertising failure ignored: code=$errorCode")
+                return
+            }
             // Reset both flags + clear the advertiser handle so a retry can
             // re-issue startAdvertising. The BluetoothLeAdvertiser doesn't
             // surface the error any other way; OEM-specific causes (chipset
@@ -95,6 +116,7 @@ class HostAdvertiser(private val context: Context) {
             isStarting = false
             isAdvertising = false
             advertiser = null
+            currentCallback = null
             // Best-effort restore of the user's BT name on async failure —
             // we may have set it already in the caller and the OS just
             // refused to advertise. Same SecurityException swallow as
@@ -125,11 +147,11 @@ class HostAdvertiser(private val context: Context) {
      * Returns false on any pre-flight failure: Bluetooth off, advertising
      * unsupported on the chipset, malformed [sessionUuid], or a
      * [SecurityException] from the missing BLUETOOTH_ADVERTISE permission.
-     * Async failures from the OS arrive on the [advertiseCallback] and are
-     * logged; callers see them indirectly through a quiet wire. A `true`
-     * return therefore only means *the request was accepted* — the
-     * [advertiseCallback] is the single source of truth for whether the
-     * radio is actually on the air.
+     * Async failures from the OS arrive on the per-attempt callback (built
+     * by [makeCallback]) and are logged; callers see them indirectly through
+     * a quiet wire. A `true` return therefore only means *the request was
+     * accepted* — the callback is the single source of truth for whether
+     * the radio is actually on the air.
      */
     fun start(sessionUuid: String, displayName: String): Boolean {
         if (isAdvertising || isStarting) {
@@ -190,24 +212,32 @@ class HostAdvertiser(private val context: Context) {
             .setTimeout(0)
             .build()
 
+        // Each attempt gets its own callback instance. The active marker
+        // (currentCallback) lets the AdvertiseCallback methods recognize
+        // events that belong to a superseded attempt and ignore them.
+        val cb = makeCallback()
         return try {
-            // Order matters: claim isStarting *before* the platform call so
-            // a callback that fires synchronously on the same thread sees a
-            // consistent state and the success transition lands on top.
+            // Order matters: claim isStarting + currentCallback *before* the
+            // platform call so a callback that fires synchronously on the
+            // same thread sees a consistent state and the success transition
+            // lands on top.
             isStarting = true
             advertiser = leAdvertiser
-            leAdvertiser.startAdvertising(settings, data, advertiseCallback)
+            currentCallback = cb
+            leAdvertiser.startAdvertising(settings, data, cb)
             Log.i(TAG, "Advertising start requested")
             true
         } catch (e: SecurityException) {
             isStarting = false
             advertiser = null
+            if (currentCallback === cb) currentCallback = null
             restoreAdapterName()
             Log.e(TAG, "Missing BLUETOOTH_ADVERTISE permission", e)
             false
         } catch (e: Exception) {
             isStarting = false
             advertiser = null
+            if (currentCallback === cb) currentCallback = null
             restoreAdapterName()
             Log.e(TAG, "Error starting advertising", e)
             false
@@ -224,17 +254,21 @@ class HostAdvertiser(private val context: Context) {
      */
     fun stop(): Boolean {
         val leAdvertiser = advertiser
+        val cb = currentCallback
         // Always clear local state, even if the underlying call throws or
         // there's nothing to stop — leaving stale flags would block a
-        // subsequent start().
+        // subsequent start(). Clearing currentCallback first means any
+        // late callback events for the just-stopped attempt see the
+        // identity-mismatch guard and bail without mutating state.
         advertiser = null
         isAdvertising = false
         isStarting = false
+        currentCallback = null
 
         var success = true
-        if (leAdvertiser != null) {
+        if (leAdvertiser != null && cb != null) {
             try {
-                leAdvertiser.stopAdvertising(advertiseCallback)
+                leAdvertiser.stopAdvertising(cb)
                 Log.i(TAG, "Advertising stopped")
             } catch (e: SecurityException) {
                 success = false

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -187,7 +187,10 @@ class MainActivity : FlutterActivity() {
                             null
                         )
                     } else {
-                        Log.i(TAG, "Starting LE advertising: session=$sessionUuid name=$displayName")
+                        // Don't echo sessionUuid / displayName here — both
+                        // are user/session identifiers and logcat is broadly
+                        // readable on dev builds.
+                        Log.i(TAG, "Starting LE advertising")
                         if (hostAdvertiser == null) {
                             hostAdvertiser = HostAdvertiser(this)
                         }
@@ -197,8 +200,11 @@ class MainActivity : FlutterActivity() {
                 }
                 "stopAdvertising" -> {
                     Log.i(TAG, "Stopping LE advertising")
-                    hostAdvertiser?.stop()
-                    result.success(true)
+                    // Propagate the underlying boolean so a SecurityException
+                    // inside HostAdvertiser.stop() doesn't pretend to be a
+                    // clean shutdown on the Dart side.
+                    val success = hostAdvertiser?.stop() ?: true
+                    result.success(success)
                 }
                 "startGattServer" -> {
                     Log.i(TAG, "Starting GATT server")

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -30,6 +30,7 @@ class MainActivity : FlutterActivity() {
     private var audioRoutingManager: AudioRoutingManager? = null
     private var gattServerManager: GattServerManager? = null
     private var gattClientManager: GattClientManager? = null
+    private var hostAdvertiser: HostAdvertiser? = null
     private var voiceTransport: L2capVoiceTransport? = null
     private var eventSink: EventChannel.EventSink? = null
     private var controlBytesSink: EventChannel.EventSink? = null
@@ -175,6 +176,29 @@ class MainActivity : FlutterActivity() {
                     } else {
                         result.error("INVALID_ARGUMENT", "muted is required", null)
                     }
+                }
+                "startAdvertising" -> {
+                    val sessionUuid = call.argument<String>("sessionUuid")
+                    val displayName = call.argument<String>("displayName")
+                    if (sessionUuid == null || displayName == null) {
+                        result.error(
+                            "INVALID_ARGUMENT",
+                            "sessionUuid and displayName are required",
+                            null
+                        )
+                    } else {
+                        Log.i(TAG, "Starting LE advertising: session=$sessionUuid name=$displayName")
+                        if (hostAdvertiser == null) {
+                            hostAdvertiser = HostAdvertiser(this)
+                        }
+                        val success = hostAdvertiser?.start(sessionUuid, displayName) ?: false
+                        result.success(success)
+                    }
+                }
+                "stopAdvertising" -> {
+                    Log.i(TAG, "Stopping LE advertising")
+                    hostAdvertiser?.stop()
+                    result.success(true)
                 }
                 "startGattServer" -> {
                     Log.i(TAG, "Starting GATT server")
@@ -414,6 +438,7 @@ class MainActivity : FlutterActivity() {
         voiceTransport?.stop()
         gattServerManager?.stop()
         gattClientManager?.disconnect()
+        hostAdvertiser?.stop()
         methodChannel?.setMethodCallHandler(null)
         eventChannel?.setStreamHandler(null)
         controlBytesEventChannel?.setStreamHandler(null)

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -252,9 +252,18 @@ class AudioService {
   /// the host on session start; the advertiser truncates it to the low
   /// 8 bytes per the wire spec.
   ///
-  /// Returns true if advertising started successfully, false otherwise.
-  /// The native implementation lands in issue #41; until then this is a
-  /// no-op stub on the platform side.
+  /// Returns true if the native side accepted the request — i.e. the
+  /// pre-flight passed (Bluetooth on, advertiser available, sessionUuid
+  /// well-formed) and `BluetoothLeAdvertiser.startAdvertising` was issued.
+  /// A `true` does **not** confirm the radio is on the air: Android
+  /// reports actual start success / failure asynchronously through its
+  /// `AdvertiseCallback`, and we currently log those events rather than
+  /// surfacing them back to Dart. Callers therefore treat advertising
+  /// as best-effort: a `false` return is a hard "won't be visible," but
+  /// a `true` still might silently fail downstream (OEM throttling,
+  /// `ADVERTISE_FAILED_TOO_MANY_ADVERTISERS`, etc.). That's acceptable
+  /// because the host doesn't depend on advertising to function — it only
+  /// affects whether other phones can discover the room.
   Future<bool> startAdvertising({
     required String sessionUuid,
     required String displayName,


### PR DESCRIPTION
## Summary

Closes #41. The Dart side (`AudioService.startAdvertising` / `stopAdvertising`) and the host bootstrap that calls them already shipped with #39 — until now the native MethodChannel returned `notImplemented`, so a host could *Start a Frequency* and the advertisement never went out the radio. This PR wires the missing native half so a second device running `DiscoveryService` actually sees the row appear.

- **New `HostAdvertiser.kt`** wraps `BluetoothLeAdvertiser`. Builds the 16-byte manufacturer payload per `docs/protocol.md` § *Bluetooth LE advertising*:
  - `[0]` version `0x01`
  - `[1]` role `0x01` (host)
  - `[2..9]` low 8 bytes of `sessionUuid` (big-endian)
  - `[10,11]` flags (reserved, zero in v1)
  - `[12..15]` reserved
- Manufacturer ID `0xFFFF` (test/internal range — fine for v1; one place to swap later). Service UUID reuses `GattServerManager.SERVICE_UUID` since they're the same wire identifier the Dart guests filter on (`kWalkieTalkieServiceUuid`).
- Advertise settings: `ADVERTISE_MODE_LOW_LATENCY` + `ADVERTISE_TX_POWER_HIGH` + connectable + no timeout.
- Idempotent `start`: a second call while advertising returns true rather than tripping `ADVERTISE_FAILED_ALREADY_STARTED` — matches the rest of the native surface (start GATT server, start voice server). Adapter name is set to `displayName` before building the payload so guests can render the row without an extra GATT round-trip; `SecurityException` there is logged but non-fatal (manufacturer payload + MAC are still on the wire).
- **`MainActivity`** wires `startAdvertising` / `stopAdvertising` MethodChannel handlers, lazily instantiates the advertiser on first use (mirrors `GattServerManager` / `L2capVoiceTransport`), and stops it from `onDestroy` alongside the other native managers so a process kill doesn't leave the radio advertising indefinitely.

The UUID encoding uses `UUID.leastSignificantBits`, whose 64 bits *are* the canonical low 8 bytes in big-endian order — that's exactly the orientation the Dart parser (`DiscoveredSession.fromManufacturerData`) reads, so a guest's `_deriveMhz` lands on the same MHz the host minted.

## What this PR does NOT do

- **No two-device smoke test.** That belongs to the manual runbook (#54) and needs a second device. The acceptance check stays: second device running `DiscoveryService` sees the row appear within 5 s; `stopAdvertising` makes it disappear within 5 s.
- **No Kotlin unit test for the payload encoder.** The Android module has no JUnit setup today and adding one to verify a 16-byte memcpy felt like dead weight. The Dart parser side is exhaustively tested in `test/protocol/discovery_test.dart`; if a real-device run shows a mismatch the encoder is the obvious first suspect.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 325 passing, 1 pre-existing skip (unchanged from main)
- [x] Existing host-bootstrap test (`test/bloc/frequency_session_cubit_test.dart`) still verifies the cubit fires `startAdvertising` with `{sessionUuid, displayName}` — the Dart contract this native PR plugs into is unchanged
- [ ] Manual two-device smoke test deferred to runbook #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android: added BLE advertising for session discovery with start/stop controls, optional display name, and encoded session identity. Startup reports success/failure and prevents stale advertising attempts.

* **Bug Fixes**
  * Ensures advertising is stopped when the app/activity is destroyed and attempts to restore the device name on shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->