### PR TITLE
feat(#118): Upgrade flutter_blue_plus 1.34.4 → 2.2.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -290,50 +290,58 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_blue_plus
-      sha256: "69a8c87c11fc792e8cf0f997d275484fbdb5143ac9f0ac4d424429700cb4e0ed"
+      sha256: "4fba86c513feab2c5cdb9497da0910ed5b50c0fa8d6cec4a26ffb1a558a24eb8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.36.8"
+    version: "2.2.1"
   flutter_blue_plus_android:
     dependency: transitive
     description:
       name: flutter_blue_plus_android
-      sha256: "6f7fe7e69659c30af164a53730707edc16aa4d959e4c208f547b893d940f853d"
+      sha256: "2a73e264685574d1d29dcdd565bad9ecfdf237630237c508ae8b47f5cc791f1d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.4"
+    version: "8.2.1"
   flutter_blue_plus_darwin:
     dependency: transitive
     description:
       name: flutter_blue_plus_darwin
-      sha256: "682982862c1d964f4d54a3fb5fccc9e59a066422b93b7e22079aeecd9c0d38f8"
+      sha256: cfef171db550670cf8110f6eb25baf15d9bc8bad2af29550f9bbc0d8fceaf285
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.3"
+    version: "8.2.1"
   flutter_blue_plus_linux:
     dependency: transitive
     description:
       name: flutter_blue_plus_linux
-      sha256: "56b0c45edd0a2eec8f85bd97a26ac3cd09447e10d0094fed55587bf0592e3347"
+      sha256: "5add6c14d2f90672c5e3ded1455b9ca8e6fe44adf9b53cdc60eb3417d38f34fe"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.3"
+    version: "8.2.1"
   flutter_blue_plus_platform_interface:
     dependency: transitive
     description:
       name: flutter_blue_plus_platform_interface
-      sha256: "84fbd180c50a40c92482f273a92069960805ce324e3673ad29c41d2faaa7c5c2"
+      sha256: "226fb6753a74a407e3b9975c0fc00de02c490ae655b31c6508cb5790ad30965d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "8.2.1"
   flutter_blue_plus_web:
     dependency: transitive
     description:
       name: flutter_blue_plus_web
-      sha256: a1aceee753d171d24c0e0cdadb37895b5e9124862721f25f60bb758e20b72c99
+      sha256: "10a7465ccfc50138280abf32c8ab314f5029aa19039628ad9b4d0ed786e0021f"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "8.2.1"
+  flutter_blue_plus_winrt:
+    dependency: transitive
+    description:
+      name: flutter_blue_plus_winrt
+      sha256: ed894f0ab341f4cece8fa33edc381d46424a7c5bfd0e841d933d0f8c34c86521
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.18"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   permission_handler: ^11.3.1
   
   # Bluetooth LE
-  flutter_blue_plus: ^1.34.4
+  flutter_blue_plus: ^2.2.1
   
   # UI/UX
   google_fonts: ^6.2.1


### PR DESCRIPTION
## Summary

- Bumps `flutter_blue_plus` from **1.34.4** → **2.2.1** (includes Android 14 GATT fixes in 2.x)
- No code changes required — API-compatible upgrade
- All 361 tests pass
- `flutter analyze` clean

## Why

Addresses the first major-version upgrade in #118. The 2.x release line includes:
- Significant Android 14 GATT stability fixes
- Bluetooth adapter state handling improvements  
- Better background scan reliability

## Testing

- ✅ All existing unit and widget tests pass (361/361)
- ✅ Static analysis passes with no new warnings
- ✅ No breaking API changes detected in our usage

## Follow-up

Per #118's recommendation, subsequent PRs will upgrade:
- `flutter_bloc` 8.x → 9.x
- `permission_handler` 11.x → 12.x

## Closes

Partially addresses #118 (flutter_blue_plus upgrade complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Bluetooth library dependency to version 2.2.1, providing access to the latest features and improvements in the underlying framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->