### PR TITLE
fix(#103): Peer drawer crash on cubit-driven roster (`_volumes[id]!`)

### DIFF
--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -84,8 +84,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   /// Per-peer playback volume, keyed by peerId. Populated lazily —
   /// only entries the user has explicitly adjusted exist; everything
   /// else reads through [_volumeFor] which falls back to
-  /// [_kDefaultPeerVolume]. Direct subscript reads will throw on
-  /// production cubit-driven peers, so always go through the helper.
+  /// [_kDefaultPeerVolume]. Null-asserting (`_volumes[peerId]!`) on
+  /// a cubit-driven peer will throw because the entry doesn't exist
+  /// yet, so always go through the helper instead of the raw map.
   late Map<String, double> _volumes;
   static const double _kDefaultPeerVolume = 0.7;
   double _volumeFor(String peerId) => _volumes[peerId] ?? _kDefaultPeerVolume;

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -81,7 +81,14 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
 
   bool _meMuted = false;
   bool _holdingPtt = false;
+  /// Per-peer playback volume, keyed by peerId. Populated lazily —
+  /// only entries the user has explicitly adjusted exist; everything
+  /// else reads through [_volumeFor] which falls back to
+  /// [_kDefaultPeerVolume]. Direct subscript reads will throw on
+  /// production cubit-driven peers, so always go through the helper.
   late Map<String, double> _volumes;
+  static const double _kDefaultPeerVolume = 0.7;
+  double _volumeFor(String peerId) => _volumes[peerId] ?? _kDefaultPeerVolume;
   final Set<String> _peerMuted = {};
   final Set<String> _removed = {};
 
@@ -153,7 +160,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // Only populate mock roster when debugDemoTimers is true (for tests)
     if (widget.debugDemoTimers) {
       _roster = [_me, ...kPeople.skip(1).take(widget.groupSize - 1)];
-      _volumes = {for (final p in _roster) p.id: 0.7};
+      _volumes = {for (final p in _roster) p.id: _kDefaultPeerVolume};
     } else {
       _volumes = {}; // Volumes populated dynamically as peers join
     }
@@ -686,7 +693,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                                         first: i == 0,
                                         talking: _talkingId == peers[i].id && !_peerMuted.contains(peers[i].id),
                                         muted: _peerMuted.contains(peers[i].id),
-                                        volume: _volumes[peers[i].id] ?? 0.7,
+                                        volume: _volumeFor(peers[i].id),
                                         onTap: () => _showPeerDrawer(peers[i]),
                                       ),
                                   ],
