### PR TITLE
feat(#101): L2capVoiceTransport — single-writer queue, length-prefix framing, thread cleanup

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,6 +68,14 @@ android {
             )
         }
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+}
+
+dependencies {
+    testImplementation("junit:junit:4.13.2")
 }
 
 flutter {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
@@ -46,9 +46,12 @@ object GattConstants {
     const val TARGET_ATT_MTU: Int = 247
 
     /**
-     * L2CAP CoC voice plane: every `sendToClient` / `sendToHost` write is one
-     * VoiceFrame (<=128 bytes) so receive-side reads stay aligned without a
-     * length prefix. Mirrors `kVoiceMtu` in `lib/protocol/voice_frame.dart`.
+     * L2CAP CoC voice plane: maximum VoiceFrame payload size. Each frame on
+     * the wire is preceded by a 2-byte big-endian length prefix (see
+     * `L2capVoiceTransport`'s class doc + `docs/protocol.md § Voice frame
+     * format`), so the on-the-wire L2CAP write is up to `VOICE_MTU + 2`
+     * bytes; the SDU MTU must be sized accordingly. Mirrors `kVoiceMtu` in
+     * `lib/protocol/voice_frame.dart`.
      */
     const val VOICE_MTU: Int = 128
 }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
@@ -292,7 +292,15 @@ class L2capVoiceTransport(
             // racy with this thread starting.
             Log.i(TAG, "Receive loop init failed for $addr: ${e.message}")
         } finally {
+            // Drop both the host-side (clientSockets) and guest-side (guestIo)
+            // reference for whichever socket this loop was bound to. The
+            // guest check is identity-based (socket ===) so a fresh
+            // connection that races a stale receiveLoop's finally can't
+            // accidentally null out the new guestIo.
             synchronized(clientSockets) { clientSockets.remove(addr) }
+            synchronized(this) {
+                if (guestIo?.socket === socket) guestIo = null
+            }
             try { socket.close() } catch (_: IOException) {}
         }
     }
