### PR TITLE
fix(#104): Reconnect watchdog — bail to lost+Discovery if no JoinAccepted in 10s

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -123,10 +123,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   StreamSubscription<List<AppPermission>>? _permissionSubscription;
   ReconnectController? _reconnectController;
 
+  /// Default watchdog duration after a successful GATT reconnect: how long
+  /// we wait for the host's JoinAccepted before bailing to lost + Discovery.
+  /// Tests can shorten this via the constructor parameter.
+  static const Duration defaultJoinAcceptedTimeout = Duration(seconds: 10);
+
+  final Duration _joinAcceptedTimeout;
+
   /// Watchdog timer started after a successful GATT reconnect to detect when
-  /// the host never sends a JoinAccepted. Fires after 10 s and transitions
-  /// to ConnectionPhase.lost if still reconnecting. Cancelled by
-  /// applyJoinAccepted or any state transition that exits SessionRoom.
+  /// the host never sends a JoinAccepted. Fires after [_joinAcceptedTimeout]
+  /// and transitions to ConnectionPhase.lost if still reconnecting.
+  /// Cancelled by applyJoinAccepted or any state transition that exits
+  /// SessionRoom.
   Timer? _joinAcceptedWatchdog;
 
   final _mediaCommandsController = StreamController<MediaCommand>.broadcast();
@@ -166,6 +174,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     SignalReporter? signalReporter,
     WeakSignalDetector? weakSignalDetector,
     String Function()? mintSessionUuid,
+    Duration joinAcceptedTimeout = defaultJoinAcceptedTimeout,
   })  : _transport = transport,
         _audio = audio,
         _permissionWatcher = permissionWatcher,
@@ -174,6 +183,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         _signalReporter = signalReporter ?? SignalReporter(),
         _weakSignalDetector = weakSignalDetector ?? WeakSignalDetector(),
         _mintSessionUuid = mintSessionUuid ?? generateUuidV4,
+        _joinAcceptedTimeout = joinAcceptedTimeout,
         super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
@@ -1057,7 +1067,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // subscription failed silently, ...), bail to lost + Discovery rather
     // than waiting forever.
     _joinAcceptedWatchdog?.cancel();
