### PR TITLE
feat(#122): Onboarding explainer — 3-screen intro + Discovery empty state

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -28,6 +28,47 @@
         "description": "Primary button on step 1 of onboarding."
     },
 
+    "explainerSkip": "Skip",
+    "@explainerSkip": {
+        "description": "Skip button on explainer pages 1 and 2."
+    },
+    "explainerPage1Headline": "Voice walkie-talkie\nfor nearby friends",
+    "@explainerPage1Headline": {
+        "description": "Explainer page 1 headline. \\n preserved for two-line layout."
+    },
+    "explainerPage1Body": "Frequency lets you create a voice channel that friends nearby can join — like a private walkie-talkie just for your group.",
+    "@explainerPage1Body": {
+        "description": "Explainer page 1 body copy."
+    },
+    "explainerPage2Headline": "Works through\nBluetooth only",
+    "@explainerPage2Headline": {
+        "description": "Explainer page 2 headline. \\n preserved for two-line layout."
+    },
+    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within Bluetooth range (about 30 feet) to stay connected.",
+    "@explainerPage2Body": {
+        "description": "Explainer page 2 body copy."
+    },
+    "explainerPage3Headline": "No internet,\nno account",
+    "@explainerPage3Headline": {
+        "description": "Explainer page 3 headline. \\n preserved for two-line layout."
+    },
+    "explainerPage3Body": "Your voice never leaves the devices. There's no server, no login, and no internet required — just Bluetooth and your microphone.",
+    "@explainerPage3Body": {
+        "description": "Explainer page 3 body copy."
+    },
+    "explainerBack": "Back",
+    "@explainerBack": {
+        "description": "Back button on explainer screen."
+    },
+    "explainerNext": "Next",
+    "@explainerNext": {
+        "description": "Next button on explainer screen."
+    },
+    "explainerGetStarted": "Get started",
+    "@explainerGetStarted": {
+        "description": "Final button on explainer page 3 — advances to permissions."
+    },
+
     "onboardingPermissionsEyebrow": "STEP 2 · PERMISSIONS",
     "@onboardingPermissionsEyebrow": {
         "description": "All-caps eyebrow label above the permissions step heading."
@@ -193,6 +234,18 @@
     "discoveryFooter": "Using Bluetooth LE Audio · No internet required for voice",
     "@discoveryFooter": {
         "description": "Reassurance line at the bottom of the discovery list."
+    },
+    "discoveryEmptyHeadline": "No frequencies nearby",
+    "@discoveryEmptyHeadline": {
+        "description": "Empty state headline when no sessions are discovered."
+    },
+    "discoveryEmptyBody": "No one around you is broadcasting right now. Try starting your own frequency above, or ask a friend to open the app.",
+    "@discoveryEmptyBody": {
+        "description": "Empty state body copy."
+    },
+    "discoveryEmptyHowItWorks": "How does this work?",
+    "@discoveryEmptyHowItWorks": {
+        "description": "Link in empty state that reopens the explainer screen."
     },
     "discoveryUnknownHost": "Unknown Host",
     "@discoveryUnknownHost": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -75,7 +75,7 @@
     },
     "onboardingPermissionsHeadline": "Two quick permissions.",
     "@onboardingPermissionsHeadline": {
-        "description": "Heading on step 2 of onboarding."
+        "description": "Heading on step 3 of onboarding."
     },
     "onboardingPermissionsBody": "We need Bluetooth to find nearby phones, and the microphone to share your voice.",
     "@onboardingPermissionsBody": {
@@ -119,7 +119,7 @@
     },
     "onboardingContinue": "Continue",
     "@onboardingContinue": {
-        "description": "Step 2 → step 3 advance button."
+        "description": "Step 3 → step 4 advance button."
     },
 
     "onboardingHandleEyebrow": "STEP 4 · YOUR HANDLE",
@@ -128,11 +128,11 @@
     },
     "onboardingHandleHeadline": "What should people call you?",
     "@onboardingHandleHeadline": {
-        "description": "Heading on step 3 of onboarding."
+        "description": "Heading on step 4 of onboarding."
     },
     "onboardingHandleBody": "This shows up to everyone on the same frequency.",
     "@onboardingHandleBody": {
-        "description": "Body copy on step 3 of onboarding."
+        "description": "Body copy on step 4 of onboarding."
     },
     "onboardingHandleHint": "Your name",
     "@onboardingHandleHint": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -69,7 +69,7 @@
         "description": "Final button on explainer page 3 — advances to permissions."
     },
 
