### PR TITLE
feat(#95): LinkQuality + BitrateHint plane with host-side BitrateAdapter

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -512,15 +512,23 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         current: snapshot,
         elapsed: elapsed,
       );
-      final String peerId;
-      try {
-        peerId = await identityStore.getPeerId();
-      } catch (error, stackTrace) {
-        if (kDebugMode) debugPrint('Failed to resolve peer id for link quality: $error');
-        if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
-        return;
+      // Prefer the cached peerId (populated during bootstrap) — this
+      // tick fires every 2 s and an identityStore round-trip is a
+      // measurable Hive disk hit. Fall back to the store only if the
+      // cache is empty (a startup race we can't otherwise reach from
+      // a guest in a SessionRoom).
+      String? peerId = _localPeerId;
+      if (peerId == null) {
+        try {
+          peerId = await identityStore.getPeerId();
+          _localPeerId = peerId;
+        } catch (error, stackTrace) {
+          if (kDebugMode) debugPrint('Failed to resolve peer id for link quality: $error');
+          if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+          return;
+        }
+        if (isClosed) return;
       }
-      if (isClosed) return;
       final msg = LinkQuality(
         peerId: peerId,
         seq: ++_seq,
@@ -552,7 +560,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     final current = state;
     if (current is! SessionRoom || !current.roomIsHost) return;
-    final newLevel = _bitrateAdapter.feed(report);
+    // Pass the host-local clock so adapter dwell windows are immune to
+    // sender clock drift / spoofing (see BitrateAdapter dwell docs).
+    final newLevel = _bitrateAdapter.feed(
+      report,
+      nowMs: DateTime.now().millisecondsSinceEpoch,
+    );
     if (newLevel == null) return;
     // Adjust the host's own outbound encoder toward the reporter (best
     // effort — the audio side returns null on missing peer / handler).
@@ -598,15 +611,22 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Future<void> _sendBitrateHint(String targetPeerId, int bps) async {
     final t = _transport;
     if (t == null) return;
-    final String hostPeerId;
-    try {
-      hostPeerId = await identityStore.getPeerId();
-    } catch (error, stackTrace) {
-      if (kDebugMode) debugPrint('Failed to resolve peer id for bitrate hint: $error');
-      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
-      return;
+    // Use the cached peerId (populated during bootstrap) — adapter
+    // steps fire on every incoming `LinkQuality`, and an identityStore
+    // round-trip per step would add a Hive disk hit per host-side adapter
+    // decision. Fall back to the store only if the cache is empty.
+    String? hostPeerId = _localPeerId;
+    if (hostPeerId == null) {
+      try {
+        hostPeerId = await identityStore.getPeerId();
+        _localPeerId = hostPeerId;
+      } catch (error, stackTrace) {
+        if (kDebugMode) debugPrint('Failed to resolve peer id for bitrate hint: $error');
+        if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+        return;
+      }
+      if (isClosed) return;
     }
-    if (isClosed) return;
     // Note: BitrateHint's envelope `peerId` is the *sender's* (host's)
     // peerId per the protocol. The recipient is implicit — the host
     // sends the hint along the GATT link to the specific guest. The

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -486,6 +486,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     try {
       final snapshot = await audio.getLinkTelemetry(mac);
       if (isClosed) return;
+      // Re-check the room snapshot after the await: the user could have
+      // left the room (or left + rejoined a different room) between the
+      // tick start and the telemetry response. Mutating `_prevTelemetry`
+      // after a leave would re-seed an entry the room teardown just
+      // cleared; sending after a leave would write to a transport whose
+      // peer we already forgot. Bail if anything changed.
+      if (!_stillSameGuestRoomFor(mac)) return;
       final now = DateTime.now();
       if (snapshot == null) {
         // Native side unavailable — drop any seeded snapshot so the next
@@ -528,6 +535,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           return;
         }
         if (isClosed) return;
+        // Same race re-check after the second possible await.
+        if (!_stillSameGuestRoomFor(mac)) return;
       }
       final msg = LinkQuality(
         peerId: peerId,
@@ -546,6 +555,19 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     } finally {
       _linkQualitySendInFlight = false;
     }
+  }
+
+  /// True iff the cubit is still in a guest [SessionRoom] whose
+  /// `macAddress` matches [mac]. Used by [_sendLinkQuality] to bail when
+  /// the user left or switched rooms during a telemetry / identity
+  /// await — a simple `isClosed` check would let post-await mutations
+  /// poison the next room's telemetry baseline.
+  bool _stillSameGuestRoomFor(String mac) {
+    if (isClosed) return false;
+    final s = state;
+    if (s is! SessionRoom) return false;
+    if (s.roomIsHost) return false;
+    return s.macAddress == mac;
   }
 
   /// Host-only ingress for `LinkQuality`. Feeds the per-peer

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -8,9 +8,11 @@ import '../protocol/messages.dart';
 import '../protocol/peer.dart';
 import '../protocol/uuid.dart';
 import '../services/audio_service.dart';
+import '../services/bitrate_adapter.dart';
 import '../services/ble_control_transport.dart';
 import '../services/heartbeat_scheduler.dart';
 import '../services/identity_store.dart';
+import '../services/link_quality_reporter.dart';
 import '../services/permission_watcher.dart';
 import '../services/recent_frequencies_store.dart';
 import '../services/reconnect_controller.dart';
@@ -104,6 +106,36 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// lifetime; cleared on `leaveRoom` and on per-peer drop / removal.
   final WeakSignalDetector _weakSignalDetector;
 
+  /// Drives the protocol's `link_quality` plane on the **guest** side.
+  /// Started on room entry, stopped on leave / close. The cubit polls
+  /// the native `PeerAudioManager` telemetry on each tick, deltas it
+  /// against the previous snapshot, and writes a `LinkQuality` to the
+  /// host. Skipped on the host side — the host is a receiver of these
+  /// reports, not a sender.
+  final LinkQualityReporter _linkQualityReporter;
+
+  /// Host-side: per-peer hysteresis state machine that consumes incoming
+  /// `LinkQuality` reports and decides when to step a peer's encoder
+  /// up or down. Cleared on `leaveRoom`.
+  final BitrateAdapter _bitrateAdapter;
+
+  /// Per-peer previous telemetry snapshot, keyed by Bluetooth MAC. Used
+  /// by the guest's link-quality tick to compute deltas. Cleared on
+  /// leave / close along with the rest of the per-session state.
+  final Map<String, LinkTelemetrySnapshot> _prevTelemetry = {};
+
+  /// Wall-clock of the previous link-quality sample, keyed by MAC.
+  /// Tracked alongside [_prevTelemetry] so a tick that's late (e.g.
+  /// because the OS suspended the timer) computes rates against actual
+  /// elapsed time rather than the nominal interval.
+  final Map<String, DateTime> _prevTelemetryAt = {};
+
+  /// Re-entrancy guard for [_sendLinkQuality]. The reporter tick is
+  /// `unawaited`-launched, so a slow telemetry round-trip plus transport
+  /// write could otherwise overlap a subsequent tick. Same rationale as
+  /// [_signalReportSendInFlight].
+  bool _linkQualitySendInFlight = false;
+
   /// Re-entrancy guard for [_sendHeartbeat]. The scheduler tick is
   /// `unawaited`-launched, so a slow GATT write could otherwise overlap
   /// the next tick and let two `send()` calls interleave on the same
@@ -159,6 +191,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     HeartbeatScheduler? heartbeats,
     SignalReporter? signalReporter,
     WeakSignalDetector? weakSignalDetector,
+    LinkQualityReporter? linkQualityReporter,
+    BitrateAdapter? bitrateAdapter,
     String Function()? mintSessionUuid,
   })  : _transport = transport,
         _audio = audio,
@@ -167,6 +201,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         _heartbeats = heartbeats ?? HeartbeatScheduler(),
         _signalReporter = signalReporter ?? SignalReporter(),
         _weakSignalDetector = weakSignalDetector ?? WeakSignalDetector(),
+        _linkQualityReporter = linkQualityReporter ?? LinkQualityReporter(),
+        _bitrateAdapter = bitrateAdapter ?? BitrateAdapter(),
         _mintSessionUuid = mintSessionUuid ?? generateUuidV4,
         super(const SessionBooting());
 
@@ -269,6 +305,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           _transport?.forgetPeer(m.peerId);
           _heartbeats.forgetPeer(m.peerId);
           _weakSignalDetector.forgetPeer(m.peerId);
+          _bitrateAdapter.forgetPeer(m.peerId);
         }
       case RemovePeer m:
         // Host-broadcasted peer removal. Drop the named peer from the roster
@@ -281,12 +318,17 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         _transport?.forgetPeer(m.target);
         _heartbeats.forgetPeer(m.target);
         _weakSignalDetector.forgetPeer(m.target);
+        _bitrateAdapter.forgetPeer(m.target);
       case Heartbeat():
         // Already noted above; no further dispatch — the heartbeat plane
         // is purely a liveness signal, not a state-changing event.
         break;
       case SignalReport m:
         _onSignalReport(m);
+      case LinkQuality m:
+        _onLinkQuality(m);
+      case BitrateHint m:
+        _onBitrateHint(m);
       // These message types are handled by future issues
       // (voice-activity detection, join request flow). Silently drop.
       case TalkingState():
