### PR TITLE
feat(#109): Remove CAPTURE_AUDIO_OUTPUT permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,11 +16,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    
-    <!-- Optional: Phone audio capture (may not work with DRM-protected content) -->
-    <uses-permission android:name="android.permission.CAPTURE_AUDIO_OUTPUT" 
-        tools:ignore="ProtectedPermissions" />
-    
+
     <!-- Hardware requirements -->
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
     <uses-feature android:name="android.hardware.microphone" android:required="true" />


### PR DESCRIPTION
## Summary

Removes `android.permission.CAPTURE_AUDIO_OUTPUT` from `AndroidManifest.xml`. This permission is signature/system-only — only system or privileged apps can hold it — so the AAB is rejected by Play Console on upload. Per `docs/protocol.md` (Shared media), the host does not capture cross-app audio, so the permission is not needed.

The accompanying `tools:ignore="ProtectedPermissions"` annotation and its comment are also removed. The `xmlns:tools` declaration on `<manifest>` is left in place — it is conventional in Android manifests and removing it is out of scope.

Closes #109.

## Test plan

- [ ] CI build green
- [ ] `flutter build appbundle --release` produces an AAB that uploads cleanly to Play Console internal testing track (manual — verified by repo owner before launch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)