### PR TITLE
feat(#107): centralize GATT + transport constants

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -3,7 +3,6 @@ package com.elodin.walkie_talkie
 import android.bluetooth.*
 import android.content.Context
 import android.util.Log
-import java.util.UUID
 
 /**
  * GATT client manager for the guest side of the Frequency control plane.
@@ -14,6 +13,9 @@ import java.util.UUID
  * RosterUpdate / Heartbeat via RESPONSE notifications.
  *
  * Counterpart to GattServerManager (host side). Per docs/protocol.md § "GATT service".
+ *
+ * Wire-level UUIDs and the target ATT MTU live in [GattConstants] — the
+ * single source of truth shared with the server side and the L2CAP transport.
  */
 class GattClientManager(
     private val context: Context,
@@ -21,15 +23,6 @@ class GattClientManager(
 ) {
     companion object {
         private const val TAG = "GattClientManager"
-
-        // Same UUIDs as the server side
-        val SERVICE_UUID: UUID = UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e")
-        val REQUEST_CHAR_UUID: UUID = UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e01")
-        val RESPONSE_CHAR_UUID: UUID = UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e02")
-        val CCCD_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
-
-        // Target MTU for GATT operations (see issue #45)
-        private const val TARGET_MTU = 247
     }
 
     private var gatt: BluetoothGatt? = null
@@ -46,7 +39,7 @@ class GattClientManager(
                 BluetoothProfile.STATE_CONNECTED -> {
                     Log.i(TAG, "Connected to GATT server: ${gatt.device.address}")
                     // Request MTU increase for better throughput
-                    gatt.requestMtu(TARGET_MTU)
+                    gatt.requestMtu(GattConstants.TARGET_ATT_MTU)
                 }
                 BluetoothProfile.STATE_DISCONNECTED -> {
                     Log.i(TAG, "Disconnected from GATT server: ${gatt.device.address}")
@@ -72,21 +65,21 @@ class GattClientManager(
                 return
             }
 
-            val service = gatt.getService(SERVICE_UUID)
+            val service = gatt.getService(GattConstants.SERVICE_UUID)
             if (service == null) {
                 Log.e(TAG, "Walkie-talkie service not found on host")
                 return
             }
 
             // Cache the REQUEST characteristic for writes
-            requestCharacteristic = service.getCharacteristic(REQUEST_CHAR_UUID)
+            requestCharacteristic = service.getCharacteristic(GattConstants.REQUEST_CHAR_UUID)
             if (requestCharacteristic == null) {
                 Log.e(TAG, "REQUEST characteristic not found")
                 return
             }
 
             // Cache and enable notifications on RESPONSE characteristic
-            responseCharacteristic = service.getCharacteristic(RESPONSE_CHAR_UUID)
+            responseCharacteristic = service.getCharacteristic(GattConstants.RESPONSE_CHAR_UUID)
             if (responseCharacteristic == null) {
                 Log.e(TAG, "RESPONSE characteristic not found")
                 return
@@ -100,7 +93,7 @@ class GattClientManager(
             }
 
             // Write CCCD descriptor to enable notifications on the server side
-            val cccd = responseCharacteristic?.getDescriptor(CCCD_UUID)
+            val cccd = responseCharacteristic?.getDescriptor(GattConstants.CCCD_UUID)
             if (cccd == null) {
                 Log.e(TAG, "CCCD descriptor not found on RESPONSE characteristic")
                 return
@@ -119,7 +112,7 @@ class GattClientManager(
             gatt: BluetoothGatt,
             characteristic: BluetoothGattCharacteristic
         ) {
-            if (characteristic.uuid == RESPONSE_CHAR_UUID) {
+            if (characteristic.uuid == GattConstants.RESPONSE_CHAR_UUID) {
                 val bytes = characteristic.value
                 if (bytes != null && bytes.isNotEmpty()) {
                     Log.d(TAG, "Received ${bytes.size} bytes from host")
@@ -135,7 +128,7 @@ class GattClientManager(
             descriptor: BluetoothGattDescriptor,
             status: Int
         ) {
-            if (descriptor.uuid == CCCD_UUID) {
+            if (descriptor.uuid == GattConstants.CCCD_UUID) {
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     Log.i(TAG, "CCCD write successful, notifications active")
                 } else {
@@ -149,7 +142,7 @@ class GattClientManager(
             characteristic: BluetoothGattCharacteristic,
             status: Int
         ) {
-            if (characteristic.uuid == REQUEST_CHAR_UUID) {
+            if (characteristic.uuid == GattConstants.REQUEST_CHAR_UUID) {
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     Log.d(TAG, "REQUEST write successful")
                 } else {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
@@ -1,0 +1,50 @@
+package com.elodin.walkie_talkie
+
+import java.util.UUID
+
+/**
+ * Single source of truth for the wire-level identifiers and MTU constants
+ * shared between the GATT client (guest), GATT server (host), the L2CAP
+ * voice transport, and any future native module that needs to recognize the
+ * walkie-talkie service.
+ *
+ * The values must stay byte-identical to:
+ *  - `lib/protocol/discovery.dart::kWalkieTalkieServiceUuid` (Dart side, used
+ *    for advertising filters), and
+ *  - `docs/protocol.md § GATT service` (the spec callers verify against).
+ *
+ * Per issue #107 — anything that wants a UUID, a target ATT MTU, or the
+ * voice-plane MTU must read it from here. Previously these were duplicated
+ * across `GattClientManager`, `GattServerManager`, and `L2capVoiceTransport`.
+ */
+object GattConstants {
+    /** 128-bit primary service UUID for the walkie-talkie GATT service. */
+    val SERVICE_UUID: UUID =
+        UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e")
+
+    /** Write / write-no-response characteristic — guests post requests here. */
+    val REQUEST_CHAR_UUID: UUID =
+        UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e01")
+
+    /** Notify characteristic — hosts push responses + roster updates here. */
+    val RESPONSE_CHAR_UUID: UUID =
+        UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e02")
+
+    /** Standard Client Characteristic Configuration Descriptor (CCCD). */
+    val CCCD_UUID: UUID =
+        UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+
+    /**
+     * ATT MTU the guest requests after connect. The peer may grant less; the
+     * actual negotiated MTU is cached per-device by `GattServerManager`
+     * (issue #45).
+     */
+    const val TARGET_ATT_MTU: Int = 247
+
+    /**
+     * L2CAP CoC voice plane: every `sendToClient` / `sendToHost` write is one
+     * VoiceFrame (<=128 bytes) so receive-side reads stay aligned without a
+     * length prefix. Mirrors `kVoiceMtu` in `lib/protocol/voice_frame.dart`.
+     */
+    const val VOICE_MTU: Int = 128
+}

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
@@ -19,18 +19,22 @@ import java.util.UUID
  */
 object GattConstants {
     /** 128-bit primary service UUID for the walkie-talkie GATT service. */
+    @JvmField
     val SERVICE_UUID: UUID =
         UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e")
 
     /** Write / write-no-response characteristic — guests post requests here. */
+    @JvmField
     val REQUEST_CHAR_UUID: UUID =
         UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e01")
 
     /** Notify characteristic — hosts push responses + roster updates here. */
+    @JvmField
     val RESPONSE_CHAR_UUID: UUID =
         UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e02")
 
     /** Standard Client Characteristic Configuration Descriptor (CCCD). */
+    @JvmField
     val CCCD_UUID: UUID =
         UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
@@ -3,7 +3,6 @@ package com.elodin.walkie_talkie
 import android.bluetooth.*
 import android.content.Context
 import android.util.Log
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -14,7 +13,8 @@ import java.util.concurrent.ConcurrentHashMap
  * Leave messages to REQUEST; the host emits JoinAccepted / RosterUpdate /
  * Heartbeat messages via RESPONSE notifications.
  *
- * Per docs/protocol.md § "GATT service".
+ * Per docs/protocol.md § "GATT service". Wire-level UUIDs live in
+ * [GattConstants] — the single source of truth shared with the client side.
  */
 class GattServerManager(
     private val context: Context,
@@ -22,11 +22,6 @@ class GattServerManager(
 ) {
     companion object {
         private const val TAG = "GattServerManager"
-
-        val SERVICE_UUID: UUID = UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e")
-        val REQUEST_CHAR_UUID: UUID = UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e01")
-        val RESPONSE_CHAR_UUID: UUID = UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e02")
-        val CCCD_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     }
 
     private var gattServer: BluetoothGattServer? = null
@@ -65,7 +60,7 @@ class GattServerManager(
         ) {
             val address = device.address
 
-            if (characteristic.uuid == REQUEST_CHAR_UUID) {
+            if (characteristic.uuid == GattConstants.REQUEST_CHAR_UUID) {
                 if (value != null && value.isNotEmpty()) {
                     Log.d(TAG, "Received ${value.size} bytes from $address")
                     onBytesReceived(address, value)
@@ -105,7 +100,7 @@ class GattServerManager(
             offset: Int,
             value: ByteArray?
         ) {
-            if (descriptor.uuid == CCCD_UUID) {
+            if (descriptor.uuid == GattConstants.CCCD_UUID) {
                 val enabled = value?.contentEquals(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE) == true
                 Log.i(TAG, "${device.address} ${if (enabled) "enabled" else "disabled"} notifications")
 
@@ -157,13 +152,13 @@ class GattServerManager(
 
             // Build the service with REQUEST and RESPONSE characteristics
             val service = BluetoothGattService(
-                SERVICE_UUID,
+                GattConstants.SERVICE_UUID,
                 BluetoothGattService.SERVICE_TYPE_PRIMARY
             )
 
             // REQUEST characteristic: write + write-no-response
             val requestChar = BluetoothGattCharacteristic(
-                REQUEST_CHAR_UUID,
+                GattConstants.REQUEST_CHAR_UUID,
                 BluetoothGattCharacteristic.PROPERTY_WRITE or
                 BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
                 BluetoothGattCharacteristic.PERMISSION_WRITE
@@ -172,14 +167,14 @@ class GattServerManager(
 
             // RESPONSE characteristic: notify
             responseCharacteristic = BluetoothGattCharacteristic(
-                RESPONSE_CHAR_UUID,
+                GattConstants.RESPONSE_CHAR_UUID,
                 BluetoothGattCharacteristic.PROPERTY_NOTIFY,
                 BluetoothGattCharacteristic.PERMISSION_READ
             )
 
             // Add CCCD descriptor for notifications
             val cccdDescriptor = BluetoothGattDescriptor(
-                CCCD_UUID,
+                GattConstants.CCCD_UUID,
                 BluetoothGattDescriptor.PERMISSION_WRITE or
                 BluetoothGattDescriptor.PERMISSION_READ
             )

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
@@ -36,7 +36,6 @@ class L2capVoiceTransport(
     companion object {
         private const val TAG = "L2capVoiceTransport"
         private val BACKOFF_MS = longArrayOf(250, 500, 1000, 2000, 5000)
-        private const val VOICE_MTU = 128
     }
 
     // Host-side: server socket + accepted client sockets
@@ -105,7 +104,7 @@ class L2capVoiceTransport(
     }
 
     private fun receiveLoop(addr: String, socket: BluetoothSocket) {
-        val buf = ByteArray(VOICE_MTU.coerceAtLeast(socket.maxReceivePacketSize))
+        val buf = ByteArray(GattConstants.VOICE_MTU.coerceAtLeast(socket.maxReceivePacketSize))
         try {
             val input = socket.inputStream
             while (socket.isConnected) {


### PR DESCRIPTION
## Summary

Closes #107. Pulls the duplicated GATT + transport constants on the Kotlin side into a single `GattConstants` object so there's one place to edit when the wire-level identity ever changes.

Before:

| constant            | declared in                                       |
| ------------------- | ------------------------------------------------- |
| `SERVICE_UUID`      | `GattClientManager`, `GattServerManager` (dup)    |
| `REQUEST_CHAR_UUID` | `GattClientManager`, `GattServerManager` (dup)    |
| `RESPONSE_CHAR_UUID`| `GattClientManager`, `GattServerManager` (dup)    |
| `CCCD_UUID`         | `GattClientManager`, `GattServerManager` (dup)    |
| `TARGET_MTU`        | `GattClientManager`                               |
| `VOICE_MTU`         | `L2capVoiceTransport`                             |

After: a single [`GattConstants.kt`](android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt) holds all six (`TARGET_MTU` is renamed to `TARGET_ATT_MTU` in the move so callers can grep for it without colliding with the unrelated `VOICE_MTU`). `GattClientManager`, `GattServerManager`, and `L2capVoiceTransport` now reference `GattConstants.<NAME>` at every use site.

The Dart-side `kWalkieTalkieServiceUuid` in `lib/protocol/discovery.dart` is the only Dart-side reference to any of these and is already a single declaration site, so no Dart changes are needed today. The Kotlin doc comment in `GattConstants.kt` calls out that the values must stay byte-identical to the Dart constant + the spec.

## What this PR does NOT do

- **No `pigeon`-generated MethodChannel registry.** The issue's *Files* section says "consider pigeon" — adding a code-generation pipeline + dependency is well out of scope for a constant-consolidation PR. Channel-name dedup is a separate workstream.
- **No C++-side change.** The C++ tree (`audio_engine.cpp` / `audio_mixer.cpp` / `peer_audio_manager.cpp`) doesn't reference any of these GATT/MTU constants, so there's nothing to consolidate there. PR #93 introduces an `audio_config.h` for the audio-side constants on the C++ side, but that's its own concern.

## Test plan

- [x] Acceptance criterion from #107: `grep -rn 'SERVICE_UUID\|REQUEST_CHAR_UUID\|RESPONSE_CHAR_UUID\|CCCD_UUID\|VOICE_MTU\|TARGET_ATT_MTU' android/app/src/main/kotlin` returns one declaration site per constant (in `GattConstants.kt`); the only other hits are call sites of the form `GattConstants.<NAME>`.
- [x] `flutter analyze` — clean.
- [x] `flutter test` — 326 passing, 1 pre-existing skip.
- [ ] Real-device smoke test — no behavior change, deferred to existing manual runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)