-    _joinAcceptedWatchdog = Timer(const Duration(seconds: 10), () async {
+    _joinAcceptedWatchdog = Timer(_joinAcceptedTimeout, () async {
       if (isClosed) return;
       final watchdogState = state;
       // Guard: applyJoinAccepted already fired and cleared to online, or the

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -123,6 +123,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   StreamSubscription<List<AppPermission>>? _permissionSubscription;
   ReconnectController? _reconnectController;
 
+  /// Watchdog timer started after a successful GATT reconnect to detect when
+  /// the host never sends a JoinAccepted. Fires after 10 s and transitions
+  /// to ConnectionPhase.lost if still reconnecting. Cancelled by
+  /// applyJoinAccepted or any state transition that exits SessionRoom.
+  Timer? _joinAcceptedWatchdog;
+
   final _mediaCommandsController = StreamController<MediaCommand>.broadcast();
 
   /// Stream of media commands relevant to the local peer's UI. Emits both
@@ -792,6 +798,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // the user manually leaves rather than waiting for the next delay tick.
     _reconnectController?.cancel();
     _reconnectController = null;
+    _joinAcceptedWatchdog?.cancel();
+    _joinAcceptedWatchdog = null;
     // Cancel the heartbeat timer so it doesn't keep ticking against an
     // empty roster (and incidentally trigger a phantom RosterUpdate if
     // a stale watermark expires post-leave).
@@ -884,6 +892,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Future<void> _teardownForPermissionRevoke() async {
     _reconnectController?.cancel();
     _reconnectController = null;
+    _joinAcceptedWatchdog?.cancel();
+    _joinAcceptedWatchdog = null;
     _heartbeats.stop();
     _signalReporter.stop();
     _weakSignalDetector.clear();
@@ -986,6 +996,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // completing is the authoritative "connection is healthy" signal.
     _reconnectController?.cancel();
     _reconnectController = null;
+    _joinAcceptedWatchdog?.cancel();
+    _joinAcceptedWatchdog = null;
     emit(current.copyWith(
       hostPeerId: msg.hostPeerId,
       roster: msg.roster,
@@ -1036,9 +1048,29 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // can show a "Lost connection" indicator, then drop to Discovery.
       emit(postAttempt.copyWith(connectionPhase: ConnectionPhase.lost));
       await leaveRoom();
+      return;
     }
-    // On success: wait for the transport's JoinAccepted to call
-    // applyJoinAccepted, which cancels the controller and resets to online.
+
+    // On success: GATT link is re-established, but we still need the host's
+    // JoinAccepted to complete the rejoin. Start a 10 s watchdog: if the
+    // host never sends JoinAccepted (host died, session UUID changed, GATT
+    // subscription failed silently, ...), bail to lost + Discovery rather
+    // than waiting forever.
+    _joinAcceptedWatchdog?.cancel();
+    _joinAcceptedWatchdog = Timer(const Duration(seconds: 10), () async {
+      if (isClosed) return;
+      final watchdogState = state;
+      // Guard: applyJoinAccepted already fired and cleared to online, or the
+      // user manually left. Don't overwrite a healthy or exited state.
+      if (watchdogState is! SessionRoom ||
+          watchdogState.connectionPhase != ConnectionPhase.reconnecting) {
+        return;
+      }
+      // Host never sent JoinAccepted after native reconnect succeeded —
+      // treat it like a full connection loss.
+      emit(watchdogState.copyWith(connectionPhase: ConnectionPhase.lost));
+      await leaveRoom();
+    });
   }
 
   /// Broadcasts a media command originated by the local peer.
@@ -1173,6 +1205,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Cancel an in-progress reconnect before closing so the attempt loop
     // won't call emit() or leaveRoom() after the cubit is disposed.
     _reconnectController?.cancel();
+    _joinAcceptedWatchdog?.cancel();
     // Stop the heartbeat timer before super.close() so a tick suspended
     // mid-microtask can't try to emit() against a closing cubit.
     _heartbeats.stop();

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -114,6 +114,8 @@ FrequencySessionCubit _makeCubit({
   SignalReporter? signalReporter,
   WeakSignalDetector? weakSignalDetector,
   String Function()? mintSessionUuid,
+  Duration joinAcceptedTimeout =
+      FrequencySessionCubit.defaultJoinAcceptedTimeout,
 }) =>
     FrequencySessionCubit(
       identityStore: identityStore ?? _FakeStore(),
@@ -127,6 +129,7 @@ FrequencySessionCubit _makeCubit({
       signalReporter: signalReporter,
       weakSignalDetector: weakSignalDetector,
       mintSessionUuid: mintSessionUuid ?? (() => _testHostSessionUuid),
+      joinAcceptedTimeout: joinAcceptedTimeout,
     );
 
 /// Drives the cubit's permission-revoked branch under test. The default
@@ -1417,13 +1420,18 @@ void main() {
       () async {
         // Scenario: native reconnect succeeds (GATT link re-established), but
         // the host never sends JoinAccepted (host died, session UUID changed,
-        // GATT subscription failed silently). The 10 s watchdog should fire,
+        // GATT subscription failed silently). The watchdog should fire,
         // transition to ConnectionPhase.lost, and call leaveRoom.
+        //
+        // The watchdog duration is injected so the test runs in milliseconds
+        // rather than seconds — production still uses the 10 s default.
         connectQueue.add(true); // Simulate successful reconnect
 
+        const watchdog = Duration(milliseconds: 50);
         final cubit = _makeCubit(
           audio: audio,
           reconnectDelays: _testReconnectDelays,
+          joinAcceptedTimeout: watchdog,
         );
         cubit.emit(const SessionRoom(
           myName: 'Maya',
@@ -1444,8 +1452,8 @@ void main() {
           ConnectionPhase.reconnecting,
         );
 
-        // Wait for the 10 s watchdog to fire. Add a small buffer.
-        await Future<void>.delayed(const Duration(seconds: 10, milliseconds: 100));
+        // Wait for the watchdog to fire, plus a small buffer.
+        await Future<void>.delayed(watchdog + const Duration(milliseconds: 50));
 
         // Watchdog should have fired and transitioned to Discovery.
         expect(cubit.state, isA<SessionDiscovery>());
@@ -1457,13 +1465,15 @@ void main() {
       'watchdog is cancelled when JoinAccepted arrives before timeout',
       () async {
         // Scenario: native reconnect succeeds and the host sends JoinAccepted
-        // before the 10 s watchdog expires. The watchdog must be cancelled
-        // and the state should transition to online.
+        // before the watchdog expires. The watchdog must be cancelled and
+        // the state should transition to online.
         connectQueue.add(true); // Simulate successful reconnect
 
+        const watchdog = Duration(milliseconds: 50);
         final cubit = _makeCubit(
           audio: audio,
           reconnectDelays: _testReconnectDelays,
+          joinAcceptedTimeout: watchdog,
         );
         cubit.emit(const SessionRoom(
           myName: 'Maya',
@@ -1499,7 +1509,7 @@ void main() {
         );
 
         // Wait past the watchdog timeout to ensure it was cancelled.
-        await Future<void>.delayed(const Duration(seconds: 10, milliseconds: 100));
+        await Future<void>.delayed(watchdog + const Duration(milliseconds: 50));
 
         // State should still be SessionRoom(online), not Discovery.
         expect(cubit.state, isA<SessionRoom>());

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1411,6 +1411,105 @@ void main() {
       blocker.complete(false);
       await expectLater(dropFuture, completes);
     });
+
+    test(
+      'watchdog fires after successful reconnect when JoinAccepted never arrives',
+      () async {
+        // Scenario: native reconnect succeeds (GATT link re-established), but
+        // the host never sends JoinAccepted (host died, session UUID changed,
+        // GATT subscription failed silently). The 10 s watchdog should fire,
+        // transition to ConnectionPhase.lost, and call leaveRoom.
+        connectQueue.add(true); // Simulate successful reconnect
+
+        final cubit = _makeCubit(
+          audio: audio,
+          reconnectDelays: _testReconnectDelays,
+        );
+        cubit.emit(const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: false,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        ));
+
+        // Start the reconnect — it will succeed but we won't send JoinAccepted.
+        final dropFuture = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+        await dropFuture; // Wait for reconnect to complete
+
+        // At this point, the cubit should be in reconnecting state with the
+        // watchdog running. The state should still be SessionRoom(reconnecting).
+        expect(cubit.state, isA<SessionRoom>());
+        expect(
+          (cubit.state as SessionRoom).connectionPhase,
+          ConnectionPhase.reconnecting,
+        );
+
+        // Wait for the 10 s watchdog to fire. Add a small buffer.
+        await Future<void>.delayed(const Duration(seconds: 10, milliseconds: 100));
+
+        // Watchdog should have fired and transitioned to Discovery.
+        expect(cubit.state, isA<SessionDiscovery>());
+        await cubit.close();
+      },
+    );
+
+    test(
+      'watchdog is cancelled when JoinAccepted arrives before timeout',
+      () async {
+        // Scenario: native reconnect succeeds and the host sends JoinAccepted
+        // before the 10 s watchdog expires. The watchdog must be cancelled
+        // and the state should transition to online.
+        connectQueue.add(true); // Simulate successful reconnect
+
+        final cubit = _makeCubit(
+          audio: audio,
+          reconnectDelays: _testReconnectDelays,
+        );
+        cubit.emit(const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: false,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        ));
+
+        final dropFuture = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
+        await dropFuture; // Wait for reconnect to complete
+
+        // State should be reconnecting with watchdog running.
+        expect(cubit.state, isA<SessionRoom>());
+        expect(
+          (cubit.state as SessionRoom).connectionPhase,
+          ConnectionPhase.reconnecting,
+        );
+
+        // Host sends JoinAccepted before the watchdog fires.
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [],
+        ));
+
+        // State should transition to online.
+        expect(cubit.state, isA<SessionRoom>());
+        expect(
+          (cubit.state as SessionRoom).connectionPhase,
+          ConnectionPhase.online,
+        );
+
+        // Wait past the watchdog timeout to ensure it was cancelled.
+        await Future<void>.delayed(const Duration(seconds: 10, milliseconds: 100));
+
+        // State should still be SessionRoom(online), not Discovery.
+        expect(cubit.state, isA<SessionRoom>());
+        expect(
+          (cubit.state as SessionRoom).connectionPhase,
+          ConnectionPhase.online,
+        );
+        await cubit.close();
+      },
+    );
   });
 
   // ── Heartbeats / dirty-disconnect ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #104 by adding a 10-second watchdog after a successful native GATT reconnect. If the host never sends `JoinAccepted` within that window (host died, session UUID changed, GATT subscription failed silently, etc.), the watchdog fires and transitions the room to `ConnectionPhase.lost`, then calls `leaveRoom()` to drop to Discovery.

- **Added**: `_joinAcceptedWatchdog` Timer field to FrequencySessionCubit
- **Modified**: `notifyDrop()` to start the watchdog after successful reconnect
- **Modified**: `applyJoinAccepted()` to cancel the watchdog when JoinAccepted arrives
- **Modified**: `leaveRoom()`, `_teardownForPermissionRevoke()`, and `close()` to cancel the watchdog during cleanup
- **Added**: Two cubit tests verifying watchdog behavior

## Test plan

- [x] New test: watchdog fires after 10s when JoinAccepted never arrives → room drops to Discovery
- [x] New test: watchdog is cancelled when JoinAccepted arrives before timeout → room stays online
- [ ] CI passes
- [ ] Manual testing: simulate host death after reconnect and verify the 10s timeout works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a join-acceptance watchdog during guest reconnects: if a join isn't confirmed within a configurable timeout (default 10s), the session transitions to a disconnected state to avoid indefinite reconnecting.
  * The reconnect flow now stops immediately after handling a timed-out reconnect.

* **New Features**
  * Exposed a configurable timeout parameter for the join-acceptance watchdog.

* **Tests**
  * Added tests for timeout-triggered disconnect and for watchdog cancellation when join is confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->