@@ -404,6 +446,185 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       }
     } finally {
       _signalReportSendInFlight = false;
+    }
+  }
+
+  /// Tick callback wired into [LinkQualityReporter.start] on the guest
+  /// side. Polls per-peer telemetry from the native `PeerAudioManager`,
+  /// computes deltas against the previous snapshot, and writes a
+  /// `LinkQuality` to the host.
+  ///
+  /// **Skipped paths.**
+  ///   * No transport, no audio, or local user is the host → no-op.
+  ///   * No `macAddress` recorded on the room state (unusual — guest
+  ///     entered without a discovered host MAC) → no-op.
+  ///   * First sample for this peer (no previous snapshot to delta
+  ///     against) → record the snapshot and bail; the *next* tick
+  ///     produces the first `LinkQuality`.
+  ///   * Native side returns null telemetry (peer not registered,
+  ///     handler not wired) → no-op; reset the previous snapshot so we
+  ///     re-seed on the next non-null sample.
+  ///
+  /// **Seq accounting.** Unlike `_sendSignalReport` and `_sendHeartbeat`,
+  /// this method does **not** advance the seq counter on skipped paths.
+  /// The first-sample case in particular is a normal startup transient,
+  /// not a failure path — burning a seq for it would put a permanent
+  /// gap at the top of every guest's wire log. The other skips (missing
+  /// audio / transport / host role) are static — they fire every tick
+  /// while the cubit is in that mode and would burn a seq per tick if
+  /// we incremented.
+  Future<void> _sendLinkQuality() async {
+    final current = state;
+    if (isClosed || current is! SessionRoom) return;
+    if (current.roomIsHost) return;
+    final t = _transport;
+    final audio = _audio;
+    final mac = current.macAddress;
+    if (t == null || audio == null || mac == null) return;
+    if (_linkQualitySendInFlight) return;
+    _linkQualitySendInFlight = true;
+    try {
+      final snapshot = await audio.getLinkTelemetry(mac);
+      if (isClosed) return;
+      final now = DateTime.now();
+      if (snapshot == null) {
+        // Native side unavailable — drop any seeded snapshot so the next
+        // successful sample re-seeds rather than computing rates against
+        // ancient data.
+        _prevTelemetry.remove(mac);
+        _prevTelemetryAt.remove(mac);
+        return;
+      }
+      final prev = _prevTelemetry[mac];
+      final prevAt = _prevTelemetryAt[mac];
+      _prevTelemetry[mac] = snapshot;
+      _prevTelemetryAt[mac] = now;
+      if (prev == null || prevAt == null) {
+        // First sample — nothing to delta against. Seed and exit.
+        return;
+      }
+      final elapsed = now.difference(prevAt);
+      // Negative or zero elapsed (clock skew) — skip computation rather
+      // than throwing inside computeLinkQuality.
+      if (elapsed <= Duration.zero) return;
+      final rates = computeLinkQuality(
+        previous: prev,
+        current: snapshot,
+        elapsed: elapsed,
+      );
+      final String peerId;
+      try {
+        peerId = await identityStore.getPeerId();
+      } catch (error, stackTrace) {
+        if (kDebugMode) debugPrint('Failed to resolve peer id for link quality: $error');
+        if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+        return;
+      }
+      if (isClosed) return;
+      final msg = LinkQuality(
+        peerId: peerId,
+        seq: ++_seq,
+        atMs: now.millisecondsSinceEpoch,
+        lossPct: rates.lossPct,
+        jitterMs: rates.jitterMs,
+        underrunsPerSec: rates.underrunsPerSec,
+      );
+      try {
+        await t.send(msg);
+      } catch (error, stackTrace) {
+        if (kDebugMode) debugPrint('LinkQuality send failed: $error');
+        if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+      }
+    } finally {
+      _linkQualitySendInFlight = false;
+    }
+  }
+
+  /// Host-only ingress for `LinkQuality`. Feeds the per-peer
+  /// [BitrateAdapter]; if the adapter decides to step the level, sends
+  /// a `BitrateHint` to the reporting peer **and** locally calls
+  /// `setPeerBitrate` for the same peer's MAC so the host's own encoder
+  /// toward that guest also tracks the new level.
+  ///
+  /// On a guest, `LinkQuality` from a host is silently dropped — only
+  /// the host owns adapter state.
+  void _onLinkQuality(LinkQuality report) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! SessionRoom || !current.roomIsHost) return;
+    final newLevel = _bitrateAdapter.feed(report);
+    if (newLevel == null) return;
+    // Adjust the host's own outbound encoder toward the reporter (best
+    // effort — the audio side returns null on missing peer / handler).
+    final audio = _audio;
+    final macForPeer = _macForPeerId(report.peerId, current);
+    if (audio != null && macForPeer != null) {
+      unawaited(audio.setPeerBitrate(macForPeer, newLevel.bps));
+    }
+    unawaited(_sendBitrateHint(report.peerId, newLevel.bps));
+  }
+
+  /// Guest-only ingress for `BitrateHint`. Applies the hinted bitrate to
+  /// the local outbound encoder (toward the host). On the host, hints
+  /// are silently dropped — the host is the source of hints, not a sink.
+  void _onBitrateHint(BitrateHint hint) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! SessionRoom || current.roomIsHost) return;
+    final audio = _audio;
+    final mac = current.macAddress;
+    if (audio == null || mac == null) return;
+    unawaited(audio.setPeerBitrate(mac, hint.bps));
+  }
+
+  /// Resolve a peer's BLE MAC from the current room snapshot. Returns
+  /// null when the peer isn't on the roster or has no `btDevice`
+  /// recorded — both cases are treated as "skip the local
+  /// `setPeerBitrate` call" rather than poisoning the adapter step.
+  String? _macForPeerId(String peerId, SessionRoom room) {
+    for (final p in room.roster) {
+      if (p.peerId == peerId) {
+        final mac = p.btDevice;
+        if (mac == null || mac.isEmpty) return null;
+        return mac;
+      }
+    }
+    return null;
+  }
+
+  /// Build and send a `BitrateHint` to [targetPeerId]. Best-effort:
+  /// transport-level failures are logged and swallowed so a single bad
+  /// adapter step doesn't poison the rest of the dispatch loop.
+  Future<void> _sendBitrateHint(String targetPeerId, int bps) async {
+    final t = _transport;
+    if (t == null) return;
+    final String hostPeerId;
+    try {
+      hostPeerId = await identityStore.getPeerId();
+    } catch (error, stackTrace) {
+      if (kDebugMode) debugPrint('Failed to resolve peer id for bitrate hint: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+      return;
+    }
+    if (isClosed) return;
+    // Note: BitrateHint's envelope `peerId` is the *sender's* (host's)
+    // peerId per the protocol. The recipient is implicit — the host
+    // sends the hint along the GATT link to the specific guest. The
+    // [targetPeerId] arg is recorded in debug logs but not in the wire
+    // envelope. If/when the protocol grows multi-hop, this can carry a
+    // separate target field.
+    if (kDebugMode) debugPrint('BitrateHint -> $targetPeerId: $bps bps');
+    final msg = BitrateHint(
+      peerId: hostPeerId,
+      seq: ++_seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+      bps: bps,
+    );
+    try {
+      await t.send(msg);
+    } catch (error, stackTrace) {
+      if (kDebugMode) debugPrint('BitrateHint send failed: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
     }
   }
 
@@ -762,6 +983,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       _signalReporter.start(
         onTick: () => unawaited(_sendSignalReport()),
       );
+      // Begin the link-quality plane on the guest side. Same gating as
+      // the signal reporter — needs a transport to write to and an
+      // audio service to poll telemetry from. The host doesn't run the
+      // reporter (it consumes incoming `LinkQuality` reports instead;
+      // see [_onLinkQuality]).
+      _linkQualityReporter.start(
+        onTick: () => unawaited(_sendLinkQuality()),
+      );
     }
   }
 
@@ -799,6 +1028,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Cancel the signal reporter so a guest leaving doesn't keep pinging
     // RSSI samples at the (now disconnected) GATT link.
     _signalReporter.stop();
+    // Cancel the link-quality reporter for the same reason — and wipe
+    // the per-peer telemetry baseline so a fresh room doesn't compute
+    // bogus deltas against the previous session's last sample.
+    _linkQualityReporter.stop();
+    _prevTelemetry.clear();
+    _prevTelemetryAt.clear();
+    _bitrateAdapter.clear();
     // Wipe per-neighbor weak-signal state so a fresh room starts with a
     // clean detector — no stale rate-limit cooldowns, no inherited
     // consecutive-weak counters from the previous session.
@@ -886,6 +1122,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _reconnectController = null;
     _heartbeats.stop();
     _signalReporter.stop();
+    _linkQualityReporter.stop();
+    _prevTelemetry.clear();
+    _prevTelemetryAt.clear();
+    _bitrateAdapter.clear();
     _weakSignalDetector.clear();
     _transport?.forgetAllPeers();
     _seq = 0;
@@ -1180,6 +1420,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // tick mid-await can't reach _onSignalReport or transport.send on a
     // disposed cubit.
     _signalReporter.stop();
+    // And the link-quality reporter — same pre-close rationale.
+    _linkQualityReporter.stop();
     // Order matters. `super.close()` flips the cubit's `isClosed`; the
     // suspended `await` in `sendMediaCommand` resumes after it sees
     // `isClosed == true` and bails before touching the controller. If

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -600,8 +600,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   }
 
   /// Guest-only ingress for `BitrateHint`. Applies the hinted bitrate to
-  /// the local outbound encoder (toward the host). On the host, hints
-  /// are silently dropped — the host is the source of hints, not a sink.
+  /// the local outbound encoder (toward the host) **only if the hint
+  /// targets this peer** — the host broadcasts on the GATT RESPONSE
+  /// characteristic, so every connected guest receives every hint and
+  /// must filter by `target == localPeerId`. Mirrors the `RemovePeer`
+  /// dispatch pattern. On the host, hints are silently dropped — the
+  /// host is the source of hints, not a sink.
   void _onBitrateHint(BitrateHint hint) {
     if (isClosed) return;
     final current = state;
@@ -609,6 +613,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     final audio = _audio;
     final mac = current.macAddress;
     if (audio == null || mac == null) return;
+    final localPeerId = _localPeerId;
+    // No cached peerId yet → can't tell whether the hint is for us. The
+    // bootstrap path always populates it before joinRoom emits a
+    // SessionRoom, so this branch is defensive only.
+    if (localPeerId == null || hint.target != localPeerId) return;
     unawaited(audio.setPeerBitrate(mac, hint.bps));
   }
 
@@ -649,17 +658,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       }
       if (isClosed) return;
     }
-    // Note: BitrateHint's envelope `peerId` is the *sender's* (host's)
-    // peerId per the protocol. The recipient is implicit — the host
-    // sends the hint along the GATT link to the specific guest. The
-    // [targetPeerId] arg is recorded in debug logs but not in the wire
-    // envelope. If/when the protocol grows multi-hop, this can carry a
-    // separate target field.
+    // The envelope `peerId` is the sender's (host's) peerId per the
+    // protocol convention; the wire's `target` field carries the
+    // intended recipient so guests other than [targetPeerId] drop the
+    // hint on receive (see [_onBitrateHint]) — the underlying GATT
+    // notification broadcasts to every subscribed central, so the host
+    // can't unicast at the transport layer today.
     if (kDebugMode) debugPrint('BitrateHint -> $targetPeerId: $bps bps');
     final msg = BitrateHint(
       peerId: hostPeerId,
       seq: ++_seq,
       atMs: DateTime.now().millisecondsSinceEpoch,
+      target: targetPeerId,
       bps: bps,
     );
     try {

--- a/lib/protocol/messages.dart
+++ b/lib/protocol/messages.dart
@@ -675,21 +675,32 @@ final class LinkQuality extends FrequencyMessage {
   }
 }
 
-/// Host → guest advisory: "set your outbound encoder bitrate to [bps]."
-/// The recipient applies the value to its own `PeerAudioManager` for the
-/// link to the host. Out-of-range values are clamped at the native layer
-/// to the {Low, Mid, High} operating points in `audio_config.h`.
+/// Host → specific-guest advisory: "guest [target], set your outbound
+/// encoder bitrate to [bps]." The recipient applies the value to its
+/// own `PeerAudioManager` for the link to the host. Out-of-range values
+/// are clamped at the native layer to the {Low, Mid, High} operating
+/// points in `audio_config.h`.
 ///
 /// The host emits these in response to its own receive-side telemetry of
-/// the guest's stream — so a guest whose uplink is degraded gets nudged
+/// each guest's stream — so a guest whose uplink is degraded gets nudged
 /// down before the host's jitter buffer underruns become audible.
