### PR TITLE
feat(#119): explicit AAB splits + auto versionCode in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          # GITHUB_RUN_NUMBER is read by android/app/build.gradle.kts so each CI
+          # run produces a unique versionCode — Play rejects duplicate codes.
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
           if [ -z "$KEYSTORE_PASSWORD" ] || [ -z "$KEY_ALIAS" ] || [ -z "$KEY_PASSWORD" ]; then
             echo "Error: One or more signing secrets are not set"
@@ -62,6 +65,31 @@ jobs:
             exit 1
           fi
           flutter build appbundle --release --target-platform=android-arm64,android-arm,android-x64
+
+      - name: Measure AAB size
+        # Logs the AAB size and fails if it exceeds the budget. The 30 MB target
+        # in #131 is the goal; we set the hard ceiling well above that so this
+        # step catches catastrophic regressions (e.g. an accidental fat APK
+        # config or a vendored binary blob) without flapping on small growth.
+        # Note: this measures the AAB itself, not the per-device download —
+        # bundletool's Play-served APK split sizes are typically much smaller.
+        env:
+          AAB_MAX_BYTES: 52428800 # 50 MiB
+        run: |
+          AAB_PATH=build/app/outputs/bundle/release/app-release.aab
+          if [ ! -f "$AAB_PATH" ]; then
+            echo "Error: $AAB_PATH not found"
+            exit 1
+          fi
+          AAB_BYTES=$(stat -c%s "$AAB_PATH")
+          AAB_MIB=$(awk "BEGIN { printf \"%.2f\", $AAB_BYTES / 1048576 }")
+          echo "AAB size: ${AAB_BYTES} bytes (${AAB_MIB} MiB)"
+          echo "::notice title=AAB size::${AAB_MIB} MiB (${AAB_BYTES} bytes)"
+          echo "aab_size_bytes=${AAB_BYTES}" >> "$GITHUB_OUTPUT"
+          if [ "$AAB_BYTES" -gt "$AAB_MAX_BYTES" ]; then
+            echo "Error: AAB size ${AAB_BYTES} bytes exceeds budget ${AAB_MAX_BYTES} bytes"
+            exit 1
+          fi
 
       - name: Upload release AAB
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,15 @@ jobs:
           echo "Keystore decoded to ${{ runner.temp }}/walkie-talkie.jks"
 
       - name: Build release AAB
+        # android/app/build.gradle.kts derives versionCode from the runner's
+        # default GITHUB_RUN_NUMBER + GITHUB_RUN_ATTEMPT env vars (auto-set on
+        # every step) so each CI run and each rerun gets a unique code — Play
+        # rejects duplicates.
         env:
           KEYSTORE_PATH: ${{ runner.temp }}/walkie-talkie.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          # GITHUB_RUN_NUMBER + GITHUB_RUN_ATTEMPT are read by
-          # android/app/build.gradle.kts so each CI run (and each rerun of a
-          # failed run) produces a unique versionCode — Play rejects duplicate
-          # codes.
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           if [ -z "$KEYSTORE_PASSWORD" ] || [ -z "$KEY_ALIAS" ] || [ -z "$KEY_PASSWORD" ]; then
             echo "Error: One or more signing secrets are not set"
@@ -88,7 +86,6 @@ jobs:
           AAB_MIB=$(awk "BEGIN { printf \"%.2f\", $AAB_BYTES / 1048576 }")
           echo "AAB size: ${AAB_BYTES} bytes (${AAB_MIB} MiB)"
           echo "::notice title=AAB size::${AAB_MIB} MiB (${AAB_BYTES} bytes)"
-          echo "aab_size_bytes=${AAB_BYTES}" >> "$GITHUB_OUTPUT"
           if [ -n "$GITHUB_STEP_SUMMARY" ]; then
             {
               echo "### AAB size"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,12 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          # GITHUB_RUN_NUMBER is read by android/app/build.gradle.kts so each CI
-          # run produces a unique versionCode — Play rejects duplicate codes.
+          # GITHUB_RUN_NUMBER + GITHUB_RUN_ATTEMPT are read by
+          # android/app/build.gradle.kts so each CI run (and each rerun of a
+          # failed run) produces a unique versionCode — Play rejects duplicate
+          # codes.
           GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           if [ -z "$KEYSTORE_PASSWORD" ] || [ -z "$KEY_ALIAS" ] || [ -z "$KEY_PASSWORD" ]; then
             echo "Error: One or more signing secrets are not set"
@@ -86,6 +89,14 @@ jobs:
           echo "AAB size: ${AAB_BYTES} bytes (${AAB_MIB} MiB)"
           echo "::notice title=AAB size::${AAB_MIB} MiB (${AAB_BYTES} bytes)"
           echo "aab_size_bytes=${AAB_BYTES}" >> "$GITHUB_OUTPUT"
+          if [ -n "$GITHUB_STEP_SUMMARY" ]; then
+            {
+              echo "### AAB size"
+              echo ""
+              echo "- **${AAB_MIB} MiB** (${AAB_BYTES} bytes)"
+              echo "- Budget: $((AAB_MAX_BYTES / 1048576)) MiB"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "$AAB_BYTES" -gt "$AAB_MAX_BYTES" ]; then
             echo "Error: AAB size ${AAB_BYTES} bytes exceeds budget ${AAB_MAX_BYTES} bytes"
             exit 1

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,15 +24,34 @@ android {
         // Android 13+ required for Bluetooth LE Audio APIs
         minSdk = 33
         targetSdk = 36
-        // Auto-derive versionCode in CI from VERSION_CODE (explicit override) or
-        // GITHUB_RUN_NUMBER (one-per-CI-run, monotonic). Local builds and any CI
-        // run without those vars fall back to the static `+N` from pubspec.yaml,
-        // surfaced via flutter.versionCode. Play rejects duplicate versionCodes,
-        // so this is what lets back-to-back release builds upload without a
-        // manual pubspec bump.
-        versionCode = (System.getenv("VERSION_CODE")?.toIntOrNull()
-            ?: System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
-            ?: flutter.versionCode)
+        // Resolve versionCode in this priority order. Play rejects duplicate
+        // versionCodes, so the goal is "every CI build uploads with a unique,
+        // strictly increasing code, with no manual pubspec bump":
+        //
+        //   1. VERSION_CODE env var — explicit override for one-off builds
+        //      (e.g. recreating a specific historical build).
+        //   2. GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT — monotonic per CI
+        //      run AND per rerun-of-the-same-run. GITHUB_RUN_NUMBER alone
+        //      repeats across reruns of a failed workflow, so a rerun would
+        //      collide with the failed attempt's code if that attempt had
+        //      uploaded; folding GITHUB_RUN_ATTEMPT in makes reruns distinct.
+        //      The multiplier is 100 because GitHub re-runs are capped well
+        //      below that in practice (the docs cap automatic reruns at 10),
+        //      so adjacent run numbers can't overlap.
+        //   3. flutter.versionCode (the static `+N` in pubspec.yaml) — local
+        //      builds and any CI run without the GitHub env vars.
+        //
+        // The CI-derived value is also clamped to >= flutter.versionCode so a
+        // manual pubspec bump (e.g. for a hotfix) still wins if it ever exceeds
+        // the run-number-derived code.
+        versionCode = run {
+            val explicit = System.getenv("VERSION_CODE")?.toIntOrNull()
+            if (explicit != null) return@run explicit
+            val runNumber = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
+            val runAttempt = System.getenv("GITHUB_RUN_ATTEMPT")?.toIntOrNull() ?: 1
+            val ciDerived = runNumber?.let { it * 100 + runAttempt }
+            if (ciDerived != null) maxOf(ciDerived, flutter.versionCode) else flutter.versionCode
+        }
         versionName = flutter.versionName
         
         // NDK configuration for Oboe audio library

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -47,12 +47,37 @@ android {
         // builds onto the same flutter.versionCode whenever the static code
         // happens to exceed the run-derived one (Play would then reject the
         // second). If you need to force a specific code in CI, set VERSION_CODE.
+        //
+        // Math is in Long and validated against Android's hard ceiling
+        // (versionCode is a 32-bit signed int but Play caps it at 2.1B) so a
+        // pathological GITHUB_RUN_NUMBER can't silently overflow into a
+        // negative or out-of-range code that breaks releases late in the build.
         versionCode = run {
-            val explicit = System.getenv("VERSION_CODE")?.toIntOrNull()
-            if (explicit != null) return@run explicit
-            val runNumber = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
-            val runAttempt = System.getenv("GITHUB_RUN_ATTEMPT")?.toIntOrNull() ?: 1
-            runNumber?.let { it * 100 + runAttempt } ?: flutter.versionCode
+            val maxVersionCode = 2_100_000_000L
+            fun checked(value: Long, source: String): Int {
+                if (value <= 0L || value > maxVersionCode) {
+                    throw GradleException(
+                        "$source resolved to invalid versionCode $value. " +
+                            "versionCode must be in (0, $maxVersionCode]."
+                    )
+                }
+                return value.toInt()
+            }
+            val explicitRaw = System.getenv("VERSION_CODE")
+            if (explicitRaw != null) {
+                val explicit = explicitRaw.toLongOrNull()
+                    ?: throw GradleException(
+                        "VERSION_CODE must be an integer, got: \"$explicitRaw\"."
+                    )
+                return@run checked(explicit, "VERSION_CODE")
+            }
+            val runNumber = System.getenv("GITHUB_RUN_NUMBER")?.toLongOrNull()
+            val runAttempt = System.getenv("GITHUB_RUN_ATTEMPT")?.toLongOrNull() ?: 1L
+            val ciDerived = runNumber?.let { it * 100L + runAttempt }
+            if (ciDerived != null) {
+                return@run checked(ciDerived, "GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT")
+            }
+            flutter.versionCode
         }
         versionName = flutter.versionName
         

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,15 @@ android {
         // Android 13+ required for Bluetooth LE Audio APIs
         minSdk = 33
         targetSdk = 36
-        versionCode = flutter.versionCode
+        // Auto-derive versionCode in CI from VERSION_CODE (explicit override) or
+        // GITHUB_RUN_NUMBER (one-per-CI-run, monotonic). Local builds and any CI
+        // run without those vars fall back to the static `+N` from pubspec.yaml,
+        // surfaced via flutter.versionCode. Play rejects duplicate versionCodes,
+        // so this is what lets back-to-back release builds upload without a
+        // manual pubspec bump.
+        versionCode = (System.getenv("VERSION_CODE")?.toIntOrNull()
+            ?: System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
+            ?: flutter.versionCode)
         versionName = flutter.versionName
         
         // NDK configuration for Oboe audio library
@@ -117,6 +125,23 @@ android {
             }
 
             signingConfig = signingConfigs.getByName("release")
+        }
+    }
+
+    // Explicit AAB split configuration. AGP currently defaults all three to
+    // enableSplit = true, but pinning them keeps a future default change from
+    // silently regressing per-device download size — the whole reason this app
+    // ships an AAB instead of a fat APK is to deliver only the ABI / density /
+    // language slice each device needs.
+    bundle {
+        language {
+            enableSplit = true
+        }
+        density {
+            enableSplit = true
+        }
+        abi {
+            enableSplit = true
         }
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -77,7 +77,7 @@ android {
             if (ciDerived != null) {
                 return@run checked(ciDerived, "GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT")
             }
-            flutter.versionCode
+            checked(flutter.versionCode.toLong(), "flutter.versionCode")
         }
         versionName = flutter.versionName
         

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         // versionCodes, so the goal is "every CI build uploads with a unique,
         // strictly increasing code, with no manual pubspec bump":
         //
-        //   1. VERSION_CODE env var — explicit override for one-off builds
-        //      (e.g. recreating a specific historical build).
+        //   1. VERSION_CODE env var — explicit override (e.g. recreating a
+        //      specific historical build, or pinning a hotfix code).
         //   2. GITHUB_RUN_NUMBER * 100 + GITHUB_RUN_ATTEMPT — monotonic per CI
         //      run AND per rerun-of-the-same-run. GITHUB_RUN_NUMBER alone
         //      repeats across reruns of a failed workflow, so a rerun would
@@ -39,18 +39,20 @@ android {
         //      below that in practice (the docs cap automatic reruns at 10),
         //      so adjacent run numbers can't overlap.
         //   3. flutter.versionCode (the static `+N` in pubspec.yaml) — local
-        //      builds and any CI run without the GitHub env vars.
+        //      builds and any CI run without the GitHub env vars. These never
+        //      reach Play, so duplicates here don't matter.
         //
-        // The CI-derived value is also clamped to >= flutter.versionCode so a
-        // manual pubspec bump (e.g. for a hotfix) still wins if it ever exceeds
-        // the run-number-derived code.
+        // Deliberately no maxOf-with-flutter.versionCode clamp: CI runs are
+        // already monotonic, and clamping would collapse two consecutive CI
+        // builds onto the same flutter.versionCode whenever the static code
+        // happens to exceed the run-derived one (Play would then reject the
+        // second). If you need to force a specific code in CI, set VERSION_CODE.
         versionCode = run {
             val explicit = System.getenv("VERSION_CODE")?.toIntOrNull()
             if (explicit != null) return@run explicit
             val runNumber = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull()
             val runAttempt = System.getenv("GITHUB_RUN_ATTEMPT")?.toIntOrNull() ?: 1
-            val ciDerived = runNumber?.let { it * 100 + runAttempt }
-            if (ciDerived != null) maxOf(ciDerived, flutter.versionCode) else flutter.versionCode
+            runNumber?.let { it * 100 + runAttempt } ?: flutter.versionCode
         }
         versionName = flutter.versionName
         


### PR DESCRIPTION
Closes #119.

## Why

Two operational holes in the release pipeline:

1. **AAB splits are implicit.** `android/app/build.gradle.kts` has no `bundle {}` block, so AGP defaults choose whether to split per ABI / density / language. Defaults are currently fine, but the whole point of shipping an AAB instead of a fat APK is per-device download size — that behavior shouldn't be at the mercy of a future AGP minor bump.
2. **`versionCode` is static.** `flutter.versionCode` reads `+N` from `pubspec.yaml`. Two `release.yml` runs on the same `pubspec.yaml` produce two AABs with the same `versionCode`, and Play rejects the second upload. Today every Play push needs a manual pubspec bump.

## Changes

### `android/app/build.gradle.kts`

- **Explicit `bundle { language { density { abi { enableSplit = true } } } }` block.** Pins each split dimension so a future AGP default flip doesn't silently regress download size.
- **`versionCode` resolution.** Now `VERSION_CODE` env (explicit override) → `GITHUB_RUN_NUMBER` (monotonic per CI run) → `flutter.versionCode` (static fallback for local builds and any CI run without those vars). Local `flutter build` keeps producing `versionCode = 1` exactly as before; CI gets a unique code per run for free.

### `.github/workflows/release.yml`

- **Exports `GITHUB_RUN_NUMBER`** to the `flutter build appbundle` step so the Gradle script above sees it.
- **New \"Measure AAB size\" step.** `stat`s `app-release.aab`, prints bytes + MiB, emits a `::notice title=AAB size::` so the value lands in the Actions run summary, and fails the build if size > 50 MiB. The 30 MiB target from #131 is the goal; 50 MiB is set as the hard ceiling so this catches catastrophic regressions (accidental fat APK, vendored binary blob) without flapping on normal growth. Note: this measures the AAB itself, not the per-device download — bundletool's Play-served APK splits will be substantially smaller.

## Acceptance criteria from #119

- [x] Tagged release CI produces an AAB whose ABI / density / language splits are explicit.
- [x] Two consecutive releases on different days have different `versionCode`s without manual edits — `GITHUB_RUN_NUMBER` is monotonic across all runs of the workflow in the repo.
- [x] AAB size reported in CI logs (also in the Actions summary via `::notice`).

## Test plan

- [x] `flutter pub get` — clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 437/437 pass (no Dart code touched; verifies nothing regressed)
- [ ] CI green
- [ ] Manual: trigger release workflow on a tag; verify (1) the build's logged `versionCode` differs from the previous run, (2) AAB size is logged + within budget, (3) AAB still installs and runs

## Out of scope

- **`vcsInfo { include = true }`** for crash deobfuscation — tracked under #131 (depends on R8 / #110 to be useful).
- **SLSA provenance** — also #131.
- **Hard 30 MiB cap** — the issue's < 30 MB target needs a per-device-download measurement (`bundletool build-apks` + `get-size total`) rather than just the AAB. Worth its own PR once we want a real budget gate; the 50 MiB AAB ceiling here is the regression tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now measures app bundle (AAB) size, posts size and a short size/budget summary to the build output, and fails the job if the bundle exceeds a 50 MiB ceiling.
  * Version codes are now generated deterministically per-build, using CI-provided values when available to ensure unique, monotonic numeric codes.
  * App bundle splits by language, screen density, and CPU architecture are enabled to produce smaller, optimized distributions for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->