### PR TITLE
feat(#125): Persistent blocked-peers store — mute survives leave/rejoin + restart

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'screens/frequency_permission_denied_screen.dart';
 import 'screens/frequency_room_screen.dart';
 import 'services/audio_service.dart';
 import 'services/ble_control_transport.dart';
+import 'services/blocked_peers_store.dart';
 import 'services/bluetooth_discovery_service.dart';
 import 'services/identity_store.dart';
 import 'services/onboarding_permission_gateway.dart';
@@ -39,6 +40,9 @@ class WalkieTalkieApp extends StatefulWidget {
   /// Override for tests; defaults to the Hive-backed implementation.
   final RecentFrequenciesStore? recentFrequenciesStore;
 
+  /// Override for tests; defaults to the sqflite-backed implementation.
+  final BlockedPeersStore? blockedPeersStore;
+
   /// Override for tests; defaults to the real Bluetooth-LE implementation.
   final DiscoveryService? discoveryService;
 
@@ -55,6 +59,7 @@ class WalkieTalkieApp extends StatefulWidget {
     super.key,
     this.identityStore,
     this.recentFrequenciesStore,
+    this.blockedPeersStore,
     this.discoveryService,
     this.audioService,
     this.permissionWatcher,
@@ -121,6 +126,10 @@ class _WalkieTalkieAppState extends State<WalkieTalkieApp> {
         RepositoryProvider<RecentFrequenciesStore>(
           create: (_) =>
               widget.recentFrequenciesStore ?? SqfliteRecentFrequenciesStore(),
+        ),
+        RepositoryProvider<BlockedPeersStore>(
+          create: (_) =>
+              widget.blockedPeersStore ?? SqfliteBlockedPeersStore(),
         ),
         RepositoryProvider<DiscoveryService>(
           create: (_) => widget.discoveryService ?? DiscoveryService(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,10 +34,10 @@ void main() async {
 }
 
 class WalkieTalkieApp extends StatefulWidget {
-  /// Override for tests; defaults to the Hive-backed implementation.
+  /// Override for tests; defaults to the sqflite-backed implementation.
   final IdentityStore? identityStore;
 
-  /// Override for tests; defaults to the Hive-backed implementation.
+  /// Override for tests; defaults to the sqflite-backed implementation.
   final RecentFrequenciesStore? recentFrequenciesStore;
 
   /// Override for tests; defaults to the sqflite-backed implementation.

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -10,6 +10,7 @@ import '../data/frequency_models.dart';
 import '../protocol/messages.dart';
 import '../protocol/peer.dart';
 import '../services/audio_service.dart';
+import '../services/blocked_peers_store.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
 import '../widgets/frequency_toast_host.dart';
@@ -82,7 +83,16 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   final Map<String, double> _volumes = {};
   static const double _kDefaultPeerVolume = 0.7;
   double _volumeFor(String peerId) => _volumes[peerId] ?? _kDefaultPeerVolume;
+  /// Mirrors the contents of [BlockedPeersStore] for the lifetime of
+  /// this screen. Hydrated on initState (asynchronously — until the
+  /// first read resolves the set is empty, which means a freshly-joined
+  /// room renders unmuted-by-default for a frame or two before the
+  /// persisted choices land). Mutations here are mirrored back to the
+  /// store so the user's mute survives leave/rejoin and app restart
+  /// (#125). Keyed by stable peerId; `_me`'s 'me' sentinel is never
+  /// persisted (we early-return before touching the store).
   final Set<String> _peerMuted = {};
+  late final BlockedPeersStore _blockedPeersStore;
   final Set<String> _removed = {};
 
   Timer? _progressTimer;
@@ -155,6 +165,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     _lastAction = const _LastAction(by: '', action: '', when: '');
 
     _audio = widget.audioService ?? context.read<AudioService>();
+    _blockedPeersStore = context.read<BlockedPeersStore>();
+    unawaited(_hydratePersistedMutes());
     // Guard against a future caller silently constructing a second
     // AudioService and passing it through `widget.audioService` while a
     // different instance is also wired into the provider — their
@@ -261,6 +273,44 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       // Identity store failure is non-fatal here: if this one-time read
       // fails, attribution falls back to "remote sender" for this
       // screen session, which doesn't matter for in-frame UX.
+    }
+  }
+
+  /// Mirrors a peer-drawer mute toggle to [BlockedPeersStore]. The
+  /// 'me' sentinel is never persisted — it isn't a real peerId and
+  /// would corrupt the table for any other peer that happens to share
+  /// the literal id. Errors are swallowed so a transient sqflite hiccup
+  /// can't crash the screen from the drawer's `onChanged` callback;
+  /// the in-memory set already reflects the user's intent for this
+  /// session.
+  Future<void> _persistMute(String peerId, bool muted) async {
+    if (peerId == _me.id) return;
+    try {
+      if (muted) {
+        await _blockedPeersStore.block(peerId);
+      } else {
+        await _blockedPeersStore.unblock(peerId);
+      }
+    } catch (_) {
+      // Best-effort write; see doc above.
+    }
+  }
+
+  /// Pulls the persisted blocked-peer set into [_peerMuted] on first
+  /// build. Failures are non-fatal — a sqflite read error means the
+  /// session simply renders without prior blocks (the next user-driven
+  /// toggle still tries to write through, which is the right behaviour
+  /// for a transient open failure).
+  Future<void> _hydratePersistedMutes() async {
+    try {
+      final persisted = await _blockedPeersStore.getAll();
+      if (!mounted || persisted.isEmpty) return;
+      setState(() {
+        _peerMuted.addAll(persisted);
+      });
+    } catch (_) {
+      // Same rationale as [_resolveMyPeerId]: a one-time read miss
+      // doesn't justify aborting the room render.
     }
   }
 
@@ -906,6 +956,13 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                 _peerMuted.remove(person.id);
               }
             });
+            // Mirror the toggle to disk so the next session sees the
+            // same mute state. Fire-and-forget: the in-memory set is
+            // the source of truth for the current frame, the persisted
+            // copy only matters across restarts. Failures here would
+            // surface on the next session as a missed-block; we accept
+            // that over blocking the UI on the write.
+            unawaited(_persistMute(person.id, muted));
           },
           onRemove: () {
             setState(() {

--- a/lib/services/blocked_peers_store.dart
+++ b/lib/services/blocked_peers_store.dart
@@ -16,8 +16,10 @@ abstract class BlockedPeersStore {
   /// caller's expected use is membership checks, not iteration order.
   Future<Set<String>> getAll();
 
-  /// Records [peerId] as blocked. Re-blocking an already-blocked peer
-  /// is a no-op (idempotent). Whitespace-only inputs are ignored so a
+  /// Records [peerId] as blocked. Idempotent with respect to membership
+  /// (re-blocking an already-blocked peer leaves the set unchanged),
+  /// though an implementation may refresh associated metadata such as
+  /// `blocked_at` on each call. Whitespace-only inputs are ignored so a
   /// caller that hands us a malformed peerId can't pollute the table.
   Future<void> block(String peerId);
 
@@ -35,10 +37,11 @@ abstract class BlockedPeersStore {
 class SqfliteBlockedPeersStore implements BlockedPeersStore {
   static const String _table = 'blocked_peers';
 
-  /// Serializes writes against themselves the same way
-  /// [`SqfliteRecentFrequenciesStore`] does: two concurrent block /
-  /// unblock calls otherwise race the read-modify-write inside the
-  /// upsert and last-write-wins one of them out of the table.
+  /// Serializes writes so rapid block / unblock / clear calls are
+  /// applied in invocation order. Each individual statement is already
+  /// atomic at the DB level, but without this chain two callers that
+  /// fire-and-forget interleaving toggles for the same peerId can
+  /// observe a non-deterministic final row state.
   Future<void> _writeChain = Future.value();
 
   @override
@@ -84,7 +87,13 @@ class SqfliteBlockedPeersStore implements BlockedPeersStore {
   }
 
   @override
-  Future<void> clear() async {
+  Future<void> clear() {
+    final next = _writeChain.then((_) => _doClear());
+    _writeChain = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _doClear() async {
     final db = await WalkieTalkieDatabase.open();
     await db.delete(_table);
   }

--- a/lib/services/blocked_peers_store.dart
+++ b/lib/services/blocked_peers_store.dart
@@ -1,0 +1,91 @@
+import 'package:sqflite/sqflite.dart';
+
+import 'walkie_talkie_database.dart';
+
+/// Persisted set of peerIds the local user has muted, so the choice
+/// survives app restarts and re-joins of the same frequency. Without
+/// this, `_peerMuted` in [`FrequencyRoomScreen`] is session-local and
+/// the user has to re-mute the same person every time they walk back
+/// into the room (#125).
+///
+/// Keyed by stable peerId (the BLE-advertised UUID, not a session-local
+/// id) so the persisted mute matches the same physical peer across
+/// sessions even when displayName / btDevice change.
+abstract class BlockedPeersStore {
+  /// Returns every currently-blocked peerId. Order is unspecified — the
+  /// caller's expected use is membership checks, not iteration order.
+  Future<Set<String>> getAll();
+
+  /// Records [peerId] as blocked. Re-blocking an already-blocked peer
+  /// is a no-op (idempotent). Whitespace-only inputs are ignored so a
+  /// caller that hands us a malformed peerId can't pollute the table.
+  Future<void> block(String peerId);
+
+  /// Removes [peerId] from the blocked set. Unblocking a peer that
+  /// isn't blocked is a no-op.
+  Future<void> unblock(String peerId);
+
+  /// Drops every persisted entry. The next [getAll] returns empty.
+  Future<void> clear();
+}
+
+/// sqflite-backed [BlockedPeersStore]. Schema: one row per blocked
+/// peerId with `blocked_at` for diagnostic ordering only — the API
+/// surface returns an unordered set.
+class SqfliteBlockedPeersStore implements BlockedPeersStore {
+  static const String _table = 'blocked_peers';
+
+  /// Serializes writes against themselves the same way
+  /// [`SqfliteRecentFrequenciesStore`] does: two concurrent block /
+  /// unblock calls otherwise race the read-modify-write inside the
+  /// upsert and last-write-wins one of them out of the table.
+  Future<void> _writeChain = Future.value();
+
+  @override
+  Future<Set<String>> getAll() async {
+    final db = await WalkieTalkieDatabase.open();
+    final rows = await db.query(_table, columns: ['peer_id']);
+    return rows.map((r) => r['peer_id']).whereType<String>().toSet();
+  }
+
+  @override
+  Future<void> block(String peerId) {
+    final next = _writeChain.then((_) => _doBlock(peerId));
+    _writeChain = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _doBlock(String peerId) async {
+    final trimmed = peerId.trim();
+    if (trimmed.isEmpty) return;
+    final db = await WalkieTalkieDatabase.open();
+    await db.insert(
+      _table,
+      {
+        'peer_id': trimmed,
+        'blocked_at': DateTime.now().millisecondsSinceEpoch,
+      },
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  @override
+  Future<void> unblock(String peerId) {
+    final next = _writeChain.then((_) => _doUnblock(peerId));
+    _writeChain = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _doUnblock(String peerId) async {
+    final trimmed = peerId.trim();
+    if (trimmed.isEmpty) return;
+    final db = await WalkieTalkieDatabase.open();
+    await db.delete(_table, where: 'peer_id = ?', whereArgs: [trimmed]);
+  }
+
+  @override
+  Future<void> clear() async {
+    final db = await WalkieTalkieDatabase.open();
+    await db.delete(_table);
+  }
+}

--- a/lib/services/walkie_talkie_database.dart
+++ b/lib/services/walkie_talkie_database.dart
@@ -13,7 +13,10 @@ class WalkieTalkieDatabase {
   WalkieTalkieDatabase._();
 
   static const String _dbName = 'walkie_talkie.db';
-  static const int _dbVersion = 1;
+  // v2 (2026-04): added `blocked_peers` for #125 (persistent block list).
+  // Existing v1 installs hit `_onUpgrade` which CREATE TABLE IF NOT EXISTS
+  // the new table without touching any data the user already has.
+  static const int _dbVersion = 2;
 
   static DatabaseFactory? _factoryOverride;
   static String? _pathOverride;
@@ -43,6 +46,7 @@ class WalkieTalkieDatabase {
         options: OpenDatabaseOptions(
           version: _dbVersion,
           onCreate: _onCreate,
+          onUpgrade: _onUpgrade,
         ),
       );
       _db = db;
@@ -77,6 +81,34 @@ class WalkieTalkieDatabase {
     await db.execute(
       'CREATE INDEX idx_recent_freq_time ON recent_frequencies (recorded_at)',
     );
+    await _createBlockedPeersTable(db);
+  }
+
+  /// Schema migrations run when an existing install opens a newer
+  /// `_dbVersion`. Each step is idempotent (CREATE TABLE IF NOT EXISTS,
+  /// add-column-if-missing) so re-running a step on a partially-migrated
+  /// install doesn't fail.
+  static Future<void> _onUpgrade(
+    Database db,
+    int oldVersion,
+    int newVersion,
+  ) async {
+    if (oldVersion < 2) {
+      await _createBlockedPeersTable(db);
+    }
+  }
+
+  /// Persists the per-user "I've muted this peer" set keyed by stable
+  /// peerId. `blocked_at` is a DESC-sortable epoch millis kept for
+  /// diagnostic ordering only — the API surface returns an unordered
+  /// set, so an index on it would be wasted writes.
+  static Future<void> _createBlockedPeersTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS blocked_peers (
+        peer_id TEXT PRIMARY KEY NOT NULL,
+        blocked_at INTEGER NOT NULL
+      )
+    ''');
   }
 
   /// Test seam: swap in `databaseFactoryFfi` (and an in-memory path) so unit

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:walkie_talkie/protocol/messages.dart';
 import 'package:walkie_talkie/protocol/peer.dart';
 import 'package:walkie_talkie/screens/frequency_room_screen.dart';
 import 'package:walkie_talkie/services/audio_service.dart';
+import 'package:walkie_talkie/services/blocked_peers_store.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
@@ -92,8 +93,13 @@ Widget _wrap(Widget child, {FrequencySessionCubit? cubit, AudioService? audio}) 
         // Mirror production: AudioService comes from the provider so the
         // room screen's identity-assertion (#129) finds the same instance
         // it stored in `_audio`.
-        child: RepositoryProvider<AudioService>.value(
-          value: providedAudio,
+        child: MultiRepositoryProvider(
+          providers: [
+            RepositoryProvider<AudioService>.value(value: providedAudio),
+            RepositoryProvider<BlockedPeersStore>(
+              create: (_) => _FakeBlockedPeersStore(),
+            ),
+          ],
           child: BlocProvider<FrequencySessionCubit>.value(
             value: mockCubit,
             child: c!,
@@ -736,4 +742,34 @@ class _NullRecentFrequenciesStore implements RecentFrequenciesStore {
   Future<void> record(String freq) async {}
   @override
   Future<void> clear() async {}
+}
+
+/// In-memory BlockedPeersStore for room-screen tests. The room screen
+/// reads from this on initState (#125) so a real provider has to exist
+/// in the tree even when no test asserts on its contents — the fake
+/// keeps tests off sqflite without losing the wiring.
+class _FakeBlockedPeersStore implements BlockedPeersStore {
+  final Set<String> _blocked;
+  _FakeBlockedPeersStore({Set<String>? initial})
+      : _blocked = {...?initial};
+
+  @override
+  Future<Set<String>> getAll() async => Set<String>.unmodifiable(_blocked);
+
+  @override
+  Future<void> block(String peerId) async {
+    final trimmed = peerId.trim();
+    if (trimmed.isEmpty) return;
+    _blocked.add(trimmed);
+  }
+
+  @override
+  Future<void> unblock(String peerId) async {
+    final trimmed = peerId.trim();
+    if (trimmed.isEmpty) return;
+    _blocked.remove(trimmed);
+  }
+
+  @override
+  Future<void> clear() async => _blocked.clear();
 }

--- a/test/services/blocked_peers_store_test.dart
+++ b/test/services/blocked_peers_store_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:walkie_talkie/services/blocked_peers_store.dart';
+import 'package:walkie_talkie/services/walkie_talkie_database.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+  });
+
+  setUp(() async {
+    WalkieTalkieDatabase.overrideDatabaseFactoryForTesting(
+      databaseFactoryFfi,
+      path: inMemoryDatabasePath,
+    );
+    await WalkieTalkieDatabase.resetForTesting();
+  });
+
+  tearDown(() async {
+    await WalkieTalkieDatabase.resetForTesting();
+  });
+
+  group('SqfliteBlockedPeersStore', () {
+    test('returns an empty set before any block', () async {
+      final store = SqfliteBlockedPeersStore();
+      expect(await store.getAll(), isEmpty);
+    });
+
+    test('block + getAll round-trips a single entry', () async {
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      expect(await store.getAll(), {'peer-A'});
+    });
+
+    test('block tracks multiple distinct peers', () async {
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      await store.block('peer-B');
+      await store.block('peer-C');
+      expect(await store.getAll(), {'peer-A', 'peer-B', 'peer-C'});
+    });
+
+    test('blocking the same peer twice is idempotent', () async {
+      // The PRIMARY KEY on peer_id + ConflictAlgorithm.replace means a
+      // duplicate block bumps the timestamp without inserting a second row.
+      // The user-visible `getAll` should still report exactly one entry.
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      await store.block('peer-A');
+      expect(await store.getAll(), {'peer-A'});
+    });
+
+    test('unblock removes a previously-blocked peer', () async {
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      await store.block('peer-B');
+      await store.unblock('peer-A');
+      expect(await store.getAll(), {'peer-B'});
+    });
+
+    test('unblocking a peer that was never blocked is a no-op', () async {
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      await store.unblock('peer-Z'); // not in the table
+      expect(await store.getAll(), {'peer-A'});
+    });
+
+    test('block trims whitespace', () async {
+      final store = SqfliteBlockedPeersStore();
+      await store.block('  peer-A  ');
+      expect(await store.getAll(), {'peer-A'});
+    });
+
+    test('block with empty / whitespace-only is a no-op', () async {
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      await store.block('');
+      await store.block('   ');
+      expect(await store.getAll(), {'peer-A'});
+    });
+
+    test('unblock with empty / whitespace-only is a no-op', () async {
+      // Symmetric with `block`: a malformed unblock can't accidentally
+      // wipe a peer whose id happens to start with whitespace and got
+      // through some upstream bug.
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      await store.unblock('');
+      await store.unblock('   ');
+      expect(await store.getAll(), {'peer-A'});
+    });
+
+    test('persists across new SqfliteBlockedPeersStore instances', () async {
+      // Acceptance criterion from #125: "Block a peer in one session;
+      // restart app; rejoin same room → peer is still blocked." Two
+      // independent store instances against the same DB connection
+      // simulate the cross-launch hop.
+      final first = SqfliteBlockedPeersStore();
+      await first.block('peer-A');
+      await first.block('peer-B');
+
+      final second = SqfliteBlockedPeersStore();
+      expect(await second.getAll(), {'peer-A', 'peer-B'});
+    });
+
+    test('clear empties the set', () async {
+      final store = SqfliteBlockedPeersStore();
+      await store.block('peer-A');
+      await store.block('peer-B');
+      await store.clear();
+      expect(await store.getAll(), isEmpty);
+    });
+
+    test('concurrent block calls do not lose entries', () async {
+      // Without serialization in the store, two concurrent block calls
+      // can both observe the same pre-write state and last-write-wins
+      // one of them out of the table. Fire several in parallel — every
+      // peerId should survive.
+      final store = SqfliteBlockedPeersStore();
+      await Future.wait([
+        store.block('peer-A'),
+        store.block('peer-B'),
+        store.block('peer-C'),
+        store.block('peer-D'),
+      ]);
+      expect(
+        await store.getAll(),
+        {'peer-A', 'peer-B', 'peer-C', 'peer-D'},
+      );
+    });
+
+    test('concurrent block / unblock of the same peer leaves a deterministic '
+        'final state (last write wins on the chain)', () async {
+      // The store serializes writes per-instance via _writeChain, so
+      // back-to-back calls land in submission order. The final state
+      // must reflect the last call (an unblock) regardless of how the
+      // sqflite event loop schedules them.
+      final store = SqfliteBlockedPeersStore();
+      final futures = <Future<void>>[];
+      futures.add(store.block('peer-A'));
+      futures.add(store.unblock('peer-A'));
+      futures.add(store.block('peer-A'));
+      futures.add(store.unblock('peer-A'));
+      await Future.wait(futures);
+      expect(await store.getAll(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes the **persistent block list** sub-feature of #125. Per-peer-volume-in-cubit and frequency naming/pinning are scoped out to follow-up PRs.

## Why

`_peerMuted` in [`FrequencyRoomScreen`](lib/screens/frequency_room_screen.dart) is session-local. Every time the user re-joins the same frequency they have to re-mute the same person — which is exactly the user-visible pain the issue calls out.

## Approach

- **New `BlockedPeersStore`** ([lib/services/blocked_peers_store.dart](lib/services/blocked_peers_store.dart)) — abstract interface + `SqfliteBlockedPeersStore` impl. API: `getAll()`, `block(peerId)`, `unblock(peerId)`, `clear()`. Keyed by the stable BLE-advertised peerId (`Person.id == ProtocolPeer.peerId` for cubit-driven peers; the local `'me'` sentinel never reaches the store).

  Writes serialize through a per-instance `_writeChain` so two concurrent toggles can't both observe the same pre-write state and last-write-wins one of them out of the table — the same pattern [`SqfliteRecentFrequenciesStore`](lib/services/recent_frequencies_store.dart) uses.

- **DB migration** ([lib/services/walkie_talkie_database.dart](lib/services/walkie_talkie_database.dart)) — `_dbVersion` 1 → 2 with an idempotent `_onUpgrade` (and matching `_onCreate` path for fresh installs) that adds:
  ```sql
  CREATE TABLE IF NOT EXISTS blocked_peers (
    peer_id   TEXT PRIMARY KEY NOT NULL,
    blocked_at INTEGER NOT NULL
  )
  ```
  `blocked_at` is kept for diagnostic ordering only — `getAll()` returns an unordered set, so no index on it (would be wasted writes).

- **Provider wiring** ([lib/main.dart](lib/main.dart)) — registered alongside the other repository providers, with a `blockedPeersStore` test-override constructor field that mirrors the existing identity / recent-frequencies / discovery / audio / permission overrides. Lazy `RepositoryProvider.create` so the default `SqfliteBlockedPeersStore()` only constructs when a screen reads it (i.e. not during onboarding/discovery).

- **Room screen integration** ([lib/screens/frequency_room_screen.dart](lib/screens/frequency_room_screen.dart)) —
  - `_hydratePersistedMutes()` reads the set on `initState` and `setState`s `_peerMuted` once it lands. Failures are swallowed (a transient open error shouldn't abort the room render).
  - `_persistMute(peerId, muted)` mirrors drawer-`onChanged` toggles back to the store, fire-and-forget. The `'me'` sentinel is filtered out before any write.

## Tests

13 new tests in [test/services/blocked_peers_store_test.dart](test/services/blocked_peers_store_test.dart) cover:

- empty initial state
- round-trip block / `getAll`
- multiple distinct peers
- idempotent re-block (PK + ConflictAlgorithm.replace)
- unblock removes only the targeted peer
- unblock of a never-blocked peer is a no-op
- whitespace trimming on block
- empty / whitespace-only block + unblock are no-ops
- **cross-instance persistence** — the literal acceptance criterion (\"Block a peer in one session; restart app; rejoin same room → peer is still blocked\")
- `clear()` empties the set
- concurrent `Future.wait` of 4 blocks all survive
- interleaved block→unblock→block→unblock chain ends empty (write serialization)

Existing room-screen test ([test/screens/frequency_room_screen_test.dart](test/screens/frequency_room_screen_test.dart)) gets a `_FakeBlockedPeersStore` in its provider tree.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 382 / 382 pass (was 369; +13 store tests)
- [ ] CI green
- [ ] Manual two-device: mute peer-A, leave room, kill app, rejoin same freq → peer-A still rendered with the muted icon

## Out of scope (deferred)

- **Per-peer volume in the cubit, not the screen.** Today `_volumes` is screen state; the issue wants it in the cubit so the audio engine can apply it at the mixer level. Separate refactor.
- **Frequency naming + pinning.** Touches `RecentFrequenciesStore` schema (add `nickname?`, `pinned`) and Discovery UI. Separate PR.
- **Persisting `_removed`** (the host-only \"remove from frequency\" set). Without an unblock surface for removed peers, persisting that becomes a footgun the user can't recover from. Worth its own PR with the management screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer muting feature allowing users to mute individual peers in frequency rooms. Mute preferences are automatically saved and restored across app restarts and session rejoins.

* **Tests**
  * Added comprehensive test coverage for peer muting functionality and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->