+///
+/// **Why a target field.** The host writes via `BleControlTransport.send`,
+/// which broadcasts on the GATT RESPONSE characteristic to every
+/// subscribed guest. Without a `target` field, every guest in a
+/// multi-guest room would interpret the hint and adjust their own
+/// encoder — turning a per-link decision into a room-wide one. Mirrors
+/// the `RemovePeer` pattern: guests filter on receive by `target ==
+/// localPeerId` and ignore hints addressed to someone else.
 final class BitrateHint extends FrequencyMessage {
+  final String target;
   final int bps;
 
   const BitrateHint({
     required super.peerId,
     required super.seq,
     required super.atMs,
+    required this.target,
     required this.bps,
   }) : assert(bps > 0, 'bps must be positive');
 
@@ -699,11 +710,16 @@ final class BitrateHint extends FrequencyMessage {
   @override
   Map<String, dynamic> toJson() => {
         ..._envelope(),
+        'target': target,
         'bps': bps,
       };
 
   factory BitrateHint._fromJson(Map<String, dynamic> j) {
     final bpsRaw = j['bps'];
+    final targetRaw = j['target'];
+    if (targetRaw is! String) {
+      throw const FormatException('`target` must be a string');
+    }
     if (bpsRaw is! int) {
       throw const FormatException('`bps` must be an int');
     }
@@ -714,6 +730,7 @@ final class BitrateHint extends FrequencyMessage {
       peerId: j['peerId'] as String,
       seq: j['seq'] as int,
       atMs: j['atMs'] as int,
+      target: targetRaw,
       bps: bpsRaw,
     );
   }

--- a/lib/protocol/messages.dart
+++ b/lib/protocol/messages.dart
@@ -157,6 +157,8 @@ sealed class FrequencyMessage {
       'mute' => MuteState._fromJson(json),
       'media' => MediaCommand._fromJson(json),
       'signal_report' => SignalReport._fromJson(json),
+      'link_quality' => LinkQuality._fromJson(json),
+      'bitrate_hint' => BitrateHint._fromJson(json),
       'ping' => Heartbeat._fromJson(json),
       _ => throw FormatException('Unknown frequency message kind: $kind'),
     };
@@ -589,4 +591,130 @@ final class Heartbeat extends FrequencyMessage {
         seq: j['seq'] as int,
         atMs: j['atMs'] as int,
       );
+}
+
+// ── Adaptive bitrate ────────────────────────────────────────────────────────
+
+/// A peer's view of the receive-side voice link quality, sampled by the
+/// `LinkQualityReporter` from the native `PeerAudioManager` telemetry every
+/// few seconds and sent to the host. The host's `BitrateAdapter` consumes
+/// these to decide whether to step the encoder up or down for that peer.
+///
+/// Direction on the wire: guests report on the host→guest stream they're
+/// receiving. The host doesn't send `LinkQuality` over the wire — it polls
+/// its own telemetry locally and feeds the adapter directly.
+///
+/// Field semantics:
+///   * `lossPct` ∈ [0, 100] — fraction of expected frames that arrived too
+///     late to play (jitter buffer rejections), as a percentage.
+///   * `jitterMs` ≥ 0 — current jitter buffer fill in ms (depth × 20 ms).
+///     Useful as an observability field; the adapter doesn't use it.
+///   * `underrunsPerSec` ≥ 0 — rate of mixer-tick underruns in the sampled
+///     window. A non-zero rate means the buffer drained faster than the
+///     wire could refill it.
+final class LinkQuality extends FrequencyMessage {
+  final double lossPct;
+  final int jitterMs;
+  final double underrunsPerSec;
+
+  const LinkQuality({
+    required super.peerId,
+    required super.seq,
+    required super.atMs,
+    required this.lossPct,
+    required this.jitterMs,
+    required this.underrunsPerSec,
+  })  : assert(lossPct >= 0 && lossPct <= 100,
+            'lossPct must be a percentage in [0, 100]'),
+        assert(jitterMs >= 0, 'jitterMs must be non-negative'),
+        assert(underrunsPerSec >= 0, 'underrunsPerSec must be non-negative');
+
+  @override
+  String get kind => 'link_quality';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ..._envelope(),
+        'lossPct': lossPct,
+        'jitterMs': jitterMs,
+        'underrunsPerSec': underrunsPerSec,
+      };
+
+  factory LinkQuality._fromJson(Map<String, dynamic> j) {
+    final lossPctRaw = j['lossPct'];
+    final jitterMsRaw = j['jitterMs'];
+    final underrunsRaw = j['underrunsPerSec'];
+    if (lossPctRaw is! num) {
+      throw const FormatException('`lossPct` must be a number');
+    }
+    if (jitterMsRaw is! int) {
+      throw const FormatException('`jitterMs` must be an int');
+    }
+    if (underrunsRaw is! num) {
+      throw const FormatException('`underrunsPerSec` must be a number');
+    }
+    final lossPct = lossPctRaw.toDouble();
+    final underruns = underrunsRaw.toDouble();
+    if (lossPct < 0 || lossPct > 100) {
+      throw FormatException('lossPct out of range: $lossPct');
+    }
+    if (jitterMsRaw < 0) {
+      throw FormatException('jitterMs out of range: $jitterMsRaw');
+    }
+    if (underruns < 0) {
+      throw FormatException('underrunsPerSec out of range: $underruns');
+    }
+    return LinkQuality(
+      peerId: j['peerId'] as String,
+      seq: j['seq'] as int,
+      atMs: j['atMs'] as int,
+      lossPct: lossPct,
+      jitterMs: jitterMsRaw,
+      underrunsPerSec: underruns,
+    );
+  }
+}
+
+/// Host → guest advisory: "set your outbound encoder bitrate to [bps]."
+/// The recipient applies the value to its own `PeerAudioManager` for the
+/// link to the host. Out-of-range values are clamped at the native layer
+/// to the {Low, Mid, High} operating points in `audio_config.h`.
+///
+/// The host emits these in response to its own receive-side telemetry of
+/// the guest's stream — so a guest whose uplink is degraded gets nudged
+/// down before the host's jitter buffer underruns become audible.
+final class BitrateHint extends FrequencyMessage {
+  final int bps;
+
+  const BitrateHint({
+    required super.peerId,
+    required super.seq,
+    required super.atMs,
+    required this.bps,
+  }) : assert(bps > 0, 'bps must be positive');
+
+  @override
+  String get kind => 'bitrate_hint';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ..._envelope(),
+        'bps': bps,
+      };
+
+  factory BitrateHint._fromJson(Map<String, dynamic> j) {
+    final bpsRaw = j['bps'];
+    if (bpsRaw is! int) {
+      throw const FormatException('`bps` must be an int');
+    }
+    if (bpsRaw <= 0) {
+      throw FormatException('bps out of range: $bpsRaw');
+    }
+    return BitrateHint(
+      peerId: j['peerId'] as String,
+      seq: j['seq'] as int,
+      atMs: j['atMs'] as int,
+      bps: bpsRaw,
+    );
+  }
 }

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -2,6 +2,55 @@ import 'package:flutter/services.dart';
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 
+/// Snapshot of per-peer link telemetry pulled from the native
+/// `PeerAudioManager`. All counts are **lifetime totals**; the link
+/// quality reporter subtracts two snapshots and divides by elapsed
+/// wall-clock to get the rates the protocol's `LinkQuality` carries.
+@immutable
+class LinkTelemetrySnapshot {
+  /// Lifetime mixer-tick underruns for this peer's stream.
+  final int underrunCount;
+
+  /// Lifetime jitter-buffer drops (frames that arrived too late to play).
+  final int lateFrameCount;
+
+  /// Adaptive jitter buffer target depth in 20 ms frames.
+  final int targetDepthFrames;
+
+  /// Adaptive jitter buffer current fill in 20 ms frames.
+  final int currentDepthFrames;
+
+  /// The encoder bitrate currently emitted toward this peer, in bps.
+  final int currentBitrateBps;
+
+  const LinkTelemetrySnapshot({
+    required this.underrunCount,
+    required this.lateFrameCount,
+    required this.targetDepthFrames,
+    required this.currentDepthFrames,
+    required this.currentBitrateBps,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LinkTelemetrySnapshot &&
+          underrunCount == other.underrunCount &&
+          lateFrameCount == other.lateFrameCount &&
+          targetDepthFrames == other.targetDepthFrames &&
+          currentDepthFrames == other.currentDepthFrames &&
+          currentBitrateBps == other.currentBitrateBps;
+
+  @override
+  int get hashCode => Object.hash(
+        underrunCount,
+        lateFrameCount,
+        targetDepthFrames,
+        currentDepthFrames,
+        currentBitrateBps,
+      );
+}
+
 /// Service for communicating with native Android audio layer
 class AudioService {
   static const MethodChannel _methodChannel = MethodChannel(
@@ -351,6 +400,80 @@ class AudioService {
     } catch (e) {
       if (kDebugMode) debugPrint('Error getting current RSSI: $e');
       return const [];
+    }
+  }
+
+  /// Per-peer voice-link telemetry snapshot. Mirrors the native
+  /// `PeerAudioManager.LinkTelemetry` struct (peer_audio_manager.h):
+  ///
+  ///   * `underrunCount` — lifetime mixer-tick underruns for this peer.
+  ///   * `lateFrameCount` — lifetime jitter-buffer drops (frames that
+  ///     arrived too late to play).
+  ///   * `targetDepthFrames` / `currentDepthFrames` — adaptive jitter
+  ///     buffer's target and current fill, in 20 ms frames.
+  ///   * `currentBitrateBps` — the encoder bitrate the host is currently
+  ///     emitting toward this peer (or, on the guest, the bitrate the
+  ///     guest is emitting toward the host — same field, different
+  ///     direction depending on role).
+  ///
+  /// `LinkQualityReporter` consumes back-to-back snapshots and turns
+  /// deltas into the protocol's `LinkQuality` rates (lossPct, jitterMs,
+  /// underrunsPerSec).
+  ///
+  /// All counters are lifetime totals — subtract two snapshots to get a
+  /// delta, divide by elapsed wall-clock to get a rate.
+  ///
+  /// Returns null if the platform call fails (handler not registered,
+  /// peer not in the native registry, native side unavailable). Callers
+  /// short-circuit on null rather than propagating an exception — a
+  /// missed telemetry sample is non-fatal to the link.
+  Future<LinkTelemetrySnapshot?> getLinkTelemetry(String macAddress) async {
+    try {
+      final raw = await _methodChannel.invokeMethod<List<dynamic>>(
+        'getLinkTelemetry',
+        <String, dynamic>{'macAddress': macAddress},
+      );
+      if (raw == null || raw.length != 5) return null;
+      // Native returns a 5-element int array: [underruns, late, target,
+      // current, bitrate]. Element-wise check guards against a truncated
+      // or padded response from a stale platform handler.
+      final values = raw.map((e) => e is int ? e : null).toList();
+      if (values.any((v) => v == null)) return null;
+      return LinkTelemetrySnapshot(
+        underrunCount: values[0]!,
+        lateFrameCount: values[1]!,
+        targetDepthFrames: values[2]!,
+        currentDepthFrames: values[3]!,
+        currentBitrateBps: values[4]!,
+      );
+    } catch (e) {
+      if (kDebugMode) debugPrint('Error getting link telemetry for $macAddress: $e');
+      return null;
+    }
+  }
+
+  /// Adjust the per-peer outbound encoder bitrate. The native
+  /// `PeerAudioManager` clamps to {Low=8, Mid=16, High=24} kbps from
+  /// `audio_config.h`; out-of-band values get snapped to the nearest.
+  ///
+  /// Returns the bitrate actually applied (after clamping), or `null` if
+  /// the call fails (peer not registered, native handler missing). The
+  /// bitrate adapter on the host calls this to adjust its own encoder
+  /// toward a guest; a guest receiving a `BitrateHint` calls this with
+  /// the host's MAC to throttle its uplink.
+  Future<int?> setPeerBitrate(String macAddress, int bps) async {
+    try {
+      final result = await _methodChannel.invokeMethod<int>(
+        'setPeerBitrate',
+        <String, dynamic>{'macAddress': macAddress, 'bps': bps},
+      );
+      if (result == null || result < 0) return null;
+      return result;
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('Error setting peer bitrate for $macAddress to $bps: $e');
+      }
+      return null;
     }
   }
 

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -429,11 +429,17 @@ class AudioService {
   /// missed telemetry sample is non-fatal to the link.
   Future<LinkTelemetrySnapshot?> getLinkTelemetry(String macAddress) async {
     try {
-      final raw = await _methodChannel.invokeMethod<List<dynamic>>(
+      // `invokeMethod<dynamic>` rather than `<List<dynamic>>`: the
+      // StandardMessageCodec encodes Kotlin `IntArray` as `Int32List`,
+      // which does *not* satisfy `is List<dynamic>` in every Dart
+      // runtime path — a typed-list cast can throw before the elements
+      // even reach the parsing logic. Accepting `dynamic` and validating
+      // the shape ourselves works for both `Int32List` and plain `List`.
+      final raw = await _methodChannel.invokeMethod<dynamic>(
         'getLinkTelemetry',
         <String, dynamic>{'macAddress': macAddress},
       );
-      if (raw == null || raw.length != 5) return null;
+      if (raw is! List || raw.length != 5) return null;
       // Native returns a 5-element int array: [underruns, late, target,
       // current, bitrate]. Element-wise check guards against a truncated
       // or padded response from a stale platform handler.

--- a/lib/services/bitrate_adapter.dart
+++ b/lib/services/bitrate_adapter.dart
@@ -229,24 +229,30 @@ class BitrateAdapter {
 
       case _Direction.up:
         if (elapsedMs < _upHold.inMilliseconds) return null;
+        // Compute the next level explicitly with returns inside each branch,
+        // rather than mutate-then-fall-through, so the upstep destination
+        // is obvious to a reader who hasn't internalised the Dart 3
+        // no-fall-through rule for switch statements.
+        final BitrateLevel next;
         switch (state.level) {
           case BitrateLevel.low:
-            state.level = BitrateLevel.mid;
+            next = BitrateLevel.mid;
           case BitrateLevel.mid:
-            state.level = BitrateLevel.high;
+            next = BitrateLevel.high;
           case BitrateLevel.high:
-            // Already at ceiling.
+            // Already at the ceiling — clear pending and emit no step.
             state.pendingDirection = _Direction.none;
             state.pendingSinceMs = null;
             return null;
         }
+        state.level = next;
         // After a step up, reset dwell so the *next* upstep starts a fresh
         // 30 s window from the host-local clock rather than carrying over
         // old dwell credit. This satisfies the "step back up one notch"
         // wording — only one level per 30 s of clean samples.
         state.pendingDirection = _Direction.up;
         state.pendingSinceMs = nowMs;
-        return state.level;
+        return next;
 
       case _Direction.none:
         // Unreachable — handled above.

--- a/lib/services/bitrate_adapter.dart
+++ b/lib/services/bitrate_adapter.dart
@@ -61,9 +61,16 @@ enum BitrateLevel {
 /// **Hysteresis.** A single bad sample never trips a downstep; it must
 /// hold for [downHoldMid] or [downHoldLow] in wall-clock time. Up-steps
 /// require [upHold]. These aren't sample counts: a bigger reporter
-/// [interval] doesn't change the dwell. The adapter consumes
-/// `LinkQuality.atMs` as the timestamp, so stale samples (e.g. a tick
-/// straddling a real-time clock jump) won't accumulate dwell credit.
+/// [interval] doesn't change the dwell.
+///
+/// Dwell is measured against the **host-local** receipt clock, not
+/// `LinkQuality.atMs` from the sender. The protocol's `atMs` is a
+/// best-effort sender wall-clock with allowed peer-to-peer drift, and
+/// trusting it for the 4 s / 30 s windows would let a guest with a
+/// skewed clock — or a malicious one — accelerate or stall the bitrate
+/// step. [feed] takes an explicit `nowMs` so callers pass
+/// `DateTime.now().millisecondsSinceEpoch` (or an injected fake in
+/// tests); `LinkQuality.atMs` is treated as informational only.
 ///
 /// **Per-peer state.** Each peer has its own state machine — slow guests
 /// shouldn't drag fast guests down, and a guest's state survives across
@@ -139,10 +146,15 @@ class BitrateAdapter {
   /// implicitly inferring from its receive-side view, *or* the peer whose
   /// local telemetry the host polled directly).
   ///
+  /// [nowMs] is the **host-local** receipt timestamp in ms (typically
+  /// `DateTime.now().millisecondsSinceEpoch`). All dwell accounting
+  /// uses this clock, not `sample.atMs`, so a guest with a skewed or
+  /// hostile clock can't manipulate the 4 s / 30 s thresholds.
+  ///
   /// Returns the new [BitrateLevel] when this sample triggered a step,
   /// `null` otherwise. The caller should treat null as "leave the
   /// encoder where it is" — a no-op on the wire.
-  BitrateLevel? feed(LinkQuality sample) {
+  BitrateLevel? feed(LinkQuality sample, {required int nowMs}) {
     final peerId = sample.peerId;
     final state = _state.putIfAbsent(
       peerId,
@@ -174,17 +186,18 @@ class BitrateAdapter {
     if (direction == _Direction.none ||
         state.pendingDirection != direction) {
       state.pendingDirection = direction;
-      state.pendingSinceMs = direction == _Direction.none ? null : sample.atMs;
+      state.pendingSinceMs = direction == _Direction.none ? null : nowMs;
       return null;
     }
 
-    // Same direction as pending — check dwell.
+    // Same direction as pending — check dwell against the host-local
+    // clock, not the sender's `atMs`.
     final since = state.pendingSinceMs;
     if (since == null) {
-      state.pendingSinceMs = sample.atMs;
+      state.pendingSinceMs = nowMs;
       return null;
     }
-    final elapsedMs = sample.atMs - since;
+    final elapsedMs = nowMs - since;
 
     switch (direction) {
       case _Direction.downToLow:
@@ -228,11 +241,11 @@ class BitrateAdapter {
             return null;
         }
         // After a step up, reset dwell so the *next* upstep starts a fresh
-        // 30 s window from this sample's timestamp rather than carrying
-        // over old dwell credit. This satisfies the "step back up one
-        // notch" wording — only one level per 30 s of clean samples.
+        // 30 s window from the host-local clock rather than carrying over
+        // old dwell credit. This satisfies the "step back up one notch"
+        // wording — only one level per 30 s of clean samples.
         state.pendingDirection = _Direction.up;
-        state.pendingSinceMs = sample.atMs;
+        state.pendingSinceMs = nowMs;
         return state.level;
 
       case _Direction.none:

--- a/lib/services/bitrate_adapter.dart
+++ b/lib/services/bitrate_adapter.dart
@@ -1,0 +1,266 @@
+import '../protocol/messages.dart';
+
+/// Three discrete encoder operating points the adapter selects between.
+/// Mirrors `audio_config.h` `kBitrateLow / kBitrateMid / kBitrateHigh` —
+/// the native side clamps a bitrate set to anything else into one of
+/// these, so keeping the Dart-side schedule in lockstep avoids surprises.
+enum BitrateLevel {
+  /// 8 kbps narrowband — used when the link is degraded and we need to
+  /// shed bytes to keep the jitter buffer fed.
+  low(8000),
+
+  /// 16 kbps wideband — the default operating point the encoder boots in.
+  mid(16000),
+
+  /// 24 kbps wideband — the best operating point the encoder will reach
+  /// when the link has been clean for a sustained window.
+  high(24000);
+
+  const BitrateLevel(this.bps);
+
+  /// Encoder bitrate in bits-per-second.
+  final int bps;
+
+  /// Map a native-reported bps back to the closest enum value. Used when
+  /// seeding adapter state from a telemetry sample (e.g. on first feed).
+  /// Returns the level whose `bps` is nearest to [bps]; ties favour the
+  /// lower level (a cautious tie-break — "prefer fewer bytes" when in
+  /// doubt about a fresh link).
+  static BitrateLevel nearest(int bps) {
+    BitrateLevel best = BitrateLevel.low;
+    int bestDiff = (BitrateLevel.low.bps - bps).abs();
+    for (final lvl in [BitrateLevel.mid, BitrateLevel.high]) {
+      final d = (lvl.bps - bps).abs();
+      if (d < bestDiff) {
+        best = lvl;
+        bestDiff = d;
+      }
+    }
+    return best;
+  }
+}
+
+/// Host-side stateful adapter that consumes per-peer `LinkQuality` samples
+/// and decides when to step the encoder bitrate up or down. Pure logic —
+/// the cubit owns the actual `BitrateHint` send and the local
+/// `setPeerBitrate` call against the native `PeerAudioManager`.
+///
+/// **Threshold schedule** (per [docs/protocol.md] §"adaptive bitrate"):
+///   * `lossPct > 12 %` sustained for [downHoldMid] → step to [BitrateLevel.low]
+///     (8 kbps narrowband). Aggressive — we want to bail quickly when the
+///     wire is genuinely failing.
+///   * `lossPct > 5 %` sustained for [downHoldMid] → step to [BitrateLevel.mid]
+///     (16 kbps wideband). Less aggressive; covers the "merely choppy"
+///     case where high bitrate is overshooting capacity.
+///   * `lossPct < 1 %` AND `underrunsPerSec < 0.1` sustained for [upHold]
+///     → step **up one notch**. Slower than the down-step on purpose —
+///     ramping back up should err on the side of caution so a brief lull
+///     in loss doesn't immediately re-collide with whatever caused the
+///     downstep.
+///
+/// **Hysteresis.** A single bad sample never trips a downstep; it must
+/// hold for [downHoldMid] or [downHoldLow] in wall-clock time. Up-steps
+/// require [upHold]. These aren't sample counts: a bigger reporter
+/// [interval] doesn't change the dwell. The adapter consumes
+/// `LinkQuality.atMs` as the timestamp, so stale samples (e.g. a tick
+/// straddling a real-time clock jump) won't accumulate dwell credit.
+///
+/// **Per-peer state.** Each peer has its own state machine — slow guests
+/// shouldn't drag fast guests down, and a guest's state survives across
+/// multiple ticks. Call [forgetPeer] on `Leave` / `RemovePeer` so a
+/// re-join doesn't inherit the previous session's dwell.
+///
+/// **Output.** [feed] returns `null` when nothing changes (the common
+/// case — most ticks land squarely inside the same level), and a
+/// `BitrateLevel` when this sample triggered a step. Returning a level
+/// rather than a `BitrateHint` lets the cubit construct the wire message
+/// with its own `peerId` / `seq` / `atMs` envelope.
+class BitrateAdapter {
+  /// Loss threshold above which we drop straight to [BitrateLevel.low].
+  /// Per the issue spec: 12 %.
+  static const double dropToLowLossPct = 12.0;
+
+  /// Loss threshold above which we drop to [BitrateLevel.mid] (and which
+  /// holds the line if we were already at [BitrateLevel.low]).
+  /// Per the issue spec: 5 %.
+  static const double dropToMidLossPct = 5.0;
+
+  /// Loss ceiling for considering a step up. Per the issue spec: 1 %.
+  static const double cleanLossPct = 1.0;
+
+  /// Underrun-rate ceiling for considering a step up. Per the issue spec:
+  /// 0.1 / s.
+  static const double cleanUnderrunsPerSec = 0.1;
+
+  /// Sustained-bad dwell required before a downstep fires. Per the issue
+  /// spec: 4 s. Same dwell is used for the >12 % and >5 % rules — both
+  /// are "down" decisions and we want the same patience for either.
+  static const Duration downHoldMid = Duration(seconds: 4);
+
+  /// Alias preserved for documentation — the >12 % rule uses the same
+  /// dwell as >5 %. Kept as a separate constant in case the protocol
+  /// later wants to differentiate.
+  static const Duration downHoldLow = downHoldMid;
+
+  /// Sustained-clean dwell required before an upstep fires. Per the issue
+  /// spec: 30 s. Long on purpose so a brief recovery lull doesn't drag
+  /// the bitrate back up into whatever caused the downstep.
+  static const Duration upHold = Duration(seconds: 30);
+
+  final Duration _downHold;
+  final Duration _upHold;
+
+  BitrateAdapter({
+    Duration? downHold,
+    Duration? upHold,
+  })  : _downHold = downHold ?? downHoldMid,
+        _upHold = upHold ?? BitrateAdapter.upHold;
+
+  /// Per-peer current level + the timestamp of the first contiguous sample
+  /// satisfying a candidate transition. `pendingSinceMs` is null when no
+  /// transition is being considered.
+  final Map<String, _PeerAdapterState> _state = {};
+
+  /// Read-only view of the current level for [peerId], or null if the
+  /// adapter has never seen a sample for that peer. Useful for tests and
+  /// for the cubit to seed its initial state from the native telemetry's
+  /// `currentBitrateBps`.
+  BitrateLevel? levelFor(String peerId) => _state[peerId]?.level;
+
+  /// Seed the per-peer level (e.g. from the native telemetry's
+  /// `currentBitrateBps` on first contact). Resets pending dwell. No-op
+  /// if a state already exists — the adapter's history wins.
+  void seed(String peerId, BitrateLevel level) {
+    _state.putIfAbsent(peerId, () => _PeerAdapterState(level: level));
+  }
+
+  /// Feed a `LinkQuality` sample reported by [peerId] (the recipient of
+  /// the host's stream — i.e. the guest whose uplink quality we're
+  /// implicitly inferring from its receive-side view, *or* the peer whose
+  /// local telemetry the host polled directly).
+  ///
+  /// Returns the new [BitrateLevel] when this sample triggered a step,
+  /// `null` otherwise. The caller should treat null as "leave the
+  /// encoder where it is" — a no-op on the wire.
+  BitrateLevel? feed(LinkQuality sample) {
+    final peerId = sample.peerId;
+    final state = _state.putIfAbsent(
+      peerId,
+      () => _PeerAdapterState(level: BitrateLevel.mid),
+    );
+
+    final wantsDownLow = sample.lossPct > dropToLowLossPct;
+    final wantsDownMid = !wantsDownLow && sample.lossPct > dropToMidLossPct;
+    final wantsUp = sample.lossPct < cleanLossPct &&
+        sample.underrunsPerSec < cleanUnderrunsPerSec;
+
+    // Categorise the sample's preferred direction. A sample that's
+    // neither "wants up" nor "wants down" lives in the dead zone — it
+    // resets any in-flight pending transition (the link is neither
+    // clearly bad nor clearly good).
+    final _Direction direction;
+    if (wantsDownLow) {
+      direction = _Direction.downToLow;
+    } else if (wantsDownMid) {
+      direction = _Direction.downToMid;
+    } else if (wantsUp) {
+      direction = _Direction.up;
+    } else {
+      direction = _Direction.none;
+    }
+
+    // The pending direction tracks what we're currently building dwell
+    // for. A sample that disagrees with the pending direction resets it.
+    if (direction == _Direction.none ||
+        state.pendingDirection != direction) {
+      state.pendingDirection = direction;
+      state.pendingSinceMs = direction == _Direction.none ? null : sample.atMs;
+      return null;
+    }
+
+    // Same direction as pending — check dwell.
+    final since = state.pendingSinceMs;
+    if (since == null) {
+      state.pendingSinceMs = sample.atMs;
+      return null;
+    }
+    final elapsedMs = sample.atMs - since;
+
+    switch (direction) {
+      case _Direction.downToLow:
+        if (elapsedMs < _downHold.inMilliseconds) return null;
+        if (state.level == BitrateLevel.low) {
+          // Already at floor — clear pending so a future change can be detected.
+          state.pendingDirection = _Direction.none;
+          state.pendingSinceMs = null;
+          return null;
+        }
+        state.level = BitrateLevel.low;
+        state.pendingDirection = _Direction.none;
+        state.pendingSinceMs = null;
+        return BitrateLevel.low;
+
+      case _Direction.downToMid:
+        if (elapsedMs < _downHold.inMilliseconds) return null;
+        if (state.level == BitrateLevel.high) {
+          state.level = BitrateLevel.mid;
+          state.pendingDirection = _Direction.none;
+          state.pendingSinceMs = null;
+          return BitrateLevel.mid;
+        }
+        // Already at mid or low — the >5 % rule shouldn't push us deeper.
+        // Clear pending and wait for either a >12 % sample or a clean run.
+        state.pendingDirection = _Direction.none;
+        state.pendingSinceMs = null;
+        return null;
+
+      case _Direction.up:
+        if (elapsedMs < _upHold.inMilliseconds) return null;
+        switch (state.level) {
+          case BitrateLevel.low:
+            state.level = BitrateLevel.mid;
+          case BitrateLevel.mid:
+            state.level = BitrateLevel.high;
+          case BitrateLevel.high:
+            // Already at ceiling.
+            state.pendingDirection = _Direction.none;
+            state.pendingSinceMs = null;
+            return null;
+        }
+        // After a step up, reset dwell so the *next* upstep starts a fresh
+        // 30 s window from this sample's timestamp rather than carrying
+        // over old dwell credit. This satisfies the "step back up one
+        // notch" wording — only one level per 30 s of clean samples.
+        state.pendingDirection = _Direction.up;
+        state.pendingSinceMs = sample.atMs;
+        return state.level;
+
+      case _Direction.none:
+        // Unreachable — handled above.
+        return null;
+    }
+  }
+
+  /// Drop adapter state for [peerId]. Call on `Leave` / `RemovePeer` so a
+  /// re-join with the same `peerId` starts a fresh state machine.
+  void forgetPeer(String peerId) {
+    _state.remove(peerId);
+  }
+
+  /// Drop all adapter state. Call on `leaveRoom`.
+  void clear() {
+    _state.clear();
+  }
+}
+
+class _PeerAdapterState {
+  BitrateLevel level;
+  _Direction pendingDirection;
+  int? pendingSinceMs;
+
+  _PeerAdapterState({required this.level})
+      : pendingDirection = _Direction.none,
+        pendingSinceMs = null;
+}
+
+enum _Direction { none, downToLow, downToMid, up }

--- a/lib/services/link_quality_reporter.dart
+++ b/lib/services/link_quality_reporter.dart
@@ -1,0 +1,135 @@
+import 'dart:async';
+
+import 'audio_service.dart';
+
+/// Compute a `LinkQuality` rate triple from two consecutive telemetry
+/// snapshots. The native side reports lifetime counters; the protocol
+/// wire format wants per-second rates and a percentage, so we delta and
+/// scale here.
+///
+/// **Loss model.** `lossPct` is `lateFrameDelta / expectedFrames * 100`,
+/// where `expectedFrames = elapsed_ms / 20` (one Opus frame per
+/// `audio_config::kFrameDurationMs`). This conservatively assumes the
+/// talker was speaking continuously across the window. When voice isn't
+/// flowing, `lateFrameDelta` is 0, `lossPct` is 0, and the adapter sees
+/// a clean sample — which is fine: no audio means link quality is moot.
+/// The percentage is clamped to [0, 100] so a counter rollover or bad
+/// snapshot can't push absurd values into the adapter.
+///
+/// **Jitter model.** `jitterMs` is the *current* jitter buffer fill
+/// converted to ms (`currentDepthFrames * 20`). It's an observability
+/// field — the adapter ignores it; only the host UI / debug logs care.
+///
+/// **Underruns.** Per-second rate of mixer underruns over the window.
+///
+/// [elapsed] must be positive — passing zero or negative would divide by
+/// zero in the rate calculation. Throws `ArgumentError` instead of
+/// silently returning bogus values; callers should never produce a
+/// zero-length window.
+({double lossPct, int jitterMs, double underrunsPerSec}) computeLinkQuality({
+  required LinkTelemetrySnapshot previous,
+  required LinkTelemetrySnapshot current,
+  required Duration elapsed,
+}) {
+  if (elapsed <= Duration.zero) {
+    throw ArgumentError.value(
+      elapsed,
+      'elapsed',
+      'Must be positive — rate computation divides by elapsed.',
+    );
+  }
+  // 20 ms is the canonical Opus / mixer frame duration (audio_config.h
+  // kFrameDurationMs). Hard-coded here rather than re-imported from the
+  // native side: this file ships in pure-Dart unit tests, and a drift
+  // between Dart and C++ here would be a wire-protocol drift (LinkQuality
+  // values would diverge between platforms) — that's a stronger signal
+  // than the avoided import.
+  const frameDurationMs = 20;
+  final elapsedMs = elapsed.inMilliseconds;
+  final expectedFrames = elapsedMs / frameDurationMs;
+
+  // Lifetime counters; deltas can't go negative under normal operation.
+  // Clamp to zero to swallow a counter reset (e.g. native side cleared and
+  // reseeded between snapshots) without poisoning the adapter with a
+  // negative rate.
+  final lateDelta =
+      (current.lateFrameCount - previous.lateFrameCount).clamp(0, 1 << 31);
+  final underrunDelta =
+      (current.underrunCount - previous.underrunCount).clamp(0, 1 << 31);
+
+  final lossPctRaw =
+      expectedFrames <= 0 ? 0.0 : (lateDelta / expectedFrames) * 100.0;
+  final lossPct = lossPctRaw.clamp(0.0, 100.0);
+
+  final jitterMs = current.currentDepthFrames * frameDurationMs;
+  final underrunsPerSec = underrunDelta / (elapsedMs / 1000.0);
+
+  return (
+    lossPct: lossPct,
+    jitterMs: jitterMs,
+    underrunsPerSec: underrunsPerSec,
+  );
+}
+
+/// Drives the protocol's `link_quality` plane: emits an [onTick] every
+/// [interval] so the caller can sample local `PeerAudioManager` telemetry,
+/// compute deltas against the previous window, and either send a
+/// `LinkQuality` over the wire (guest side) or feed the host-local
+/// [BitrateAdapter] directly (host side).
+///
+/// Mirrors the [SignalReporter] / [HeartbeatScheduler] shape — the reporter
+/// is a **timer only**. Delta arithmetic and per-peer state live in the
+/// caller, partly so unit tests can drive ticks without depending on real
+/// time, and partly so the host vs guest plumbing can branch without the
+/// reporter knowing the difference.
+///
+/// Per [docs/protocol.md] §"link_quality": [defaultInterval] is 2 s — fast
+/// enough that a sustained-loss rule of "loss > 12% for 4 s" trips after
+/// two consecutive bad samples, slow enough that the JNI hop into the
+/// native telemetry struct is amortised.
+///
+/// **Lifecycle.** [start] is called when the local peer enters a room and
+/// [stop] is called on leave. [start] is idempotent: calling it twice
+/// cancels the prior timer first, so callers don't need to guard against
+/// double-start.
+class LinkQualityReporter {
+  /// Default cadence per the protocol: sample telemetry every 2 s.
+  static const Duration defaultInterval = Duration(seconds: 2);
+
+  final Duration interval;
+
+  Timer? _timer;
+  void Function()? _onTick;
+
+  LinkQualityReporter({this.interval = defaultInterval}) {
+    if (interval <= Duration.zero) {
+      throw ArgumentError.value(
+        interval,
+        'interval',
+        'Must be positive — Timer.periodic(0) busy-loops.',
+      );
+    }
+  }
+
+  /// Whether the periodic timer is currently active.
+  bool get isRunning => _timer != null;
+
+  /// Starts the periodic tick. [onTick] fires every [interval] so the
+  /// caller can poll telemetry and dispatch `LinkQuality` / `BitrateHint`
+  /// downstream.
+  ///
+  /// Calling [start] while already running cancels the previous timer
+  /// before installing the new one.
+  void start({required void Function() onTick}) {
+    stop();
+    _onTick = onTick;
+    _timer = Timer.periodic(interval, (_) => _onTick?.call());
+  }
+
+  /// Cancels the timer. Safe to call when not running.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _onTick = null;
+  }
+}

--- a/lib/services/link_quality_reporter.dart
+++ b/lib/services/link_quality_reporter.dart
@@ -59,7 +59,10 @@ import 'audio_service.dart';
 
   final lossPctRaw =
       expectedFrames <= 0 ? 0.0 : (lateDelta / expectedFrames) * 100.0;
-  final lossPct = lossPctRaw.clamp(0.0, 100.0);
+  // `num.clamp` returns `num`, not `double`; the record's `lossPct` field is
+  // typed `double`, so spell the conversion explicitly to keep the analyzer
+  // (and a strict-mode reader) happy.
+  final lossPct = lossPctRaw.clamp(0.0, 100.0).toDouble();
 
   final jitterMs = current.currentDepthFrames * frameDurationMs;
   final underrunsPerSec = underrunDelta / (elapsedMs / 1000.0);

--- a/lib/services/link_quality_reporter.dart
+++ b/lib/services/link_quality_reporter.dart
@@ -45,7 +45,14 @@ import 'audio_service.dart';
   // values would diverge between platforms) — that's a stronger signal
   // than the avoided import.
   const frameDurationMs = 20;
-  final elapsedMs = elapsed.inMilliseconds;
+  // Use microseconds for the rate math: a sub-millisecond `elapsed`
+  // (legal — `Duration.zero` is the only thing the guard rejects)
+  // would truncate `inMilliseconds` to 0 and turn the division into
+  // Infinity. Microseconds avoid the truncation and survive the same
+  // `> 0` guarantee from the guard above.
+  final elapsedMicros = elapsed.inMicroseconds;
+  final elapsedMs = elapsedMicros / 1000.0;
+  final elapsedSeconds = elapsedMicros / 1000000.0;
   final expectedFrames = elapsedMs / frameDurationMs;
 
   // Lifetime counters; deltas can't go negative under normal operation.
@@ -65,7 +72,7 @@ import 'audio_service.dart';
   final lossPct = lossPctRaw.clamp(0.0, 100.0).toDouble();
 
   final jitterMs = current.currentDepthFrames * frameDurationMs;
-  final underrunsPerSec = underrunDelta / (elapsedMs / 1000.0);
+  final underrunsPerSec = underrunDelta / elapsedSeconds;
 
   return (
     lossPct: lossPct,

--- a/test/protocol/messages_test.dart
+++ b/test/protocol/messages_test.dart
@@ -380,22 +380,39 @@ void main() {
       expect(() => FrequencyMessage.decode(floatJitter), throwsFormatException);
     });
 
-    test('BitrateHint round-trips', () {
-      const msg = BitrateHint(peerId: 'p-host', seq: 7, atMs: 0, bps: 16000);
+    test('BitrateHint round-trips with target + bps', () {
+      const msg = BitrateHint(
+        peerId: 'p-host',
+        seq: 7,
+        atMs: 0,
+        target: 'p-guest-a',
+        bps: 16000,
+      );
       final json = jsonDecode(msg.encode()) as Map<String, dynamic>;
       expect(json['kind'], 'bitrate_hint');
+      expect(json['target'], 'p-guest-a');
       expect(json['bps'], 16000);
       final round = _roundTrip(msg);
+      expect(round.target, 'p-guest-a');
       expect(round.bps, 16000);
+    });
+
+    test('BitrateHint rejects missing or wrong-typed target', () {
+      final missing =
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":16000}';
+      final intTarget =
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":16000,"target":42}';
+      expect(() => FrequencyMessage.decode(missing), throwsFormatException);
+      expect(() => FrequencyMessage.decode(intTarget), throwsFormatException);
     });
 
     test('BitrateHint rejects non-positive or non-int bps', () {
       final negative =
-          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":-100}';
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"target":"g","bps":-100}';
       final zero =
-          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":0}';
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"target":"g","bps":0}';
       final string =
-          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":"16000"}';
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"target":"g","bps":"16000"}';
       expect(() => FrequencyMessage.decode(negative), throwsFormatException);
       expect(() => FrequencyMessage.decode(zero), throwsFormatException);
       expect(() => FrequencyMessage.decode(string), throwsFormatException);

--- a/test/protocol/messages_test.dart
+++ b/test/protocol/messages_test.dart
@@ -319,6 +319,89 @@ void main() {
     });
   });
 
+  group('adaptive bitrate messages', () {
+    test('LinkQuality round-trips with all fields', () {
+      const msg = LinkQuality(
+        peerId: 'p-guest',
+        seq: 4,
+        atMs: 1234,
+        lossPct: 6.5,
+        jitterMs: 80,
+        underrunsPerSec: 0.4,
+      );
+      final json = jsonDecode(msg.encode()) as Map<String, dynamic>;
+      expect(json['kind'], 'link_quality');
+      expect(json['lossPct'], 6.5);
+      expect(json['jitterMs'], 80);
+      expect(json['underrunsPerSec'], 0.4);
+      final round = _roundTrip(msg);
+      expect(round.lossPct, 6.5);
+      expect(round.jitterMs, 80);
+      expect(round.underrunsPerSec, 0.4);
+    });
+
+    test('LinkQuality decodes integer-shaped lossPct / underrunsPerSec', () {
+      // jsonEncode of `0.0` may serialize as `0` on some encoders; the
+      // decoder must accept either shape rather than rejecting an
+      // otherwise-valid sample. (jitterMs is the only int-typed field.)
+      final wire =
+          '{"kind":"link_quality","peerId":"p","seq":1,"atMs":0,"v":1,"lossPct":0,"jitterMs":40,"underrunsPerSec":0}';
+      final decoded = FrequencyMessage.decode(wire) as LinkQuality;
+      expect(decoded.lossPct, 0.0);
+      expect(decoded.underrunsPerSec, 0.0);
+      expect(decoded.jitterMs, 40);
+    });
+
+    test('LinkQuality rejects out-of-range values', () {
+      const base =
+          '{"kind":"link_quality","peerId":"p","seq":1,"atMs":0,"v":1,"jitterMs":40,"underrunsPerSec":0.1';
+      final negativeLoss = '$base,"lossPct":-1.0}';
+      final overLoss = '$base,"lossPct":150.0}';
+      final negativeJitter =
+          '{"kind":"link_quality","peerId":"p","seq":1,"atMs":0,"v":1,"lossPct":1.0,"jitterMs":-1,"underrunsPerSec":0.1}';
+      final negativeUnderruns =
+          '{"kind":"link_quality","peerId":"p","seq":1,"atMs":0,"v":1,"lossPct":1.0,"jitterMs":40,"underrunsPerSec":-0.5}';
+      expect(() => FrequencyMessage.decode(negativeLoss), throwsFormatException);
+      expect(() => FrequencyMessage.decode(overLoss), throwsFormatException);
+      expect(
+          () => FrequencyMessage.decode(negativeJitter), throwsFormatException);
+      expect(
+        () => FrequencyMessage.decode(negativeUnderruns),
+        throwsFormatException,
+      );
+    });
+
+    test('LinkQuality rejects wrong-typed numeric fields', () {
+      final stringLoss =
+          '{"kind":"link_quality","peerId":"p","seq":1,"atMs":0,"v":1,"lossPct":"oops","jitterMs":40,"underrunsPerSec":0.1}';
+      final floatJitter =
+          '{"kind":"link_quality","peerId":"p","seq":1,"atMs":0,"v":1,"lossPct":1.0,"jitterMs":40.5,"underrunsPerSec":0.1}';
+      expect(() => FrequencyMessage.decode(stringLoss), throwsFormatException);
+      expect(() => FrequencyMessage.decode(floatJitter), throwsFormatException);
+    });
+
+    test('BitrateHint round-trips', () {
+      const msg = BitrateHint(peerId: 'p-host', seq: 7, atMs: 0, bps: 16000);
+      final json = jsonDecode(msg.encode()) as Map<String, dynamic>;
+      expect(json['kind'], 'bitrate_hint');
+      expect(json['bps'], 16000);
+      final round = _roundTrip(msg);
+      expect(round.bps, 16000);
+    });
+
+    test('BitrateHint rejects non-positive or non-int bps', () {
+      final negative =
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":-100}';
+      final zero =
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":0}';
+      final string =
+          '{"kind":"bitrate_hint","peerId":"p","seq":1,"atMs":0,"v":1,"bps":"16000"}';
+      expect(() => FrequencyMessage.decode(negative), throwsFormatException);
+      expect(() => FrequencyMessage.decode(zero), throwsFormatException);
+      expect(() => FrequencyMessage.decode(string), throwsFormatException);
+    });
+  });
+
   group('ProtocolPeer', () {
     test('JSON round-trip preserves all fields', () {
       const original = ProtocolPeer(
@@ -358,6 +441,8 @@ void main() {
           MuteState() => 'mute',
           MediaCommand() => 'media',
           SignalReport() => 'signal_report',
+          LinkQuality() => 'link_quality',
+          BitrateHint() => 'bitrate_hint',
           Heartbeat() => 'ping',
         };
 

--- a/test/services/bitrate_adapter_test.dart
+++ b/test/services/bitrate_adapter_test.dart
@@ -18,6 +18,15 @@ LinkQuality _lq({
       underrunsPerSec: underrunsPerSec,
     );
 
+/// Test shorthand — the adapter takes a separate `nowMs` (host-local
+/// receipt clock); these tests were written before that split, and the
+/// existing scenarios match the case where the host clock advances in
+/// lockstep with the sender's `atMs`. Pinning `nowMs == sample.atMs`
+/// preserves the original semantics; clock-drift scenarios get their
+/// own `feedAt` calls below.
+BitrateLevel? _feed(BitrateAdapter a, LinkQuality sample) =>
+    a.feed(sample, nowMs: sample.atMs);
+
 void main() {
   group('BitrateLevel', () {
     test('bps values match audio_config.h operating points', () {
@@ -60,7 +69,7 @@ void main() {
   group('BitrateAdapter downstep behaviour', () {
     test('one bad sample does not trip — dwell is required', () {
       final a = BitrateAdapter();
-      final out = a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      final out = _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
       expect(out, isNull);
       expect(a.levelFor('g1'), BitrateLevel.mid,
           reason: 'default seed is Mid');
@@ -72,9 +81,9 @@ void main() {
       // Two consecutive bad samples — the second must be ≥ 4 s after the
       // first to trip. Sample-count alone is not the criterion; wall-time
       // dwell is.
-      final first = a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      final first = _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
       expect(first, isNull, reason: 'first bad sample seeds dwell');
-      final second = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0));
+      final second = _feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 20.0));
       expect(second, BitrateLevel.low);
       expect(a.levelFor('g1'), BitrateLevel.low);
     });
@@ -83,10 +92,10 @@ void main() {
         '>12 % at exactly 3.999 s does not trip; one more ms over the boundary does',
         () {
       final a = BitrateAdapter();
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
-      expect(a.feed(_lq(peerId: 'g1', atMs: 3999, lossPct: 20.0)), isNull);
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      expect(_feed(a, _lq(peerId: 'g1', atMs: 3999, lossPct: 20.0)), isNull);
       expect(
-        a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0)),
+        _feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 20.0)),
         BitrateLevel.low,
       );
     });
@@ -95,8 +104,8 @@ void main() {
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.high);
       // 7 % is in the >5 % but ≤12 % band.
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 7.0));
-      final out = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 7.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 7.0));
+      final out = _feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 7.0));
       expect(out, BitrateLevel.mid);
       expect(a.levelFor('g1'), BitrateLevel.mid);
     });
@@ -106,23 +115,23 @@ void main() {
       // be allowed to push past Mid down to Low.
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.mid);
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 7.0));
-      final out = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 7.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 7.0));
+      final out = _feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 7.0));
       expect(out, isNull);
       expect(a.levelFor('g1'), BitrateLevel.mid);
     });
 
     test('a clean sample interrupting bad dwell resets the timer', () {
       final a = BitrateAdapter();
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
       // 2 s in, the link briefly clears — pending dwell resets.
-      a.feed(_lq(peerId: 'g1', atMs: 2000, lossPct: 0.5));
+      _feed(a, _lq(peerId: 'g1', atMs: 2000, lossPct: 0.5));
       // Another bad sample at 4 s wall-time — but only 2 s of *contiguous*
       // bad dwell, so no trip yet.
-      final stillNo = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0));
+      final stillNo = _feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 20.0));
       expect(stillNo, isNull);
       // The full 4 s must elapse from the *last* bad sample.
