### PR TITLE
fix(#129): single AudioService — room screen reads from the provider

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -172,6 +172,11 @@ class FrequencyApp extends StatelessWidget {
           groupSize: 5,
           mediaKind: MediaKind.music,
           pttMode: false,
+          // Pass the singleton from the provider so the screen reuses the
+          // one instance (#129) — its own fallback would otherwise build a
+          // second AudioService whose audioEvents/controlBytes stream
+          // caches diverge from the rest of the app.
+          audioService: context.read<AudioService>(),
           // `leaveRoom` is async (re-reads recent frequencies before
           // emitting), but `onLeave` is a sync VoidCallback — wrap
           // explicitly so the discarded future is intentional rather

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -46,11 +46,12 @@ class FrequencyRoomScreen extends StatefulWidget {
   final String myName;
   final VoidCallback onLeave;
 
-  /// Native audio bridge. Optional so widget tests that don't care about the
-  /// MethodChannel can omit it (the catch-blocks inside [AudioService]
-  /// swallow `MissingPluginException`); production wiring constructs the
-  /// default instance. Tests that *do* assert on audio engine calls can
-  /// pass an instance whose channel handler they've registered.
+  /// Native audio bridge. Optional so widget tests that want to inject a
+  /// mock or fake can pass one explicitly; production wiring should pass
+  /// `context.read<AudioService>()` so the screen shares the singleton the
+  /// rest of the app sees (see #129). When omitted, the screen falls back
+  /// to `context.read<AudioService>()` — never a fresh instance — to
+  /// guarantee one `AudioService` per process at runtime.
   final AudioService? audioService;
 
   /// When true, demo timers fire fake BLE events for design previews.
@@ -170,7 +171,14 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     _lib = kMedia[_source]!;
     _lastAction = const _LastAction(by: 'Devon', action: 'started playback', when: '12s ago');
 
-    _audio = widget.audioService ?? AudioService();
+    _audio = widget.audioService ?? context.read<AudioService>();
+    // Guard against a future caller silently constructing a second
+    // AudioService and passing it through `widget.audioService` while a
+    // different instance is also wired into the provider — their
+    // audioEvents/controlBytes stream caches diverge and event-routing
+    // bugs become very hard to trace (#129). The provider is the single
+    // source of truth.
+    assert(identical(_audio, context.read<AudioService>()));
     // Start the foreground service first so the OS elevates process priority
     // before AudioRecord opens — avoids the mic being killed when the screen
     // turns off during the capture-engine init window. Then spin up voice and

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:walkie_talkie/data/frequency_mock_data.dart';
 import 'package:walkie_talkie/protocol/messages.dart';
 import 'package:walkie_talkie/protocol/peer.dart';
 import 'package:walkie_talkie/screens/frequency_room_screen.dart';
+import 'package:walkie_talkie/services/audio_service.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
@@ -37,10 +38,11 @@ const _viewport = Size(432, 1200);
 /// weak-signal toast (fires at 7.2s) — those are demo timers in initState.
 const _settle = Duration(milliseconds: 500);
 
-Widget _wrap(Widget child, {FrequencySessionCubit? cubit}) {
+Widget _wrap(Widget child, {FrequencySessionCubit? cubit, AudioService? audio}) {
   final mockCubit = cubit ?? MockFrequencySessionCubit();
   final mockStore = MockIdentityStore();
-  
+  final providedAudio = audio ?? AudioService();
+
   if (cubit == null) {
     when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
     when(() => mockCubit.identityStore).thenReturn(mockStore);
@@ -89,9 +91,15 @@ Widget _wrap(Widget child, {FrequencySessionCubit? cubit}) {
         // fields focus, which would push modal sheet content off-screen
         // (same gotcha as the discovery rename test).
         data: MediaQuery.of(context).copyWith(viewInsets: EdgeInsets.zero),
-        child: BlocProvider<FrequencySessionCubit>.value(
-          value: mockCubit,
-          child: c!,
+        // Mirror production: AudioService comes from the provider so the
+        // room screen's identity-assertion (#129) finds the same instance
+        // it stored in `_audio`.
+        child: RepositoryProvider<AudioService>.value(
+          value: providedAudio,
+          child: BlocProvider<FrequencySessionCubit>.value(
+            value: mockCubit,
+            child: c!,
+          ),
         ),
       ),
     ),
@@ -156,6 +164,22 @@ void main() {
   });
 
   group('FrequencyRoomScreen', () {
+    testWidgets(
+      'uses the AudioService from the provider, not a fresh one (#129)',
+      (tester) async {
+        // Two distinct instances: the one wired into the provider vs.
+        // a parallel one that should NOT end up as the screen's `_audio`.
+        // The screen's debug assertion (`identical(_audio, provider)`)
+        // is the lock — if we ever regress and build a second instance
+        // inside the screen, the framework crashes the test here.
+        final providerAudio = AudioService();
+        await tester.pumpWidget(_wrap(_room(), audio: providerAudio));
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      },
+    );
+
     testWidgets('renders the on-air chrome and the user as the first peer',
         (tester) async {
       await tester.pumpWidget(_wrap(_room()));


### PR DESCRIPTION
## Summary

Closes #129. [main.dart:68](https://github.com/ElodinLaarz/walkie-talkie/blob/main/lib/main.dart#L68) provided `AudioService` via `RepositoryProvider`, but [frequency_room_screen.dart:165](https://github.com/ElodinLaarz/walkie-talkie/blob/main/lib/screens/frequency_room_screen.dart#L165) did `widget.audioService ?? AudioService()` and `_buildStage` never passed one in. So at runtime two `AudioService` instances existed: the one wired into the cubit / `BleControlTransport`, and a separate one whose `audioEvents` / `controlBytes` stream caches the room screen subscribed to. MethodChannel is global so calls landed correctly, but EventChannel listeners pointed at different cached streams — a nasty trap for the next person debugging event routing.

- **`lib/main.dart`** — `_buildStage` now passes `audioService: context.read<AudioService>()` into `FrequencyRoomScreen`. Production wiring goes through the singleton.
- **`lib/screens/frequency_room_screen.dart`** — fallback changed from `?? AudioService()` to `?? context.read<AudioService>()` so any future caller that forgets is still safe (no parallel instance can be silently constructed inside the screen). Added a debug assertion `assert(identical(_audio, context.read<AudioService>()))` to lock the contract: if anyone wires a separate instance through `widget.audioService` while a different one lives in the provider, the assertion crashes loudly in debug builds.
- **`test/screens/frequency_room_screen_test.dart`** — `_wrap` now provides `RepositoryProvider<AudioService>.value` (a real `AudioService()` instance — its calls still land on the existing mock MethodChannel, so the recorder in `audioCalls` works unchanged) so the screen's new `context.read<AudioService>()` resolves. New regression test asserts the screen uses the provider's instance: it passes a known instance through the provider, pumps the screen, and verifies no exception fires (the new debug assertion is what would trip if the old `?? AudioService()` path crept back).

The acceptance criterion from #129 ("One `AudioService` instance per process at runtime; debug assertion `assert(identical(_audio, context.read<AudioService>()))`") is now structurally enforced — the only `AudioService()` constructor call left in `lib/` is the one inside the provider's `create:`.

## What this PR does NOT do

- Doesn't drop the optional `audioService` parameter on `FrequencyRoomScreen`. Tests that want to inject a mock or fake (none today, but the seam was deliberate) can still pass one explicitly. The change is from "constructs a fresh fallback" to "falls back to the provider's instance," which keeps the test seam without keeping the bug.
- Doesn't touch the test files in `test/bloc/` and `test/services/` that construct their own `AudioService()` directly — those are isolated unit tests that don't go through the provider, and they're outside the scope of #129.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 326 passing + 1 new regression test = 327 passing, 1 pre-existing skip
- [x] New test "uses the AudioService from the provider, not a fresh one (#129)" — passes with the fix, would crash on the debug assertion if the old `?? AudioService()` regressed
- [ ] Manual smoke test on a real device — deferred; the runtime symptom (event-routing divergence) is structural and the assertion is the durable lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio service initialization to properly use the application's global singleton instance, preventing potential audio routing inconsistencies across the app.

* **Tests**
  * Added regression test to validate audio service consistency and proper instance management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->