-    "onboardingPermissionsEyebrow": "STEP 2 · PERMISSIONS",
+    "onboardingPermissionsEyebrow": "STEP 3 · PERMISSIONS",
     "@onboardingPermissionsEyebrow": {
         "description": "All-caps eyebrow label above the permissions step heading."
     },
@@ -122,7 +122,7 @@
         "description": "Step 2 → step 3 advance button."
     },
 
-    "onboardingHandleEyebrow": "STEP 3 · YOUR HANDLE",
+    "onboardingHandleEyebrow": "STEP 4 · YOUR HANDLE",
     "@onboardingHandleEyebrow": {
         "description": "All-caps eyebrow above the display-name step."
     },

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -797,8 +797,13 @@ class _EmptyState extends StatelessWidget {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
-          GestureDetector(
-            onTap: onShowExplainer,
+          TextButton(
+            onPressed: onShowExplainer,
+            style: TextButton.styleFrom(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              foregroundColor: c.accent,
+            ),
             child: Text(
               l10n.discoveryEmptyHowItWorks,
               style: TextStyle(

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -11,6 +11,7 @@ import '../l10n/styled_template.dart';
 import '../protocol/discovery.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
+import 'frequency_explainer_screen.dart';
 
 class DiscoveryResult {
   final String freq;
@@ -334,12 +335,14 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
   Widget _buildNearbyList(BuildContext context) {
     return BlocBuilder<DiscoveryCubit, DiscoveryState>(
       builder: (context, state) {
-        final sessions = state is DiscoveryScanning 
-            ? state.sessions 
+        final sessions = state is DiscoveryScanning
+            ? state.sessions
             : (state is DiscoveryStopped ? state.sessions : const <DiscoveredSession>[]);
-        
+
         if (sessions.isEmpty) {
-          return const SizedBox.shrink();
+          return _EmptyState(
+            onShowExplainer: _openExplainer,
+          );
         }
 
         return FreqCard(
@@ -367,6 +370,16 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
           ),
         );
       },
+    );
+  }
+
+  Future<void> _openExplainer() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FrequencyExplainerScreen(
+          onDone: () => Navigator.of(context).pop(),
+        ),
+      ),
     );
   }
 }
@@ -728,6 +741,75 @@ class _RenameSheetState extends State<_RenameSheet> {
             padding: const EdgeInsets.symmetric(vertical: 14),
             fontSize: 15,
             onPressed: hasName ? _submit : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final VoidCallback onShowExplainer;
+  const _EmptyState({required this.onShowExplainer});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    return FreqCard(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        children: [
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              color: c.surface2,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              Icons.search_off,
+              size: 28,
+              color: c.ink3,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            l10n.discoveryEmptyHeadline,
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: c.ink,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.discoveryEmptyBody,
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 13,
+              color: c.ink2,
+              height: 1.5,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          GestureDetector(
+            onTap: onShowExplainer,
+            child: Text(
+              l10n.discoveryEmptyHowItWorks,
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 13,
+                color: c.accent,
+                fontWeight: FontWeight.w500,
+                decoration: TextDecoration.underline,
+                decorationColor: c.accent,
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/screens/frequency_explainer_screen.dart
+++ b/lib/screens/frequency_explainer_screen.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/generated/app_localizations.dart';
+import '../theme/app_theme.dart';
+import '../widgets/frequency_atoms.dart';
+
+/// 3-page swipeable explainer: what is this / Bluetooth-only / no internet.
+/// Can be shown standalone (from Discovery empty state) or embedded in
+/// onboarding flow.
+class FrequencyExplainerScreen extends StatefulWidget {
+  final VoidCallback onDone;
+
+  /// If true, renders without Scaffold/SafeArea/Chrome (for embedding).
+  final bool embedded;
+
+  const FrequencyExplainerScreen({
+    super.key,
+    required this.onDone,
+    this.embedded = false,
+  });
+
+  @override
+  State<FrequencyExplainerScreen> createState() =>
+      _FrequencyExplainerScreenState();
+}
+
+class _FrequencyExplainerScreenState extends State<FrequencyExplainerScreen> {
+  final PageController _controller = PageController();
+  int _currentPage = 0;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final content = _buildContent(context);
+    if (widget.embedded) {
+      return content;
+    }
+    final c = FrequencyTheme.of(context).colors;
+    return Scaffold(
+      backgroundColor: c.bg,
+      body: SafeArea(
+        child: content,
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    return Column(
+      children: [
+        if (!widget.embedded)
+          FreqChrome(
+            left: const FrequencyWordmark(),
+            right: [
+              if (_currentPage < 2)
+                TextButton(
+                  onPressed: widget.onDone,
+                  style: TextButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 6),
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  child: Text(
+                    l10n.explainerSkip,
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 13,
+                      color: c.ink2,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        Expanded(
+          child: PageView(
+            controller: _controller,
+            onPageChanged: (page) => setState(() => _currentPage = page),
+            children: [
+              _ExplainerPage(
+                icon: Icons.podcasts_outlined,
+                headline: l10n.explainerPage1Headline,
+                body: l10n.explainerPage1Body,
+              ),
+              _ExplainerPage(
+                icon: Icons.bluetooth,
+                headline: l10n.explainerPage2Headline,
+                body: l10n.explainerPage2Body,
+              ),
+              _ExplainerPage(
+                icon: Icons.cloud_off_outlined,
+                headline: l10n.explainerPage3Headline,
+                body: l10n.explainerPage3Body,
+              ),
+            ],
+          ),
+        ),
+        _buildBottomBar(context),
+      ],
+    );
+  }
+
+  Widget _buildBottomBar(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
+      child: Column(
+        children: [
+          _PageIndicator(
+            currentPage: _currentPage,
+            pageCount: 3,
+          ),
+          const SizedBox(height: 20),
+          if (_currentPage == 2)
+            PrimaryButton(
+              label: l10n.explainerGetStarted,
+              block: true,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              fontSize: 15,
+              onPressed: widget.onDone,
+            )
+          else
+            Row(
+              children: [
+                Expanded(
+                  child: FreqButton(
+                    label: l10n.explainerBack,
+                    block: true,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    fontSize: 15,
+                    onPressed: _currentPage > 0
+                        ? () => _controller.previousPage(
+                              duration: const Duration(milliseconds: 280),
+                              curve: Curves.easeInOut,
+                            )
+                        : null,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: PrimaryButton(
+                    label: l10n.explainerNext,
+                    block: true,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    fontSize: 15,
+                    onPressed: () => _controller.nextPage(
+                      duration: const Duration(milliseconds: 280),
+                      curve: Curves.easeInOut,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExplainerPage extends StatelessWidget {
+  final IconData icon;
+  final String headline;
+  final String body;
+
+  const _ExplainerPage({
+    required this.icon,
+    required this.headline,
+    required this.body,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(32, 40, 32, 20),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 120,
+            height: 120,
+            decoration: BoxDecoration(
+              color: c.accentSoft,
+              borderRadius: BorderRadius.circular(30),
+            ),
+            alignment: Alignment.center,
+            child: Icon(icon, size: 56, color: c.accentInk),
+          ),
+          const SizedBox(height: 40),
+          Text(
+            headline,
+            style: Theme.of(context).textTheme.displayMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          Text(
+            body,
+            style: Theme.of(context)
+                .textTheme
+                .bodyLarge
+                ?.copyWith(color: c.ink2, height: 1.5),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PageIndicator extends StatelessWidget {
+  final int currentPage;
+  final int pageCount;
+
+  const _PageIndicator({
+    required this.currentPage,
+    required this.pageCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(
+        pageCount,
+        (index) => Container(
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          width: index == currentPage ? 24 : 8,
+          height: 8,
+          decoration: BoxDecoration(
+            color: index == currentPage ? c.accent : c.line,
+            borderRadius: BorderRadius.circular(4),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/frequency_explainer_screen.dart
+++ b/lib/screens/frequency_explainer_screen.dart
@@ -28,6 +28,27 @@ class _FrequencyExplainerScreenState extends State<FrequencyExplainerScreen> {
   final PageController _controller = PageController();
   int _currentPage = 0;
 
+  /// Source of truth for page count. Derive every off-by-one /
+  /// last-page check from this list rather than hard-coding indices,
+  /// so adding or removing a page only touches this one place.
+  List<_ExplainerPage> _buildPages(AppLocalizations l10n) => [
+        _ExplainerPage(
+          icon: Icons.podcasts_outlined,
+          headline: l10n.explainerPage1Headline,
+          body: l10n.explainerPage1Body,
+        ),
+        _ExplainerPage(
+          icon: Icons.bluetooth,
+          headline: l10n.explainerPage2Headline,
+          body: l10n.explainerPage2Body,
+        ),
+        _ExplainerPage(
+          icon: Icons.cloud_off_outlined,
+          headline: l10n.explainerPage3Headline,
+          body: l10n.explainerPage3Body,
+        ),
+      ];
+
   @override
   void dispose() {
     _controller.dispose();
@@ -52,20 +73,20 @@ class _FrequencyExplainerScreenState extends State<FrequencyExplainerScreen> {
   Widget _buildContent(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
     final l10n = AppLocalizations.of(context);
+    final pages = _buildPages(l10n);
+    final isLastPage = _currentPage >= pages.length - 1;
     return Column(
       children: [
         if (!widget.embedded)
           FreqChrome(
             left: const FrequencyWordmark(),
             right: [
-              if (_currentPage < 2)
+              if (!isLastPage)
                 TextButton(
                   onPressed: widget.onDone,
                   style: TextButton.styleFrom(
                     padding: const EdgeInsets.symmetric(
                         horizontal: 12, vertical: 6),
-                    minimumSize: Size.zero,
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   ),
                   child: Text(
                     l10n.explainerSkip,
@@ -83,31 +104,19 @@ class _FrequencyExplainerScreenState extends State<FrequencyExplainerScreen> {
           child: PageView(
             controller: _controller,
             onPageChanged: (page) => setState(() => _currentPage = page),
-            children: [
-              _ExplainerPage(
-                icon: Icons.podcasts_outlined,
-                headline: l10n.explainerPage1Headline,
-                body: l10n.explainerPage1Body,
-              ),
-              _ExplainerPage(
-                icon: Icons.bluetooth,
-                headline: l10n.explainerPage2Headline,
-                body: l10n.explainerPage2Body,
-              ),
-              _ExplainerPage(
-                icon: Icons.cloud_off_outlined,
-                headline: l10n.explainerPage3Headline,
-                body: l10n.explainerPage3Body,
-              ),
-            ],
+            children: pages,
           ),
         ),
-        _buildBottomBar(context),
+        _buildBottomBar(context, pageCount: pages.length, isLastPage: isLastPage),
       ],
     );
   }
 
-  Widget _buildBottomBar(BuildContext context) {
+  Widget _buildBottomBar(
+    BuildContext context, {
+    required int pageCount,
+    required bool isLastPage,
+  }) {
     final l10n = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
@@ -115,10 +124,10 @@ class _FrequencyExplainerScreenState extends State<FrequencyExplainerScreen> {
         children: [
           _PageIndicator(
             currentPage: _currentPage,
-            pageCount: 3,
+            pageCount: pageCount,
           ),
           const SizedBox(height: 20),
-          if (_currentPage == 2)
+          if (isLastPage)
             PrimaryButton(
               label: l10n.explainerGetStarted,
               block: true,

--- a/lib/screens/frequency_onboarding_screen.dart
+++ b/lib/screens/frequency_onboarding_screen.dart
@@ -13,7 +13,7 @@ import 'frequency_explainer_screen.dart';
 /// updating the ARB or every locale's translation.
 const int _kOnboardingTotalSteps = 4;
 
-/// 3-step onboarding: welcome → permissions → display name.
+/// 4-step onboarding: welcome → explainer → permissions → display name.
 class FrequencyOnboardingScreen extends StatefulWidget {
   final ValueChanged<String> onDone;
 

--- a/lib/screens/frequency_onboarding_screen.dart
+++ b/lib/screens/frequency_onboarding_screen.dart
@@ -6,11 +6,12 @@ import '../l10n/generated/app_localizations.dart';
 import '../services/onboarding_permission_gateway.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
+import 'frequency_explainer_screen.dart';
 
 /// Total number of steps in the onboarding flow. Surfaces in the chrome
-/// indicator (e.g. "01/03"); kept here so adding a step does not require
+/// indicator (e.g. "01/04"); kept here so adding a step does not require
 /// updating the ARB or every locale's translation.
-const int _kOnboardingTotalSteps = 3;
+const int _kOnboardingTotalSteps = 4;
 
 /// 3-step onboarding: welcome → permissions → display name.
 class FrequencyOnboardingScreen extends StatefulWidget {
@@ -114,6 +115,11 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen> {
       case 0:
         return _Welcome(onNext: () => setState(() => _step = 1));
       case 1:
+        return FrequencyExplainerScreen(
+          onDone: () => setState(() => _step = 2),
+          embedded: true,
+        );
+      case 2:
         return _Permissions(
           btStatus: _btStatus,
           micStatus: _micStatus,
@@ -122,7 +128,7 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen> {
           onRequestBt: _requestBluetooth,
           onRequestMic: _requestMicrophone,
           onOpenSettings: _gateway.openAppSettings,
-          onContinue: _allGranted ? () => setState(() => _step = 2) : null,
+          onContinue: _allGranted ? () => setState(() => _step = 3) : null,
         );
       default:
         return _NamePicker(

--- a/test/screens/frequency_onboarding_screen_test.dart
+++ b/test/screens/frequency_onboarding_screen_test.dart
@@ -64,6 +64,18 @@ void main() {
       await tester.tap(find.text('Get started'));
       await tester.pumpAndSettle();
 
+      // Explainer step — skip through the 3 pages
+      expect(find.text('Voice walkie-talkie\nfor nearby friends'), findsOneWidget);
+      // Navigate to the last page of the explainer
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      // Click Get started on the last explainer page
+      expect(find.text('No internet,\nno account'), findsOneWidget);
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
       // Permissions step — Continue is disabled until both granted.
       expect(find.text('Continue'), findsOneWidget);
       expect(gateway.btRequests, 0);
@@ -103,6 +115,14 @@ void main() {
       await tester.tap(find.text('Get started'));
       await tester.pumpAndSettle();
 
+      // Skip through explainer
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
       // First request: denied → button should still say Allow.
       await tester.tap(find.text('Allow').first);
       await tester.pumpAndSettle();
@@ -128,6 +148,14 @@ void main() {
           onDone: (_) {},
         ),
       ));
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      // Skip through explainer
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Get started'));
       await tester.pumpAndSettle();
 
@@ -157,6 +185,14 @@ void main() {
       await tester.tap(find.text('Get started'));
       await tester.pumpAndSettle();
 
+      // Skip through explainer
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
       // Grant only Bluetooth.
       await tester.tap(find.text('Allow').first);
       await tester.pumpAndSettle();
@@ -178,6 +214,14 @@ void main() {
           onDone: (_) {},
         ),
       ));
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      // Skip through explainer
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
       await tester.tap(find.text('Get started'));
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
Closes #122.

## Summary

Three files added/modified to complete the onboarding explainer:

1. **New FrequencyExplainerScreen** ([lib/screens/frequency_explainer_screen.dart](lib/screens/frequency_explainer_screen.dart)):
   - 3 swipeable pages: what is this / Bluetooth-only / no internet
   - Works standalone (from Discovery empty state) or embedded in onboarding
   - Page indicators, Next/Back navigation, Skip button on early pages

2. **Onboarding integration** ([lib/screens/frequency_onboarding_screen.dart](lib/screens/frequency_onboarding_screen.dart)):
   - Step count increased from 3 to 4
   - Explainer now step 1 (after Welcome, before Permissions)
   - First launch: Welcome → Explainer → Permissions → Name
   - Subsequent launches: skip explainer (already saw it)

3. **Discovery empty state** ([lib/screens/frequency_discovery_screen.dart](lib/screens/frequency_discovery_screen.dart)):
   - When no sessions found: shows card with headline + body + "How does this work?" link
   - Link opens explainer in standalone mode
   - Replaces previous SizedBox.shrink()

4. **Localization** ([lib/l10n/app_en.arb](lib/l10n/app_en.arb)):
   - Added 11 new strings: explainer pages, navigation, empty state

5. **Test updates** ([test/screens/frequency_onboarding_screen_test.dart](test/screens/frequency_onboarding_screen_test.dart)):
   - All 5 onboarding tests updated to navigate through explainer step
   - Tests now click Next twice then Get started to reach Permissions

## Acceptance

- ✅ First launch routes through onboarding → explainer → permission prompt → discovery
- ✅ Subsequent launches skip the explainer (SessionOnboarding state only on first launch)
- ✅ Discovery's empty state is informative with "How does this work?" link
- ✅ Link reopens the explainer in standalone mode
- ✅ All tests pass

## Wire-format note

No protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a three-page explainer screen with swipe, Back/Next, Skip, and "Get started" actions; integrated into onboarding (now 4 steps).
  * Added an empty-state on discovery with a "How it works?" link that opens the explainer.

* **Localization**
  * Added and updated English strings for the explainer, onboarding step labels, and discovery empty-state.

* **Tests**
  * Updated onboarding tests to exercise the explainer flow.

* **Chores**
  * Updated native audio library reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->