-      final trip = a.feed(_lq(peerId: 'g1', atMs: 8000, lossPct: 20.0));
+      final trip = _feed(a, _lq(peerId: 'g1', atMs: 8000, lossPct: 20.0));
       expect(trip, BitrateLevel.low);
     });
 
@@ -131,15 +140,15 @@ void main() {
       // direction change — pending dwell resets to the new direction.
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.high);
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 7.0));   // wantsDownMid
-      a.feed(_lq(peerId: 'g1', atMs: 1000, lossPct: 20.0)); // wantsDownLow
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 7.0));   // wantsDownMid
+      _feed(a, _lq(peerId: 'g1', atMs: 1000, lossPct: 20.0)); // wantsDownLow
       // Only 3 s of "down to low" dwell so far — no trip yet.
       expect(
-        a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0)),
+        _feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 20.0)),
         isNull,
       );
       // 4 s + 1 ms of contiguous "down to low" dwell from atMs=1000 → trips.
-      final trip = a.feed(_lq(peerId: 'g1', atMs: 5001, lossPct: 20.0));
+      final trip = _feed(a, _lq(peerId: 'g1', atMs: 5001, lossPct: 20.0));
       expect(trip, BitrateLevel.low);
     });
   });
@@ -150,24 +159,24 @@ void main() {
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.low);
       // First clean sample seeds the dwell.
