### PR TITLE
feat(#110): Enable R8 minification + proguard rules for JNI + plugins

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -84,6 +84,14 @@ android {
 
     buildTypes {
         release {
+            // Enable R8 minification and resource shrinking for release builds
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+
             // Fail fast if release build is requested but no signing config is available
             // Only check when a release task is actually being executed
             val isReleaseBuild = gradle.startParameter.taskNames.any {

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,107 @@
+# Walkie-Talkie ProGuard Rules
+# Keep rules for R8 minification + shrinking
+
+# ============================================================================
+# JNI: Keep all native methods and classes called from C++
+# ============================================================================
+
+# Keep all native method declarations
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+# Keep entire walkie_talkie package - native code calls many methods via JNI
+-keep class com.elodin.walkie_talkie.** { *; }
+
+# Explicit keep for classes with JNI callbacks invoked from C++
+-keepclassmembers class com.elodin.walkie_talkie.MainActivity {
+    void sendLocalTalkingEvent(boolean);
+    void sendAudioError(java.lang.String);
+}
+
+-keepclassmembers class com.elodin.walkie_talkie.PeerAudioManager {
+    void onMixedAudioReady(java.lang.String, byte[], int);
+}
+
+# Keep AudioEngineManager and AudioMixerManager - used via reflection/JNI
+-keep class com.elodin.walkie_talkie.AudioEngineManager { *; }
+-keep class com.elodin.walkie_talkie.AudioMixerManager { *; }
+-keep class com.elodin.walkie_talkie.PeerAudioManager { *; }
+
+# ============================================================================
+# flutter_blue_plus: Bluetooth LE library keep rules
+# ============================================================================
+
+# Keep FlutterBluePlus plugin classes - used via platform channels
+-keep class com.lib.flutter_blue_plus.** { *; }
+
+# Keep Bluetooth GATT classes - reflection and JNI dependencies
+-keep class android.bluetooth.** { *; }
+
+# ============================================================================
+# sqflite: Local database keep rules
+# ============================================================================
+
+# Keep sqflite plugin classes
+-keep class com.tekartik.sqflite.** { *; }
+
+# ============================================================================
+# Flutter framework keep rules
+# ============================================================================
+
+# Keep Flutter embedding classes - required for plugin integration
+-keep class io.flutter.** { *; }
+-keep class io.flutter.embedding.** { *; }
+-keep class io.flutter.plugin.** { *; }
+-keep class io.flutter.util.** { *; }
+-keep class io.flutter.view.** { *; }
+
+# Keep generated plugin registrant
+-keep class io.flutter.plugins.GeneratedPluginRegistrant { *; }
+
+# ============================================================================
+# AndroidX and Android SDK keep rules
+# ============================================================================
+
+# Keep androidx.media for MediaSession + NotificationCompat.MediaStyle
+-keep class androidx.media.** { *; }
+-keep interface androidx.media.** { *; }
+
+# Keep Android components that may be accessed reflectively
+-keepclassmembers class * extends android.app.Activity { *; }
+-keepclassmembers class * extends android.app.Service { *; }
+-keepclassmembers class * extends android.content.BroadcastReceiver { *; }
+
+# ============================================================================
+# General Android best practices
+# ============================================================================
+
+# Keep line numbers for debugging stack traces
+-keepattributes SourceFile,LineNumberTable
+
+# Keep generic signatures for reflection
+-keepattributes Signature
+
+# Keep annotations
+-keepattributes *Annotation*
+
+# Keep exceptions
+-keepattributes Exceptions
+
+# Don't warn about missing platform classes
+-dontwarn javax.annotation.**
+-dontwarn org.checkerframework.**
+-dontwarn com.google.errorprone.**
+
+# ============================================================================
+# Oboe audio library
+# ============================================================================
+
+# Oboe is statically linked C++ - no special keep rules needed for symbols
+# R8 doesn't touch .so files, only Java/Kotlin bytecode
+
+# ============================================================================
+# Opus codec library
+# ============================================================================
+
+# Opus is vendored in cpp/opus/ and statically linked - no Java layer to keep

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -10,23 +10,19 @@
     native <methods>;
 }
 
-# Keep entire walkie_talkie package - native code calls many methods via JNI
--keep class com.elodin.walkie_talkie.** { *; }
+# Keep specific JNI classes and their callback methods invoked from C++
+-keep class com.elodin.walkie_talkie.AudioEngineManager { *; }
+-keep class com.elodin.walkie_talkie.AudioMixerManager { *; }
+-keep class com.elodin.walkie_talkie.PeerAudioManager { *; }
 
-# Explicit keep for classes with JNI callbacks invoked from C++
 -keepclassmembers class com.elodin.walkie_talkie.MainActivity {
     void sendLocalTalkingEvent(boolean);
     void sendAudioError(java.lang.String);
 }
 
--keepclassmembers class com.elodin.walkie_talkie.PeerAudioManager {
-    void onMixedAudioReady(java.lang.String, byte[], int);
-}
-
-# Keep AudioEngineManager and AudioMixerManager - used via reflection/JNI
--keep class com.elodin.walkie_talkie.AudioEngineManager { *; }
--keep class com.elodin.walkie_talkie.AudioMixerManager { *; }
--keep class com.elodin.walkie_talkie.PeerAudioManager { *; }
+# Keep GATT managers - accessed via platform channel and may use reflection
+-keep class com.elodin.walkie_talkie.GattClientManager { *; }
+-keep class com.elodin.walkie_talkie.GattServerManager { *; }
 
 # ============================================================================
 # flutter_blue_plus: Bluetooth LE library keep rules
@@ -49,15 +45,19 @@
 # Flutter framework keep rules
 # ============================================================================
 
-# Keep Flutter embedding classes - required for plugin integration
--keep class io.flutter.** { *; }
--keep class io.flutter.embedding.** { *; }
--keep class io.flutter.plugin.** { *; }
--keep class io.flutter.util.** { *; }
--keep class io.flutter.view.** { *; }
+# Keep Flutter embedding entry points
+-keep class io.flutter.app.FlutterApplication { *; }
+-keep class io.flutter.plugin.common.** { *; }
+-keep class io.flutter.plugin.platform.** { *; }
+-keep class io.flutter.embedding.engine.** { *; }
 
 # Keep generated plugin registrant
 -keep class io.flutter.plugins.GeneratedPluginRegistrant { *; }
+
+# Keep method channel handlers
+-keepclassmembers class * {
+    @io.flutter.embedding.engine.dart.DartExecutor$DartEntrypoint *;
+}
 
 # ============================================================================
 # AndroidX and Android SDK keep rules


### PR DESCRIPTION
## Summary
Implements issue #110 by enabling R8 code shrinking and resource shrinking for release builds. Ships comprehensive proguard-rules.pro to protect JNI methods and plugin classes from obfuscation.

## Changes
- **android/app/build.gradle.kts**: Enable `isMinifyEnabled` and `isShrinkResources` for release builds, configure proguard files
- **android/app/proguard-rules.pro** (new): Keep rules for:
  - All JNI native methods
  - C++ → Kotlin callbacks (MainActivity.sendLocalTalkingEvent, sendAudioError, PeerAudioManager.onMixedAudioReady)
  - flutter_blue_plus Bluetooth classes
  - sqflite database plugin
  - androidx.media for MediaSession
  - Flutter framework and plugin classes

## Testing
- [ ] Build release AAB: `flutter build appbundle --release --target-platform=android-arm64`
- [ ] Verify AAB size is smaller than debug build
- [ ] Test onboarding flow on release build
- [ ] Test discovery flow on release build
- [ ] Test room flow (join, PTT, leave) on release build
- [ ] Verify no JNI crashes on release build

## Related
Closes #110
Depends on #94 (closed: libopus vendored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled release code minification and resource shrinking to reduce app size and improve performance.
  * Added release rules to ensure native, plugin, and platform-bridge components remain intact to prevent runtime issues after minification.
  * Preserved necessary runtime metadata and reflective entry points while suppressing benign build warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->