@@ -391,14 +399,14 @@ internal fun writeFramed(out: OutputStream, frame: ByteArray) {
     require(frame.size <= L2capVoiceTransport.MAX_FRAME_SIZE) {
         "Frame size ${frame.size} exceeds MAX_FRAME_SIZE ${L2capVoiceTransport.MAX_FRAME_SIZE}"
     }
-    val prefix = ByteArray(L2capVoiceTransport.LENGTH_PREFIX_SIZE)
-    prefix[0] = ((frame.size ushr 8) and 0xff).toByte()
-    prefix[1] = (frame.size and 0xff).toByte()
     // Single buffer + single write avoids interleaving prefix and payload
-    // if a future caller ever shares the OutputStream across threads
-    // (the writer thread doesn't, but the API leaves no foot-gun).
+    // if a future caller ever shares the OutputStream across threads (the
+    // writer thread doesn't, but the API leaves no foot-gun). Writing the
+    // length bytes directly into the head of `buf` saves a per-frame
+    // ByteArray allocation + arraycopy, which matters at 50 fps voice.
     val buf = ByteArray(L2capVoiceTransport.LENGTH_PREFIX_SIZE + frame.size)
-    System.arraycopy(prefix, 0, buf, 0, L2capVoiceTransport.LENGTH_PREFIX_SIZE)
+    buf[0] = ((frame.size ushr 8) and 0xff).toByte()
+    buf[1] = (frame.size and 0xff).toByte()
     System.arraycopy(frame, 0, buf, L2capVoiceTransport.LENGTH_PREFIX_SIZE, frame.size)
     out.write(buf)
     out.flush()

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
@@ -3,9 +3,12 @@ package com.elodin.walkie_talkie
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothSocket
 import android.util.Log
+import java.io.DataInputStream
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * L2CAP CoC (Credit-Based Flow Control) voice transport.
@@ -14,12 +17,24 @@ import java.util.concurrent.atomic.AtomicInteger
  * in [0x80, 0xFF] odd range. Guests call [connectClient] to dial the host's
  * PSM. VoiceFrame packets flow over the established channel.
  *
- * **Framing (v1)**: L2CAP CoC is a stream protocol. For v1 we treat each
- * [sendToClient]/[sendToHost] call as one L2CAP packet by keeping frames
- * under kVoiceMtu = 128 bytes, which fits inside a single MTU. Full
- * length-prefixed reassembly is deferred to a future issue; callers must
- * ensure every write is a complete VoiceFrame (<=128 bytes) so receive-side
- * reads stay aligned.
+ * **Framing (v1.1)**: L2CAP CoC is a stream protocol. To keep frame
+ * boundaries deterministic across OEMs (some kernels coalesce multiple
+ * SDUs into one userspace `read`), every L2CAP write is preceded by a
+ * 2-byte big-endian length prefix carrying the size of the VoiceFrame
+ * payload that follows. Receivers read the prefix, then exactly that
+ * many bytes, then dispatch the inner bytes to [onVoiceFrame] — exactly
+ * the same payload the original v1 spec described, just framed at the
+ * transport layer instead of relying on packet boundaries.
+ *
+ * **Thread model**: each connected socket owns one *writer* thread and
+ * one *reader* thread. Producers (audio capture, heartbeats, …) call
+ * [sendToHost] / [sendToClient], which push onto a bounded
+ * [LinkedBlockingQueue]; the writer drains the queue and serialises
+ * writes onto the socket so concurrent producers can never tear a frame.
+ * The reader runs the framed-read loop. [stop] signals shutdown via a
+ * sentinel + socket close, then joins both threads with a short timeout
+ * so callers (the foreground service) can fully tear down between
+ * sessions without leaking threads.
  *
  * **Known risks** documented in issue #46:
  *  - `listenUsingInsecureL2capChannel` is flaky on some OEMs; guest side
@@ -36,18 +51,54 @@ class L2capVoiceTransport(
     companion object {
         private const val TAG = "L2capVoiceTransport"
         private val BACKOFF_MS = longArrayOf(250, 500, 1000, 2000, 5000)
+
+        /**
+         * Per-socket send queue capacity. ~64 frames at one-per-20-ms is
+         * ~1.3 s of audio. Above this, the link can't keep up; we drop
+         * the oldest frame so latency stays bounded instead of blocking
+         * the audio capture thread.
+         */
+        const val SEND_QUEUE_CAPACITY = 64
+
+        /** Length-prefix size: 2 bytes big-endian. */
+        const val LENGTH_PREFIX_SIZE = 2
+
+        /**
+         * Defensive ceiling on the length-prefix value. The protocol
+         * caps voice frames at [GattConstants.VOICE_MTU] (= 128); we
+         * accept up to 4 KB so future header growth has headroom and a
+         * malformed peer can't trick us into allocating gigabytes.
+         */
+        const val MAX_FRAME_SIZE = 4096
+
+        /** How long to wait for worker threads to drain on [stop]. */
+        private const val JOIN_TIMEOUT_MS = 500L
     }
+
+    /**
+     * Per-socket I/O bundle. We keep a strong reference to both threads
+     * so [stop] (and the per-link cleanup path on the guest side) can
+     * join them rather than leaking them to GC.
+     */
+    private class SocketIo(
+        val socket: BluetoothSocket,
+        val sendQueue: LinkedBlockingQueue<ByteArray>,
+        var recvThread: Thread? = null,
+        var writerThread: Thread? = null,
+    )
+
+    /** Sentinel pushed onto the send queue to terminate the writer thread. */
+    private val shutdownSentinel = ByteArray(0)
 
     // Host-side: server socket + accepted client sockets
     private var serverSocket: android.bluetooth.BluetoothServerSocket? = null
     private var activePsm: Int = -1
     private var acceptThread: Thread? = null
-    private val clientSockets = mutableMapOf<String, BluetoothSocket>()
+    private val clientSockets = mutableMapOf<String, SocketIo>()
     private val running = AtomicBoolean(false)
 
     // Guest-side: single connection to the host
-    private var guestSocket: BluetoothSocket? = null
-    private var guestRecvThread: Thread? = null
+    private var guestIo: SocketIo? = null
 
     // ── Host side ──────────────────────────────────────────────────────────
 
@@ -85,11 +136,13 @@ class L2capVoiceTransport(
                 val client = serverSock.accept()
                 val addr = client.remoteDevice.address
                 Log.i(TAG, "L2CAP client connected: $addr")
-                synchronized(clientSockets) { clientSockets[addr] = client }
+                // Insert into the map *before* starting threads so the recv
+                // thread's finally-block remove() can never fire ahead of the
+                // put() if the peer disconnects immediately.
+                val io = SocketIo(client, LinkedBlockingQueue(SEND_QUEUE_CAPACITY))
+                synchronized(clientSockets) { clientSockets[addr] = io }
+                startSocketIoThreads(addr, io)
                 onClientConnected(addr)
-                Thread({ receiveLoop(addr, client) }, "L2capRecv-$addr").apply {
-                    isDaemon = true; start()
-                }
             } catch (e: IOException) {
                 if (!running.get()) break
                 Log.e(TAG, "Accept error: ${e.message}")
@@ -103,35 +156,10 @@ class L2capVoiceTransport(
         }
     }
 
-    private fun receiveLoop(addr: String, socket: BluetoothSocket) {
-        val buf = ByteArray(GattConstants.VOICE_MTU.coerceAtLeast(socket.maxReceivePacketSize))
-        try {
-            val input = socket.inputStream
-            while (socket.isConnected) {
-                try {
-                    val n = input.read(buf)
-                    if (n <= 0) break  // EOF
-                    if (n < 8) continue // shorter than VoiceFrame header — drop
-                    onVoiceFrame(buf.copyOf(n))
-                } catch (e: IOException) {
-                    Log.i(TAG, "Receive loop ended for $addr: ${e.message}")
-                    break
-                }
-            }
-        } finally {
-            synchronized(clientSockets) { clientSockets.remove(addr) }
-            try { socket.close() } catch (_: IOException) {}
-        }
-    }
-
     /** Send [frame] to a connected client at [addr]. No-op if not connected. */
     fun sendToClient(addr: String, frame: ByteArray) {
-        val sock = synchronized(clientSockets) { clientSockets[addr] } ?: return
-        try {
-            sock.outputStream.write(frame)
-        } catch (e: IOException) {
-            Log.w(TAG, "Send to $addr failed: ${e.message}")
-        }
+        val io = synchronized(clientSockets) { clientSockets[addr] } ?: return
+        enqueueFrame(io, frame)
     }
 
     // ── Guest side ─────────────────────────────────────────────────────────
@@ -148,11 +176,15 @@ class L2capVoiceTransport(
             onError("Invalid voice PSM 0x${psm.toString(16)}")
             return false
         }
-        // Close any existing guest socket before dialling a new one.
-        synchronized(this) {
-            guestSocket?.let { try { it.close() } catch (_: IOException) {} }
-            guestSocket = null
+        // Tear down any existing guest connection before dialling a new one.
+        // Snapshot under the lock, then join the worker threads outside it
+        // so we never block other callers (sendToHost, stop) while waiting.
+        val prev = synchronized(this) {
+            val p = guestIo
+            guestIo = null
+            p
         }
+        prev?.let { stopSocketIo(it) }
 
         val device = try {
             bluetoothAdapter.getRemoteDevice(macAddress)
@@ -168,11 +200,9 @@ class L2capVoiceTransport(
                 Thread.sleep(delay)
                 sock = device.createInsecureL2capChannel(psm)
                 sock.connect()
-                synchronized(this) { guestSocket = sock }
-                guestRecvThread = Thread(
-                    { receiveLoop(macAddress, sock) },
-                    "L2capGuestRecv"
-                ).apply { isDaemon = true; start() }
+                val io = SocketIo(sock, LinkedBlockingQueue(SEND_QUEUE_CAPACITY))
+                synchronized(this) { guestIo = io }
+                startSocketIoThreads(macAddress, io)
                 Log.i(TAG, "L2CAP connected to $macAddress PSM 0x${psm.toString(16)}")
                 return true
             } catch (e: Exception) {
@@ -186,12 +216,126 @@ class L2capVoiceTransport(
 
     /** Send [frame] to the host (guest-side path). */
     fun sendToHost(frame: ByteArray) {
-        val sock = synchronized(this) { guestSocket } ?: return
-        try {
-            sock.outputStream.write(frame)
-        } catch (e: IOException) {
-            Log.w(TAG, "Send to host failed: ${e.message}")
+        val io = synchronized(this) { guestIo } ?: return
+        enqueueFrame(io, frame)
+    }
+
+    // ── Per-socket worker plumbing ─────────────────────────────────────────
+
+    /**
+     * Start the reader + writer threads for [io]. Splitting thread spawn
+     * from [SocketIo] construction lets callers insert the bundle into
+     * their tracking map *first*, so the recv-thread's remove-on-EOF
+     * finally never races ahead of the insert.
+     */
+    private fun startSocketIoThreads(addr: String, io: SocketIo) {
+        io.recvThread = Thread({ receiveLoop(addr, io.socket) }, "L2capRecv-$addr").apply {
+            isDaemon = true; start()
         }
+        io.writerThread = Thread({ writerLoop(addr, io.socket.outputStream, io.sendQueue) }, "L2capWriter-$addr").apply {
+            isDaemon = true; start()
+        }
+    }
+
+    /**
+     * Drain the per-socket queue and write each frame as a
+     * length-prefixed payload. Exits when the writer pulls
+     * [shutdownSentinel] off the queue, on I/O error, or on interrupt.
+     *
+     * This is the *only* thread that touches [out] — concurrent producers
+     * push to [queue] but never write directly to the socket. That's what
+     * eliminates the torn-frame race that issue #101 reports.
+     */
+    private fun writerLoop(addr: String, out: OutputStream, queue: LinkedBlockingQueue<ByteArray>) {
+        try {
+            while (true) {
+                val frame = queue.take()
+                if (frame === shutdownSentinel) break
+                if (frame.isEmpty()) continue
+                if (frame.size > MAX_FRAME_SIZE) {
+                    Log.w(TAG, "Dropping oversized frame (${frame.size}B) for $addr")
+                    continue
+                }
+                try {
+                    writeFramed(out, frame)
+                } catch (e: IOException) {
+                    Log.i(TAG, "Writer for $addr ended: ${e.message}")
+                    break
+                }
+            }
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    private fun receiveLoop(addr: String, socket: BluetoothSocket) {
+        try {
+            val input = DataInputStream(socket.inputStream)
+            while (socket.isConnected) {
+                val frame = try {
+                    readFramed(input)
+                } catch (e: IOException) {
+                    Log.i(TAG, "Receive loop ended for $addr: ${e.message}")
+                    break
+                } ?: break // EOF
+                if (frame.size < 8) {
+                    // VoiceFrame requires the 8-byte header — drop and keep
+                    // reading; a malformed peer can't lock us out.
+                    Log.w(TAG, "Frame from $addr shorter than VoiceFrame header — dropping")
+                    continue
+                }
+                onVoiceFrame(frame)
+            }
+        } catch (e: IOException) {
+            // Defensive — DataInputStream construction shouldn't throw, but
+            // BluetoothSocket.getInputStream() can if the socket closed
+            // racy with this thread starting.
+            Log.i(TAG, "Receive loop init failed for $addr: ${e.message}")
+        } finally {
+            synchronized(clientSockets) { clientSockets.remove(addr) }
+            try { socket.close() } catch (_: IOException) {}
+        }
+    }
+
+    /**
+     * Push [frame] onto [io]'s send queue. If the queue is full
+     * (producers outpacing the link), drop the *oldest* frame — voice is
+     * latency-sensitive, and stale audio is worse than missing audio.
+     */
+    private fun enqueueFrame(io: SocketIo, frame: ByteArray) {
+        if (frame.isEmpty()) return
+        if (!io.sendQueue.offer(frame)) {
+            io.sendQueue.poll() // drop oldest
+            io.sendQueue.offer(frame)
+        }
+    }
+
+    /**
+     * Cleanly stop a socket's I/O workers: enqueue the shutdown
+     * sentinel, close the socket to unblock the reader, then join both
+     * threads with a bounded timeout. Anything still alive after
+     * the timeout gets interrupted as a fallback.
+     */
+    private fun stopSocketIo(io: SocketIo) {
+        // Signal the writer first; clearing the queue avoids one last
+        // enqueued frame slipping out after stop.
+        io.sendQueue.clear()
+        io.sendQueue.offer(shutdownSentinel)
+        // Closing the socket unblocks readFully() in the recv loop and
+        // breaks any in-progress write() in the writer loop.
+        try { io.socket.close() } catch (_: IOException) {}
+
+        io.recvThread?.let { joinOrInterrupt(it) }
+        io.writerThread?.let { joinOrInterrupt(it) }
+    }
+
+    private fun joinOrInterrupt(t: Thread) {
+        try {
+            t.join(JOIN_TIMEOUT_MS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+        if (t.isAlive) t.interrupt()
     }
 
     // ── Lifecycle ──────────────────────────────────────────────────────────
@@ -203,14 +347,88 @@ class L2capVoiceTransport(
             serverSocket = null
             activePsm = -1
         }
+        // Snapshot under lock so we can join without holding it.
+        val hostIos: List<SocketIo>
         synchronized(clientSockets) {
-            clientSockets.values.forEach { try { it.close() } catch (_: IOException) {} }
+            hostIos = clientSockets.values.toList()
             clientSockets.clear()
         }
-        synchronized(this) {
-            guestSocket?.let { try { it.close() } catch (_: IOException) {} }
-            guestSocket = null
+        hostIos.forEach { stopSocketIo(it) }
+        val guest = synchronized(this) {
+            val g = guestIo
+            guestIo = null
+            g
         }
+        guest?.let { stopSocketIo(it) }
+        // Join the accept thread last; closing the server socket above
+        // unblocks accept() with an IOException, which the loop treats
+        // as a shutdown signal once running == false.
+        acceptThread?.let { joinOrInterrupt(it) }
+        acceptThread = null
         Log.i(TAG, "L2CAP transport stopped")
     }
+
+    /**
+     * Test hook: snapshot the number of currently-tracked client sockets.
+     * Real code shouldn't need this, but instrumented tests do.
+     */
+    internal fun activeClientCount(): Int =
+        synchronized(clientSockets) { clientSockets.size }
 }
+
+// ── Framing helpers (package-private for unit tests) ───────────────────────
+
+/**
+ * Write [frame] to [out] as a 2-byte big-endian length prefix followed by
+ * the frame bytes. The length carries only the frame size — the prefix
+ * itself is *not* counted, matching common framed-protocol convention.
+ *
+ * Throws [IllegalArgumentException] if the frame exceeds
+ * [L2capVoiceTransport.MAX_FRAME_SIZE]; throws [IOException] if the
+ * underlying stream errors mid-write.
+ */
+internal fun writeFramed(out: OutputStream, frame: ByteArray) {
+    require(frame.size <= L2capVoiceTransport.MAX_FRAME_SIZE) {
+        "Frame size ${frame.size} exceeds MAX_FRAME_SIZE ${L2capVoiceTransport.MAX_FRAME_SIZE}"
+    }
+    val prefix = ByteArray(L2capVoiceTransport.LENGTH_PREFIX_SIZE)
+    prefix[0] = ((frame.size ushr 8) and 0xff).toByte()
+    prefix[1] = (frame.size and 0xff).toByte()
+    // Single buffer + single write avoids interleaving prefix and payload
+    // if a future caller ever shares the OutputStream across threads
+    // (the writer thread doesn't, but the API leaves no foot-gun).
+    val buf = ByteArray(L2capVoiceTransport.LENGTH_PREFIX_SIZE + frame.size)
+    System.arraycopy(prefix, 0, buf, 0, L2capVoiceTransport.LENGTH_PREFIX_SIZE)
+    System.arraycopy(frame, 0, buf, L2capVoiceTransport.LENGTH_PREFIX_SIZE, frame.size)
+    out.write(buf)
+    out.flush()
+}
+
+/**
+ * Read one length-prefixed frame from [input]. Returns the frame bytes
+ * (without the length prefix), or `null` on clean EOF *before* any bytes
+ * of a new frame have been read.
+ *
+ * Throws [IOException] if the stream errors mid-frame, or if the length
+ * prefix is zero / exceeds [L2capVoiceTransport.MAX_FRAME_SIZE].
+ */
+internal fun readFramed(input: DataInputStream): ByteArray? {
+    val hi = input.read()
+    if (hi < 0) return null // clean EOF before a frame started
+    val lo = input.read()
+    if (lo < 0) throw IOException("EOF mid-prefix (after high byte)")
+    val len = (hi shl 8) or lo
+    if (len <= 0 || len > L2capVoiceTransport.MAX_FRAME_SIZE) {
+        throw IOException("Invalid frame length $len")
+    }
+    val buf = ByteArray(len)
+    input.readFully(buf)
+    return buf
+}
+
+/**
+ * Adapter for [readFramed] that takes a plain [InputStream]; tests
+ * sometimes have a `ByteArrayInputStream` and don't want to hand-wrap.
+ */
+internal fun readFramed(input: InputStream): ByteArray? =
+    readFramed(if (input is DataInputStream) input else DataInputStream(input))

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
@@ -229,10 +229,10 @@ class L2capVoiceTransport(
      * finally never races ahead of the insert.
      */
     private fun startSocketIoThreads(addr: String, io: SocketIo) {
-        io.recvThread = Thread({ receiveLoop(addr, io.socket) }, "L2capRecv-$addr").apply {
+        io.recvThread = Thread({ receiveLoop(addr, io) }, "L2capRecv-$addr").apply {
             isDaemon = true; start()
         }
-        io.writerThread = Thread({ writerLoop(addr, io.socket.outputStream, io.sendQueue) }, "L2capWriter-$addr").apply {
+        io.writerThread = Thread({ writerLoop(addr, io) }, "L2capWriter-$addr").apply {
             isDaemon = true; start()
         }
     }
@@ -242,14 +242,27 @@ class L2capVoiceTransport(
      * length-prefixed payload. Exits when the writer pulls
      * [shutdownSentinel] off the queue, on I/O error, or on interrupt.
      *
-     * This is the *only* thread that touches [out] — concurrent producers
-     * push to [queue] but never write directly to the socket. That's what
-     * eliminates the torn-frame race that issue #101 reports.
+     * This is the *only* thread that touches the socket's [OutputStream]
+     * — concurrent producers push to [SocketIo.sendQueue] but never
+     * write directly to the socket. That's what eliminates the
+     * torn-frame race that issue #101 reports.
+     *
+     * The OutputStream is opened lazily here rather than at thread-spawn
+     * time because [BluetoothSocket.getOutputStream] can throw if the
+     * socket closes racily with thread start; opening inside the worker
+     * keeps that failure path inside the catch block instead of crashing
+     * the spawn site.
      */
-    private fun writerLoop(addr: String, out: OutputStream, queue: LinkedBlockingQueue<ByteArray>) {
+    private fun writerLoop(addr: String, io: SocketIo) {
+        val out = try {
+            io.socket.outputStream
+        } catch (e: IOException) {
+            Log.w(TAG, "Writer for $addr couldn't open output stream: ${e.message}")
+            return
+        }
         try {
             while (true) {
-                val frame = queue.take()
+                val frame = io.sendQueue.take()
                 if (frame === shutdownSentinel) break
                 if (frame.isEmpty()) continue
                 if (frame.size > MAX_FRAME_SIZE) {
@@ -268,7 +281,8 @@ class L2capVoiceTransport(
         }
     }
 
-    private fun receiveLoop(addr: String, socket: BluetoothSocket) {
+    private fun receiveLoop(addr: String, io: SocketIo) {
+        val socket = io.socket
         try {
             val input = DataInputStream(socket.inputStream)
             while (socket.isConnected) {
@@ -292,6 +306,13 @@ class L2capVoiceTransport(
             // racy with this thread starting.
             Log.i(TAG, "Receive loop init failed for $addr: ${e.message}")
         } finally {
+            // Signal the writer to stop *before* dropping references — if
+            // the peer disconnected silently, the writer is parked on
+            // queue.take() forever, which is the leak Copilot flagged.
+            // Clearing the queue plus offering the sentinel guarantees
+            // the writer wakes up and exits.
+            io.sendQueue.clear()
+            io.sendQueue.offer(shutdownSentinel)
             // Drop both the host-side (clientSockets) and guest-side (guestIo)
             // reference for whichever socket this loop was bound to. The
             // guest check is identity-based (socket ===) so a fresh
@@ -309,12 +330,17 @@ class L2capVoiceTransport(
      * Push [frame] onto [io]'s send queue. If the queue is full
      * (producers outpacing the link), drop the *oldest* frame — voice is
      * latency-sensitive, and stale audio is worse than missing audio.
+     *
+     * The poll+offer pair is wrapped in a `while` loop so a competing
+     * producer that refills the queue between our poll and our offer
+     * can't cause us to silently drop the *newest* frame instead of the
+     * oldest. Each loop iteration drops one and tries to add one;
+     * progress is bounded by the queue capacity.
      */
     private fun enqueueFrame(io: SocketIo, frame: ByteArray) {
         if (frame.isEmpty()) return
-        if (!io.sendQueue.offer(frame)) {
-            io.sendQueue.poll() // drop oldest
-            io.sendQueue.offer(frame)
+        while (!io.sendQueue.offer(frame)) {
+            io.sendQueue.poll() // drop oldest, retry the offer
         }
     }
 

--- a/android/app/src/test/kotlin/com/elodin/walkie_talkie/L2capFramingTest.kt
+++ b/android/app/src/test/kotlin/com/elodin/walkie_talkie/L2capFramingTest.kt
@@ -1,0 +1,221 @@
+package com.elodin.walkie_talkie
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.IOException
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.Random
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Unit tests for the L2CAP voice transport framing helpers and writer-thread
+ * queue. These cover the correctness contracts called out in issue #101 — they
+ * don't (and can't) exercise the actual Bluetooth socket path, but every
+ * behaviour that can be tested against an in-memory stream is.
+ */
+class L2capFramingTest {
+
+    /** Round-trip a single frame through writeFramed / readFramed. */
+    @Test
+    fun roundTripSingleFrame() {
+        val payload = ByteArray(40) { it.toByte() }
+        val out = ByteArrayOutputStream()
+        writeFramed(out, payload)
+
+        val input = DataInputStream(ByteArrayInputStream(out.toByteArray()))
+        val read = readFramed(input)
+        assertArrayEquals(payload, read)
+        // Stream is now at EOF.
+        assertNull(readFramed(input))
+    }
+
+    /**
+     * Two frames written back-to-back must come out as two distinct frames
+     * even though the receiving InputStream might return them in a single
+     * read() — the whole point of the length prefix.
+     */
+    @Test
+    fun framesDoNotMergeAcrossReads() {
+        val a = ByteArray(64) { it.toByte() }
+        val b = ByteArray(96) { (it + 100).toByte() }
+        val out = ByteArrayOutputStream()
+        writeFramed(out, a)
+        writeFramed(out, b)
+
+        // Wrap as a single InputStream — typical receive-side scenario where
+        // both writes coalesce into one TCP-style read.
+        val input = DataInputStream(ByteArrayInputStream(out.toByteArray()))
+        assertArrayEquals(a, readFramed(input))
+        assertArrayEquals(b, readFramed(input))
+        assertNull(readFramed(input))
+    }
+
+    /** Clean EOF *between* frames returns null without throwing. */
+    @Test
+    fun cleanEofBetweenFramesReturnsNull() {
+        val input = DataInputStream(ByteArrayInputStream(ByteArray(0)))
+        assertNull(readFramed(input))
+    }
+
+    /** EOF mid-prefix is an error — partial header is corrupt. */
+    @Test
+    fun midPrefixEofThrows() {
+        val input = DataInputStream(ByteArrayInputStream(byteArrayOf(0x00)))
+        try {
+            readFramed(input)
+            fail("expected IOException")
+        } catch (_: IOException) { /* expected */ }
+    }
+
+    /** Zero-length frames are rejected — Opus always emits >0 bytes. */
+    @Test
+    fun zeroLengthFrameThrows() {
+        val input = DataInputStream(ByteArrayInputStream(byteArrayOf(0x00, 0x00)))
+        try {
+            readFramed(input)
+            fail("expected IOException")
+        } catch (_: IOException) { /* expected */ }
+    }
+
+    /**
+     * A length prefix above MAX_FRAME_SIZE must throw rather than allocate
+     * gigabytes — defends against a malformed peer.
+     */
+    @Test
+    fun oversizedLengthPrefixThrows() {
+        val len = L2capVoiceTransport.MAX_FRAME_SIZE + 1
+        val bytes = byteArrayOf(((len ushr 8) and 0xff).toByte(), (len and 0xff).toByte())
+        val input = DataInputStream(ByteArrayInputStream(bytes))
+        try {
+            readFramed(input)
+            fail("expected IOException")
+        } catch (_: IOException) { /* expected */ }
+    }
+
+    /**
+     * writeFramed rejects a frame larger than MAX_FRAME_SIZE — symmetric
+     * with the reader's check so misbehaving senders get caught early.
+     */
+    @Test
+    fun oversizedWriteThrows() {
+        val out = ByteArrayOutputStream()
+        try {
+            writeFramed(out, ByteArray(L2capVoiceTransport.MAX_FRAME_SIZE + 1))
+            fail("expected IllegalArgumentException")
+        } catch (_: IllegalArgumentException) { /* expected */ }
+    }
+
+    /**
+     * The contention test that issue #101 calls out as the missing acceptance
+     * criterion: many concurrent producers all push frames into one queue,
+     * a single drainer thread writes them framed onto a pipe, and the
+     * reader on the other end of the pipe pulls them back out with
+     * readFramed. The writer is the only party that touches the stream,
+     * which is what eliminates torn frames.
+     */
+    @Test
+    fun multiProducerSingleWriterNeverTearsAFrame() {
+        val producers = 8
+        val framesPerProducer = 200
+        val queue = LinkedBlockingQueue<ByteArray>(L2capVoiceTransport.SEND_QUEUE_CAPACITY * 4)
+        // Sentinel — empty array — terminates the writer.
+        val SENTINEL = ByteArray(0)
+
+        val pipeOut = PipedOutputStream()
+        val pipeIn = PipedInputStream(pipeOut, 4096)
+        val readerInput = DataInputStream(pipeIn)
+
+        // Writer drains queue -> pipe.
+        val writer = Thread {
+            try {
+                while (true) {
+                    val frame = queue.take()
+                    if (frame === SENTINEL) break
+                    writeFramed(pipeOut, frame)
+                }
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+            } finally {
+                pipeOut.close()
+            }
+        }.apply { isDaemon = true; start() }
+
+        val totalExpected = producers * framesPerProducer
+        val rng = Random(42)
+
+        // Reader collects frames.
+        val readFrames = mutableListOf<ByteArray>()
+        val reader = Thread {
+            try {
+                while (readFrames.size < totalExpected) {
+                    val f = readFramed(readerInput) ?: break
+                    synchronized(readFrames) { readFrames.add(f) }
+                }
+            } catch (_: IOException) { /* pipe closed */ }
+        }.apply { isDaemon = true; start() }
+
+        // Producers pump distinct payloads.
+        val producerCount = AtomicInteger(producers)
+        repeat(producers) { p ->
+            Thread {
+                try {
+                    repeat(framesPerProducer) { i ->
+                        // Length varies so a torn frame would surface as a
+                        // wrong size in the assertion below.
+                        val size = 8 + rng.nextInt(120) // VoiceFrame header + payload
+                        val frame = ByteArray(size)
+                        // Encode a producer ID + sequence so we can verify
+                        // ordering inside each producer.
+                        frame[0] = p.toByte()
+                        frame[1] = (i ushr 24).toByte()
+                        frame[2] = (i ushr 16).toByte()
+                        frame[3] = (i ushr 8).toByte()
+                        frame[4] = (i and 0xff).toByte()
+                        for (b in 5 until size) frame[b] = ((p * 31 + i + b) and 0xff).toByte()
+                        // Block on full queue — we want the test to exercise
+                        // backpressure, not lossy drop-oldest behaviour.
+                        queue.put(frame)
+                    }
+                } finally {
+                    if (producerCount.decrementAndGet() == 0) queue.put(SENTINEL)
+                }
+            }.apply { isDaemon = true; start() }
+        }
+
+        // Reader should finish within a generous timeout.
+        reader.join(TimeUnit.SECONDS.toMillis(10))
+        writer.join(TimeUnit.SECONDS.toMillis(2))
+        assertTrue("reader should have terminated", !reader.isAlive)
+        assertTrue("writer should have terminated", !writer.isAlive)
+        assertEquals(totalExpected, readFrames.size)
+
+        // Per producer, the embedded sequence numbers must be strictly
+        // monotonic — anything else means a frame got torn or merged.
+        val perProducer = Array(producers) { mutableListOf<Int>() }
+        for (frame in readFrames) {
+            val p = frame[0].toInt() and 0xff
+            val seq = ((frame[1].toInt() and 0xff) shl 24) or
+                ((frame[2].toInt() and 0xff) shl 16) or
+                ((frame[3].toInt() and 0xff) shl 8) or
+                (frame[4].toInt() and 0xff)
+            perProducer[p].add(seq)
+        }
+        for (p in 0 until producers) {
+            val seqs = perProducer[p]
+            assertEquals("producer $p missing frames", framesPerProducer, seqs.size)
+            for (i in 0 until framesPerProducer) {
+                assertEquals("producer $p out-of-order frame at index $i", i, seqs[i])
+            }
+        }
+    }
+}

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -406,13 +406,22 @@ Comfortably under L2CAP throughput on any LE 4.2+ device.
 
 ### Voice frame format
 
-Each L2CAP write is a single Opus frame prefixed with an 8-byte header (MTU **MUST** be ≥ 128 bytes):
+Each L2CAP write is one VoiceFrame, framed by a 2-byte big-endian length
+prefix so the receiver can recover frame boundaries even when the kernel
+coalesces multiple SDUs into a single userspace `read` (observed on some
+Samsung and Pixel kernels). MTU **MUST** be ≥ 130 bytes (128 voice + 2
+prefix):
 
 | offset | bytes | meaning                                                       |
 | ------ | ----- | ------------------------------------------------------------- |
-| 0      | 4     | `seq` — per-link monotonic uint32, big-endian                 |
-| 4      | 4     | `senderTsMs` — sender's ms-since-epoch low 32 bits, big-endian |
-| 8      | N     | Opus frame payload                                            |
+| 0      | 2     | `frameLen` — uint16, big-endian; size of the VoiceFrame that follows (does **not** include this prefix) |
+| 2      | 4     | `seq` — per-link monotonic uint32, big-endian                 |
+| 6      | 4     | `senderTsMs` — sender's ms-since-epoch low 32 bits, big-endian |
+| 10     | N     | Opus frame payload                                            |
+
+`frameLen` is the size of the inner VoiceFrame (`seq` + `senderTsMs` +
+payload). Receivers that observe a `frameLen` of 0 or > 4096 close the
+channel — both indicate a malformed peer.
 
 `peerId` is **not** in the header — each L2CAP CoC is dedicated to a single
 peer (the connection identifies the sender). On the receive side, the host


### PR DESCRIPTION
Closes #101.

## Summary

Three correctness bugs called out in #101 are fixed in
[android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt):

1. **Single-writer queue per socket.** `sendToHost` / `sendToClient` now
   push onto a bounded `LinkedBlockingQueue<ByteArray>` (capacity 64 ≈
   1.3 s of audio) drained by a per-socket writer thread. Concurrent
   producers (audio capture + heartbeats) can no longer race on the
   same `OutputStream` and tear frames at the receiver. Backpressure is
   drop-oldest so a slow link can't stall the audio capture thread.
2. **Length-prefix framing.** Every L2CAP write is now `[len:uint16
   BE][VoiceFrame]`. The receiver reads exactly two bytes for the
   prefix, then exactly `len` bytes via `DataInputStream.readFully`, so
   kernels that coalesce multiple SDUs into a single userspace `read`
   no longer hand a multi-frame blob to `onVoiceFrame`. A 4096-byte
   defensive ceiling on the prefix value defeats malformed senders.
3. **Thread cleanup in `stop()`.** Accept, recv, and writer threads are
   joined with a 500 ms timeout and interrupted as a fallback. Stop +
   restart no longer leaks recv threads to GC. The map insert in
   `acceptLoop` now happens before the recv thread starts, so a fast
   peer disconnect can't fire the cleanup `finally` ahead of the put.
   `connectClient` snapshots the previous `guestIo` outside the
   `synchronized(this)` block before joining its threads, so other
   callers (`sendToHost`, `stop`) never block on the join.

## Wire-format note

The 2-byte length prefix is a wire-format change; [docs/protocol.md §
Voice frame format](docs/protocol.md) has been updated. SDU MTU now
needs to be ≥ 130 bytes (128 voice + 2 prefix). `GattConstants.VOICE_MTU`
keeps its value (still the size of the inner VoiceFrame); its KDoc
notes the prefix overhead. No production callers of `sendToHost` /
`sendToClient` exist yet (the voice plane is still scaffolding from
issue #46), so this is internal-only churn.

## Test plan

Acceptance criteria from #101:

- [x] **Unit test for the writer-thread queue under contention** —
  added `android/app/src/test/kotlin/com/elodin/walkie_talkie/L2capFramingTest.kt`.
  Pumps 8 producers × 200 frames each through a single drainer thread
  onto a `PipedOutputStream`, then verifies the reader on the other
  end pulls all 1600 frames back out with strictly monotonic
  per-producer sequence numbers — anything else would mean a torn or
  merged frame. Also covers framing round-trip, clean / mid-prefix
  EOF, zero-length and oversized frames. `testImplementation
  junit:4.13.2` wired into `android/app/build.gradle.kts`.
- [ ] **Two-device room, mic + heartbeat both active for 5 minutes:
  no malformed frames at receiver** — manual smoke test, deferred to
  hardware-on-desk verification per `docs/two_device_smoke_test.md`.
- [ ] **Stop and restart the room 20 times: `Thread.activeCount`
  returns to baseline** — same; manual hardware verification.

CI doesn't currently run Android-side JUnit tests (no `gradlew test`
step in `.github/workflows/flutter.yml`); reviewers can run the new
test locally with:

```sh
cd android && ./gradlew :app:testDebugUnitTest
```

Wiring it into CI is a small follow-up (needs `android-actions/setup-android`
or equivalent) and is out of scope for this PR.

`flutter analyze` + `flutter test` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)