-      expect(a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 0.0)), isNull);
+      expect(_feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 0.0)), isNull);
       // 29 s in — not yet 30 s.
       expect(
-        a.feed(_lq(peerId: 'g1', atMs: 29000, lossPct: 0.0)),
+        _feed(a, _lq(peerId: 'g1', atMs: 29000, lossPct: 0.0)),
         isNull,
       );
       // 30 s — first upstep.
       expect(
-        a.feed(_lq(peerId: 'g1', atMs: 30000, lossPct: 0.0)),
+        _feed(a, _lq(peerId: 'g1', atMs: 30000, lossPct: 0.0)),
         BitrateLevel.mid,
       );
       // After a step, dwell resets — another 30 s of clean to step again.
       expect(
-        a.feed(_lq(peerId: 'g1', atMs: 59000, lossPct: 0.0)),
+        _feed(a, _lq(peerId: 'g1', atMs: 59000, lossPct: 0.0)),
         isNull,
       );
       expect(
-        a.feed(_lq(peerId: 'g1', atMs: 60001, lossPct: 0.0)),
+        _feed(a, _lq(peerId: 'g1', atMs: 60001, lossPct: 0.0)),
         BitrateLevel.high,
       );
     });
@@ -176,13 +185,13 @@ void main() {
       // lossPct = 0, but underruns > 0.1 / s — not clean enough.
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.mid);
-      a.feed(_lq(
+      _feed(a, _lq(
         peerId: 'g1',
         atMs: 0,
         lossPct: 0.0,
         underrunsPerSec: 0.5,
       ));
-      final out = a.feed(_lq(
+      final out = _feed(a, _lq(
         peerId: 'g1',
         atMs: 60000,
         lossPct: 0.0,
@@ -198,8 +207,8 @@ void main() {
       // to count toward the 30 s upstep dwell.
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.mid);
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 3.0));
-      final out = a.feed(_lq(peerId: 'g1', atMs: 60000, lossPct: 3.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 3.0));
+      final out = _feed(a, _lq(peerId: 'g1', atMs: 60000, lossPct: 3.0));
       expect(out, isNull);
       expect(a.levelFor('g1'), BitrateLevel.mid);
     });
@@ -208,8 +217,8 @@ void main() {
         () {
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.high);
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 0.0));
-      final out = a.feed(_lq(peerId: 'g1', atMs: 30000, lossPct: 0.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 0.0));
+      final out = _feed(a, _lq(peerId: 'g1', atMs: 30000, lossPct: 0.0));
       expect(out, isNull);
       expect(a.levelFor('g1'), BitrateLevel.high);
     });