@@ -911,7 +918,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         return _PeerDrawer(
           person: person,
           isHost: widget.isHost,
-          initialVolume: _volumes[person.id]!,
+          initialVolume: _volumeFor(person.id),
           initialMuted: _peerMuted.contains(person.id),
           onChanged: (vol, muted) {
             setState(() {

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -367,6 +367,11 @@ void main() {
         // checks, but driven through the production roster path.
         expect(find.text('Mute from your side'), findsOneWidget);
         expect(find.text('Their voice volume'), findsOneWidget);
+        // Lock the fallback contract: both the peer row's
+        // volume label (still visible behind the drawer) and the
+        // drawer's label track `_kDefaultPeerVolume` (0.7) for
+        // unknown peer ids.
+        expect(find.text('70%'), findsNWidgets(2));
         expect(tester.takeException(), isNull);
       },
     );

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:walkie_talkie/bloc/frequency_session_cubit.dart';
 import 'package:walkie_talkie/bloc/frequency_session_state.dart';
 import 'package:walkie_talkie/data/frequency_mock_data.dart';
 import 'package:walkie_talkie/protocol/messages.dart';
+import 'package:walkie_talkie/protocol/peer.dart';
 import 'package:walkie_talkie/screens/frequency_room_screen.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
@@ -300,6 +301,75 @@ void main() {
 
       expect(find.text('Remove from frequency'), findsOneWidget);
     });
+
+    testWidgets(
+      'opening peer drawer on a cubit-driven roster does not crash on missing volume entry',
+      // Regression for #103: in production `debugDemoTimers: false`,
+      // `_volumes` is empty until the user adjusts a slider, so reading
+      // `_volumes[person.id]!` for any cubit-driven peer threw a null
+      // dereference. The drawer must read through `_volumeFor`, which
+      // falls back to the default volume for unknown peer ids.
+      (tester) async {
+        final cubit = FrequencySessionCubit(
+          identityStore: _MemoryStore(),
+          recentFrequenciesStore: _NullRecentFrequenciesStore(),
+        );
+        addTearDown(cubit.close);
+
+        cubit
+          ..emit(const SessionDiscovery(myName: 'Caleb'))
+          ..joinRoom(freq: '104.3', isHost: false);
+
+        // Non-demo room screen — `debugDemoTimers: false` exercises the
+        // cubit-driven roster path and the production `_volumes`
+        // initialization (empty map).
+        await tester.pumpWidget(_wrap(
+          FrequencyRoomScreen(
+            freq: '104.3',
+            isHost: false,
+            myName: 'Caleb',
+            groupSize: 5,
+            mediaKind: MediaKind.music,
+            pttMode: false,
+            onLeave: () {},
+          ),
+          cubit: cubit,
+        ));
+        // Pump twice: first to settle initState's post-frame
+        // microtasks (startVoice + the identity-store read inside
+        // _resolveMyPeerId), second to drain the resulting setStates.
+        await tester.pump();
+        await tester.pump();
+
+        // Land a roster with a single non-self peer. Different peerId
+        // from the identity store's `'me-peer-id'` so the screen
+        // doesn't filter it out as the local user.
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [
+            ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+          ],
+        ));
+        await tester.pump();
+
+        expect(find.text('Devon'), findsOneWidget);
+
+        // Tap the cubit-driven peer row — pre-fix this threw because
+        // `_volumes['p-host']` was null and the bang operator
+        // dereferenced it.
+        await tester.tap(find.text('Devon'));
+        await tester.pump(_settle);
+
+        // Drawer rendered — same content the demo-roster test
+        // checks, but driven through the production roster path.
+        expect(find.text('Mute from your side'), findsOneWidget);
+        expect(find.text('Their voice volume'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
 
     // testWidgets.skip is bool-only; wrap in a group so the runner records
     // a reason instead of a silent skip count.


### PR DESCRIPTION
## Summary

- Production paths in `FrequencyRoomScreen` only populate `_volumes` in `debugDemoTimers` mode; everywhere else the map is empty. The peer drawer at [frequency_room_screen.dart:914](https://github.com/ElodinLaarz/walkie-talkie/blob/main/lib/screens/frequency_room_screen.dart#L914) read `_volumes[person.id]!`, which threw on every cubit-driven peer tap.
- Hoist a `_volumeFor(peerId)` helper backed by `_kDefaultPeerVolume` (0.7). Use it consistently in both reads — the row-render site (was already `?? 0.7`) and the drawer (was the bang operator).
- Add a regression widget test that exercises the production roster path: real `FrequencySessionCubit`, `debugDemoTimers: false`, `JoinAccepted` lands a non-self peer, then we open the drawer and assert it renders without throwing.

Fixes #103.

## Test plan
- [x] `flutter analyze` — `No issues found! (ran in 36.2s)`
- [x] `flutter test` — `326 passed` (1 pre-existing skip)
- [x] `flutter test test/screens/frequency_room_screen_test.dart` — 21 passed including the new `opening peer drawer on a cubit-driven roster does not crash on missing volume entry` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of peer volume handling to prevent crashes when peer entries are missing from volume tracking.

* **Tests**
  * Added regression test to verify stable behavior when managing peer volumes in roster scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->