@@ -226,15 +235,15 @@ void main() {
       a.seed('g1', BitrateLevel.high);
       // 10 % is in the >5 % band — should drop one notch (not all the
       // way to low).
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 10.0));
-      final downstep = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 10.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 10.0));
+      final downstep = _feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 10.0));
       expect(downstep, BitrateLevel.mid);
 
       // Drop is lifted at atMs = 5000. 30 s of clean later, we step back
       // up. Need a sample to seed the upstep dwell (5000) and one to
       // confirm at 35001.
-      a.feed(_lq(peerId: 'g1', atMs: 5000, lossPct: 0.0));
-      expect(a.feed(_lq(peerId: 'g1', atMs: 35001, lossPct: 0.0)),
+      _feed(a, _lq(peerId: 'g1', atMs: 5000, lossPct: 0.0));
+      expect(_feed(a, _lq(peerId: 'g1', atMs: 35001, lossPct: 0.0)),
           BitrateLevel.high);
     });
 
@@ -244,15 +253,65 @@ void main() {
       // run climbs to Mid; another 30 s climbs to High.
       final a = BitrateAdapter();
       a.seed('g1', BitrateLevel.high);
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 25.0));
-      expect(a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 25.0)),
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 25.0));
+      expect(_feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 25.0)),
           BitrateLevel.low);
 
-      a.feed(_lq(peerId: 'g1', atMs: 5000, lossPct: 0.0));
-      expect(a.feed(_lq(peerId: 'g1', atMs: 35000, lossPct: 0.0)),
+      _feed(a, _lq(peerId: 'g1', atMs: 5000, lossPct: 0.0));
+      expect(_feed(a, _lq(peerId: 'g1', atMs: 35000, lossPct: 0.0)),
           BitrateLevel.mid);
-      expect(a.feed(_lq(peerId: 'g1', atMs: 65000, lossPct: 0.0)),
+      expect(_feed(a, _lq(peerId: 'g1', atMs: 65000, lossPct: 0.0)),
           BitrateLevel.high);
+    });
+  });
+
+  group('BitrateAdapter dwell vs. sender clock', () {
+    // Regression guard: dwell must use the host-local `nowMs`, not the
+    // sender's `sample.atMs`. A guest with a skewed (or hostile) clock
+    // could otherwise jump the dwell window by stamping `atMs` 4 s into
+    // the future on its very first bad sample — which is not how the
+    // 4 s sustained-loss rule is supposed to work.
+    test(
+        'sender atMs jumping ahead does NOT short-circuit the 4 s downstep dwell',
+        () {
+      final a = BitrateAdapter();
+      // Sample 1 at host-local nowMs=0; sample's atMs is 0 too.
+      a.feed(
+        _lq(peerId: 'g1', atMs: 0, lossPct: 20.0),
+        nowMs: 0,
+      );
+      // Sample 2: sender claims atMs=10_000 (10 s in the future) but
+      // host clock has only advanced 1 s. Dwell should follow the host
+      // clock — no trip yet.
+      final out = a.feed(
+        _lq(peerId: 'g1', atMs: 10000, lossPct: 20.0),
+        nowMs: 1000,
+      );
+      expect(out, isNull,
+          reason: 'sender clock skew must not satisfy the 4 s dwell');
+      // After the host clock has actually advanced 4 s, the trip fires.
+      final trip = a.feed(
+        _lq(peerId: 'g1', atMs: 11000, lossPct: 20.0),
+        nowMs: 4000,
+      );
+      expect(trip, BitrateLevel.low);
+    });
+
+    test(
+        'sender atMs lagging behind does NOT block a downstep that the host clock has earned',
+        () {
+      final a = BitrateAdapter();
+      a.feed(
+        _lq(peerId: 'g1', atMs: 100000, lossPct: 20.0),
+        nowMs: 0,
+      );
+      // Sender claims atMs=100_000 (the past, vs. itself) — irrelevant.
+      // Host has advanced 4 s since the seed; the trip should fire.
+      final trip = a.feed(
+        _lq(peerId: 'g1', atMs: 100100, lossPct: 20.0),
+        nowMs: 4000,
+      );
+      expect(trip, BitrateLevel.low);
     });
   });
 
@@ -262,14 +321,14 @@ void main() {
       // g1 is going down; g2 is going up.
       a.seed('g1', BitrateLevel.high);
       a.seed('g2', BitrateLevel.low);
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 25.0));
-      a.feed(_lq(peerId: 'g2', atMs: 0, lossPct: 0.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 25.0));
+      _feed(a, _lq(peerId: 'g2', atMs: 0, lossPct: 0.0));
       // 4 s later — g1 trips down, g2 not yet.
-      expect(a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 25.0)),
+      expect(_feed(a, _lq(peerId: 'g1', atMs: 4000, lossPct: 25.0)),
           BitrateLevel.low);
-      expect(a.feed(_lq(peerId: 'g2', atMs: 4000, lossPct: 0.0)), isNull);
+      expect(_feed(a, _lq(peerId: 'g2', atMs: 4000, lossPct: 0.0)), isNull);
       // 30 s — g2 finally trips up.
-      expect(a.feed(_lq(peerId: 'g2', atMs: 30000, lossPct: 0.0)),
+      expect(_feed(a, _lq(peerId: 'g2', atMs: 30000, lossPct: 0.0)),
           BitrateLevel.mid);
       // g1 stayed at low through this — g2's clean samples didn't help it.
       expect(a.levelFor('g1'), BitrateLevel.low);
@@ -297,7 +356,7 @@ void main() {
         'unseen peer auto-seeds at Mid on first feed, retains state across feeds',
         () {
       final a = BitrateAdapter();
-      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 0.0));
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 0.0));
       expect(a.levelFor('g1'), BitrateLevel.mid);
     });
   });

--- a/test/services/bitrate_adapter_test.dart
+++ b/test/services/bitrate_adapter_test.dart
@@ -1,0 +1,304 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/protocol/messages.dart';
+import 'package:walkie_talkie/services/bitrate_adapter.dart';
+
+LinkQuality _lq({
+  required String peerId,
+  required int atMs,
+  required double lossPct,
+  int jitterMs = 60,
+  double underrunsPerSec = 0.0,
+}) =>
+    LinkQuality(
+      peerId: peerId,
+      seq: 1,
+      atMs: atMs,
+      lossPct: lossPct,
+      jitterMs: jitterMs,
+      underrunsPerSec: underrunsPerSec,
+    );
+
+void main() {
+  group('BitrateLevel', () {
+    test('bps values match audio_config.h operating points', () {
+      // These three are the only values native PeerAudioManager will
+      // honour after clamping. The Dart adapter must agree with the
+      // native enum so a `BitrateHint(bps: 16000)` lands as Mid and not
+      // as a "snap to nearest" surprise.
+      expect(BitrateLevel.low.bps, 8000);
+      expect(BitrateLevel.mid.bps, 16000);
+      expect(BitrateLevel.high.bps, 24000);
+    });
+
+    test('nearest snaps to the closest operating point, ties favour lower',
+        () {
+      expect(BitrateLevel.nearest(8000), BitrateLevel.low);
+      expect(BitrateLevel.nearest(16000), BitrateLevel.mid);
+      expect(BitrateLevel.nearest(24000), BitrateLevel.high);
+      // 12000 is equidistant from low (8000) and mid (16000) — the
+      // tie-break docstring says "favour the lower level."
+      expect(BitrateLevel.nearest(12000), BitrateLevel.low);
+      // 11000 is closer to low; 14000 closer to mid.
+      expect(BitrateLevel.nearest(11000), BitrateLevel.low);
+      expect(BitrateLevel.nearest(14000), BitrateLevel.mid);
+    });
+  });
+
+  group('BitrateAdapter thresholds', () {
+    test('protocol-pinned threshold constants', () {
+      // These are wire-protocol load-bearing; bumping them changes how
+      // quickly the encoder reacts to a degrading link.
+      expect(BitrateAdapter.dropToLowLossPct, 12.0);
+      expect(BitrateAdapter.dropToMidLossPct, 5.0);
+      expect(BitrateAdapter.cleanLossPct, 1.0);
+      expect(BitrateAdapter.cleanUnderrunsPerSec, 0.1);
+      expect(BitrateAdapter.downHoldMid, const Duration(seconds: 4));
+      expect(BitrateAdapter.upHold, const Duration(seconds: 30));
+    });
+  });
+
+  group('BitrateAdapter downstep behaviour', () {
+    test('one bad sample does not trip — dwell is required', () {
+      final a = BitrateAdapter();
+      final out = a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      expect(out, isNull);
+      expect(a.levelFor('g1'), BitrateLevel.mid,
+          reason: 'default seed is Mid');
+    });
+
+    test('>12 % sustained for 4 s steps from default Mid all the way to Low',
+        () {
+      final a = BitrateAdapter();
+      // Two consecutive bad samples — the second must be ≥ 4 s after the
+      // first to trip. Sample-count alone is not the criterion; wall-time
+      // dwell is.
+      final first = a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      expect(first, isNull, reason: 'first bad sample seeds dwell');
+      final second = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0));
+      expect(second, BitrateLevel.low);
+      expect(a.levelFor('g1'), BitrateLevel.low);
+    });
+
+    test(
+        '>12 % at exactly 3.999 s does not trip; one more ms over the boundary does',
+        () {
+      final a = BitrateAdapter();
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      expect(a.feed(_lq(peerId: 'g1', atMs: 3999, lossPct: 20.0)), isNull);
+      expect(
+        a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0)),
+        BitrateLevel.low,
+      );
+    });
+
+    test('>5 % (but ≤12 %) sustained 4 s drops only one notch from High', () {
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.high);
+      // 7 % is in the >5 % but ≤12 % band.
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 7.0));
+      final out = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 7.0));
+      expect(out, BitrateLevel.mid);
+      expect(a.levelFor('g1'), BitrateLevel.mid);
+    });
+
+    test('>5 % from Mid does not push deeper to Low', () {
+      // The 5 % rule covers "merely choppy" — only the >12 % rule should
+      // be allowed to push past Mid down to Low.
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.mid);
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 7.0));
+      final out = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 7.0));
+      expect(out, isNull);
+      expect(a.levelFor('g1'), BitrateLevel.mid);
+    });
+
+    test('a clean sample interrupting bad dwell resets the timer', () {
+      final a = BitrateAdapter();
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 20.0));
+      // 2 s in, the link briefly clears — pending dwell resets.
+      a.feed(_lq(peerId: 'g1', atMs: 2000, lossPct: 0.5));
+      // Another bad sample at 4 s wall-time — but only 2 s of *contiguous*
+      // bad dwell, so no trip yet.
+      final stillNo = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0));
+      expect(stillNo, isNull);
+      // The full 4 s must elapse from the *last* bad sample.
+      final trip = a.feed(_lq(peerId: 'g1', atMs: 8000, lossPct: 20.0));
+      expect(trip, BitrateLevel.low);
+    });
+
+    test('contiguous bad samples in different bands restart dwell', () {
+      // Switching from "wants down to mid" to "wants down to low" is a
+      // direction change — pending dwell resets to the new direction.
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.high);
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 7.0));   // wantsDownMid
+      a.feed(_lq(peerId: 'g1', atMs: 1000, lossPct: 20.0)); // wantsDownLow
+      // Only 3 s of "down to low" dwell so far — no trip yet.
+      expect(
+        a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 20.0)),
+        isNull,
+      );
+      // 4 s + 1 ms of contiguous "down to low" dwell from atMs=1000 → trips.
+      final trip = a.feed(_lq(peerId: 'g1', atMs: 5001, lossPct: 20.0));
+      expect(trip, BitrateLevel.low);
+    });
+  });
+
+  group('BitrateAdapter upstep behaviour', () {
+    test('clean link from Low climbs Low → Mid after 30 s, then Mid → High',
+        () {
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.low);
+      // First clean sample seeds the dwell.
+      expect(a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 0.0)), isNull);
+      // 29 s in — not yet 30 s.
+      expect(
+        a.feed(_lq(peerId: 'g1', atMs: 29000, lossPct: 0.0)),
+        isNull,
+      );
+      // 30 s — first upstep.
+      expect(
+        a.feed(_lq(peerId: 'g1', atMs: 30000, lossPct: 0.0)),
+        BitrateLevel.mid,
+      );
+      // After a step, dwell resets — another 30 s of clean to step again.
+      expect(
+        a.feed(_lq(peerId: 'g1', atMs: 59000, lossPct: 0.0)),
+        isNull,
+      );
+      expect(
+        a.feed(_lq(peerId: 'g1', atMs: 60001, lossPct: 0.0)),
+        BitrateLevel.high,
+      );
+    });
+
+    test('upstep blocked when underruns/sec exceeds the clean ceiling', () {
+      // lossPct = 0, but underruns > 0.1 / s — not clean enough.
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.mid);
+      a.feed(_lq(
+        peerId: 'g1',
+        atMs: 0,
+        lossPct: 0.0,
+        underrunsPerSec: 0.5,
+      ));
+      final out = a.feed(_lq(
+        peerId: 'g1',
+        atMs: 60000,
+        lossPct: 0.0,
+        underrunsPerSec: 0.5,
+      ));
+      expect(out, isNull);
+      expect(a.levelFor('g1'), BitrateLevel.mid);
+    });
+
+    test('upstep blocked when lossPct is in the dead zone (≥1 % but ≤5 %)',
+        () {
+      // 3 % is neither bad enough to trigger a downstep nor clean enough
+      // to count toward the 30 s upstep dwell.
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.mid);
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 3.0));
+      final out = a.feed(_lq(peerId: 'g1', atMs: 60000, lossPct: 3.0));
+      expect(out, isNull);
+      expect(a.levelFor('g1'), BitrateLevel.mid);
+    });
+
+    test('Already at High — upstep is a no-op even after a long clean run',
+        () {
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.high);
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 0.0));
+      final out = a.feed(_lq(peerId: 'g1', atMs: 30000, lossPct: 0.0));
+      expect(out, isNull);
+      expect(a.levelFor('g1'), BitrateLevel.high);
+    });
+  });
+
+  group('Issue acceptance: thresholds → BitrateHint schedule', () {
+    test(
+        '24 → 16 → 24: bad uplink trips down to Mid, recovery climbs back to High',
+        () {
+      // Mirrors the two-device acceptance scenario in the issue:
+      //  * Inject ~10 % loss → within 4 s the encoder shifts to 16 kbps.
+      //  * Lift the drop → returns to 24 kbps within 30 s of clean samples.
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.high);
+      // 10 % is in the >5 % band — should drop one notch (not all the
+      // way to low).
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 10.0));
+      final downstep = a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 10.0));
+      expect(downstep, BitrateLevel.mid);
+
+      // Drop is lifted at atMs = 5000. 30 s of clean later, we step back
+      // up. Need a sample to seed the upstep dwell (5000) and one to
+      // confirm at 35001.
+      a.feed(_lq(peerId: 'g1', atMs: 5000, lossPct: 0.0));
+      expect(a.feed(_lq(peerId: 'g1', atMs: 35001, lossPct: 0.0)),
+          BitrateLevel.high);
+    });
+
+    test('24 → 8 → 16 → 24: catastrophic loss bypasses Mid, then climbs back',
+        () {
+      // Heavy loss (>12 %) goes straight to Low. From Low, a 30 s clean
+      // run climbs to Mid; another 30 s climbs to High.
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.high);
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 25.0));
+      expect(a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 25.0)),
+          BitrateLevel.low);
+
+      a.feed(_lq(peerId: 'g1', atMs: 5000, lossPct: 0.0));
+      expect(a.feed(_lq(peerId: 'g1', atMs: 35000, lossPct: 0.0)),
+          BitrateLevel.mid);
+      expect(a.feed(_lq(peerId: 'g1', atMs: 65000, lossPct: 0.0)),
+          BitrateLevel.high);
+    });
+  });
+
+  group('BitrateAdapter per-peer isolation', () {
+    test('two peers with independent state machines', () {
+      final a = BitrateAdapter();
+      // g1 is going down; g2 is going up.
+      a.seed('g1', BitrateLevel.high);
+      a.seed('g2', BitrateLevel.low);
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 25.0));
+      a.feed(_lq(peerId: 'g2', atMs: 0, lossPct: 0.0));
+      // 4 s later — g1 trips down, g2 not yet.
+      expect(a.feed(_lq(peerId: 'g1', atMs: 4000, lossPct: 25.0)),
+          BitrateLevel.low);
+      expect(a.feed(_lq(peerId: 'g2', atMs: 4000, lossPct: 0.0)), isNull);
+      // 30 s — g2 finally trips up.
+      expect(a.feed(_lq(peerId: 'g2', atMs: 30000, lossPct: 0.0)),
+          BitrateLevel.mid);
+      // g1 stayed at low through this — g2's clean samples didn't help it.
+      expect(a.levelFor('g1'), BitrateLevel.low);
+    });
+
+    test('forgetPeer drops state for that peer only', () {
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.high);
+      a.seed('g2', BitrateLevel.low);
+      a.forgetPeer('g1');
+      expect(a.levelFor('g1'), isNull);
+      expect(a.levelFor('g2'), BitrateLevel.low);
+    });
+
+    test('clear drops state for every peer', () {
+      final a = BitrateAdapter();
+      a.seed('g1', BitrateLevel.high);
+      a.seed('g2', BitrateLevel.mid);
+      a.clear();
+      expect(a.levelFor('g1'), isNull);
+      expect(a.levelFor('g2'), isNull);
+    });
+
+    test(
+        'unseen peer auto-seeds at Mid on first feed, retains state across feeds',
+        () {
+      final a = BitrateAdapter();
+      a.feed(_lq(peerId: 'g1', atMs: 0, lossPct: 0.0));
+      expect(a.levelFor('g1'), BitrateLevel.mid);
+    });
+  });
+}

--- a/test/services/link_quality_reporter_test.dart
+++ b/test/services/link_quality_reporter_test.dart
@@ -154,6 +154,26 @@ void main() {
       expect(out.underrunsPerSec, 0.0);
     });
 
+    test('sub-millisecond elapsed does not divide by zero', () {
+      // Regression guard: `Duration.inMilliseconds` truncates a 500 µs
+      // window to 0, which would make the underruns/sec division blow
+      // up to Infinity even though the guard above only rejects
+      // `<= Duration.zero`. The math must use microseconds (or some
+      // other higher-resolution conversion) so the rate stays finite.
+      final prev = _snap(underrun: 0, late: 0);
+      final curr = _snap(underrun: 1, late: 1);
+      final out = computeLinkQuality(
+        previous: prev,
+        current: curr,
+        elapsed: const Duration(microseconds: 500),
+      );
+      expect(out.underrunsPerSec.isFinite, isTrue,
+          reason: 'must not divide by zero');
+      expect(out.lossPct.isFinite, isTrue,
+          reason: 'must not divide by zero');
+      expect(out.lossPct, lessThanOrEqualTo(100.0));
+    });
+
     test('non-positive elapsed throws ArgumentError', () {
       final prev = _snap();
       final curr = _snap();

--- a/test/services/link_quality_reporter_test.dart
+++ b/test/services/link_quality_reporter_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/audio_service.dart';
+import 'package:walkie_talkie/services/link_quality_reporter.dart';
+
+LinkTelemetrySnapshot _snap({
+  int underrun = 0,
+  int late = 0,
+  int target = 3,
+  int current = 3,
+  int bps = 16000,
+}) =>
+    LinkTelemetrySnapshot(
+      underrunCount: underrun,
+      lateFrameCount: late,
+      targetDepthFrames: target,
+      currentDepthFrames: current,
+      currentBitrateBps: bps,
+    );
+
+void main() {
+  group('LinkQualityReporter defaults', () {
+    test('default interval matches the protocol: 2 s', () {
+      // Load-bearing constant — the BitrateAdapter's "sustained 4 s"
+      // downstep rule needs exactly two ticks at 2 s. Bumping this
+      // changes how quickly the adapter trips.
+      expect(LinkQualityReporter.defaultInterval, const Duration(seconds: 2));
+    });
+
+    test('rejects a non-positive interval', () {
+      expect(
+        () => LinkQualityReporter(interval: Duration.zero),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => LinkQualityReporter(interval: const Duration(seconds: -1)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('LinkQualityReporter.start / stop', () {
+    test('start fires onTick periodically, stop cancels the timer',
+        () async {
+      final reporter =
+          LinkQualityReporter(interval: const Duration(milliseconds: 10));
+      var ticks = 0;
+      reporter.start(onTick: () => ticks++);
+      await Future<void>.delayed(const Duration(milliseconds: 35));
+      expect(ticks, greaterThanOrEqualTo(2));
+      reporter.stop();
+      final ticksAtStop = ticks;
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      expect(ticks, ticksAtStop, reason: 'no further ticks after stop');
+    });
+
+    test('isRunning toggles on start / stop', () {
+      final reporter =
+          LinkQualityReporter(interval: const Duration(seconds: 1));
+      expect(reporter.isRunning, isFalse);
+      reporter.start(onTick: () {});
+      expect(reporter.isRunning, isTrue);
+      reporter.stop();
+      expect(reporter.isRunning, isFalse);
+    });
+
+    test('start while running cancels the previous timer + callback',
+        () async {
+      final reporter =
+          LinkQualityReporter(interval: const Duration(milliseconds: 10));
+      var ticks1 = 0;
+      reporter.start(onTick: () => ticks1++);
+      var ticks2 = 0;
+      reporter.start(onTick: () => ticks2++);
+      await Future<void>.delayed(const Duration(milliseconds: 35));
+      final ticks1AtSwap = ticks1;
+      reporter.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(ticks1, ticks1AtSwap);
+      expect(ticks2, greaterThan(0));
+    });
+
+    test('stop is safe when never started', () {
+      final reporter = LinkQualityReporter();
+      expect(reporter.stop, returnsNormally);
+    });
+  });
+
+  group('computeLinkQuality', () {
+    test('clean window: 0 % loss, 0 underruns/s, jitter from current depth',
+        () {
+      final prev = _snap(underrun: 5, late: 2, current: 3);
+      final curr = _snap(underrun: 5, late: 2, current: 4);
+      final out = computeLinkQuality(
+        previous: prev,
+        current: curr,
+        elapsed: const Duration(seconds: 2),
+      );
+      expect(out.lossPct, 0.0);
+      expect(out.underrunsPerSec, 0.0);
+      // 4 frames * 20 ms.
+      expect(out.jitterMs, 80);
+    });
+
+    test('lossPct: lateDelta / expected * 100', () {
+      // 2 s window → 100 expected frames (one Opus frame per 20 ms).
+      // 7 late frames in the delta → 7 % loss.
+      final prev = _snap(late: 10);
+      final curr = _snap(late: 17);
+      final out = computeLinkQuality(
+        previous: prev,
+        current: curr,
+        elapsed: const Duration(seconds: 2),
+      );
+      expect(out.lossPct, closeTo(7.0, 1e-9));
+    });
+
+    test('lossPct clamps to 100 when lateDelta exceeds expected', () {
+      // 1 s window expects 50 frames; 200 late frames is impossible in
+      // practice (counter rollover, OS hibernation) but the function
+      // mustn't return a 400 % loss value into the adapter.
+      final prev = _snap(late: 0);
+      final curr = _snap(late: 200);
+      final out = computeLinkQuality(
+        previous: prev,
+        current: curr,
+        elapsed: const Duration(seconds: 1),
+      );
+      expect(out.lossPct, 100.0);
+    });
+
+    test('underrunsPerSec: delta / interval in seconds', () {
+      final prev = _snap(underrun: 10);
+      final curr = _snap(underrun: 16);
+      final out = computeLinkQuality(
+        previous: prev,
+        current: curr,
+        elapsed: const Duration(seconds: 2),
+      );
+      // 6 underruns over 2 s → 3.0 / s.
+      expect(out.underrunsPerSec, closeTo(3.0, 1e-9));
+    });
+
+    test('counter reset (delta < 0) clamps to zero rather than throwing', () {
+      // Native side cleared and reseeded between snapshots — current is
+      // *less* than previous. Treat as zero delta, not a negative rate.
+      final prev = _snap(underrun: 100, late: 100);
+      final curr = _snap(underrun: 0, late: 0);
+      final out = computeLinkQuality(
+        previous: prev,
+        current: curr,
+        elapsed: const Duration(seconds: 2),
+      );
+      expect(out.lossPct, 0.0);
+      expect(out.underrunsPerSec, 0.0);
+    });
+
+    test('non-positive elapsed throws ArgumentError', () {
+      final prev = _snap();
+      final curr = _snap();
+      expect(
+        () => computeLinkQuality(
+          previous: prev,
+          current: curr,
+          elapsed: Duration.zero,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => computeLinkQuality(
+          previous: prev,
+          current: curr,
+          elapsed: const Duration(seconds: -1),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the Dart-side adaptive-bitrate plumbing on top of the native
`PeerAudioManager` scaffolding that landed in #92 (PR #93). Closes #95.

## Wire protocol additions

| message | direction | fields |
| --- | --- | --- |
| `LinkQuality` | guest → host | `lossPct`, `jitterMs`, `underrunsPerSec` |
| `BitrateHint` | host → guest | `bps` |

`messages.dart` validates ranges on the wire (lossPct ∈ [0, 100], non-negative jitter / underruns, positive bps) and the sealed-switch is exhaustive across both new kinds.

## Services

- **`LinkQualityReporter`** ([lib/services/link_quality_reporter.dart](lib/services/link_quality_reporter.dart)) — thin 2 s ticker mirroring `SignalReporter`. Pairs with a top-level `computeLinkQuality` helper that converts two `LinkTelemetrySnapshot`s + elapsed wall-clock into the protocol's rate triple. Counter-reset deltas are clamped to zero.
- **`BitrateAdapter`** ([lib/services/bitrate_adapter.dart](lib/services/bitrate_adapter.dart)) — per-peer hysteresis state machine. Threshold schedule per the issue spec:
  - `lossPct > 12 %` sustained 4 s → step to `Low` (8 kbps)
  - `lossPct > 5 %` sustained 4 s → step to `Mid` (16 kbps)
  - `lossPct < 1 %` AND `underrunsPerSec < 0.1` sustained 30 s → step **up one notch**
- **`AudioService`** ([lib/services/audio_service.dart](lib/services/audio_service.dart)) — `getLinkTelemetry` / `setPeerBitrate` method-channel surface that gracefully returns null on `PlatformException`.

## Cubit wiring

[lib/bloc/frequency_session_cubit.dart](lib/bloc/frequency_session_cubit.dart):

- Guest starts `LinkQualityReporter` alongside `SignalReporter` in `joinRoom` and stops it on leave / permission revoke / close. Each tick polls `getLinkTelemetry(hostMac)`, deltas against the previous snapshot, and writes a `LinkQuality` to the host (no seq burn on the first-sample warm-up).
- Host receives `LinkQuality`, feeds the adapter; on a level change emits a `BitrateHint` to the reporting peer **and** locally calls `setPeerBitrate(guestMac, bps)` so the host's own outbound encoder toward that peer tracks the new level too.
- Guest receives `BitrateHint`, applies via `setPeerBitrate(hostMac, bps)`.
- `forgetPeer` hooks added for `Leave` / `RemovePeer`.

## Tests

403 tests pass (39 new):

- [test/protocol/messages_test.dart](test/protocol/messages_test.dart) — round-trip + envelope validation for both new kinds; sealed-switch exhaustiveness coverage.
- [test/services/link_quality_reporter_test.dart](test/services/link_quality_reporter_test.dart) — timer behaviour and `computeLinkQuality` math (loss%, jitter, underruns/sec, clamp on counter reset, ArgumentError on non-positive elapsed).
- [test/services/bitrate_adapter_test.dart](test/services/bitrate_adapter_test.dart) — threshold-schedule scenarios from the issue acceptance criteria, dwell-boundary checks, per-peer isolation.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 403 / 403 pass
- [ ] CI passes
- [ ] Two-device end-to-end (deferred — needs the MainActivity method-channel handlers below)

## Native side

The C++ telemetry surface (`PeerAudioManager::setPeerBitrate`, `getTelemetry`, `OpusEncoder::setExpectedLossPct`) is already in place from #92 / PR #93.

The Kotlin `PeerAudioManager` wrapper exists, but `MainActivity` doesn't yet have method-channel handlers for `getLinkTelemetry` / `setPeerBitrate` — that small piece of plumbing belongs in a follow-up PR. Until then `AudioService.getLinkTelemetry` returns null on `PlatformException`, the cubit's guest reporter no-ops the send (no seq burn), and the host's adapter never receives a `LinkQuality` over the wire — so no behavioural change in production yet, but the full end-to-end shape is unit-tested and ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guests now periodically report per-peer link quality; hosts adapt per-peer audio bitrate and send bitrate hints to peers.
  * Local clients apply bitrate hints targeted to them and stop reporting when leaving or losing permissions to avoid stale telemetry.

* **Tests**
  * Added comprehensive tests covering link-quality computation, reporter timing, bitrate-adapter stepping, and message encode/decode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->