### PR TITLE
feat(#131): vcsInfo in AAB + R8 fullMode + nonTransitiveRClass

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -187,6 +187,11 @@ android {
     // silently regressing per-device download size — the whole reason this app
     // ships an AAB instead of a fat APK is to deliver only the ABI / density /
     // language slice each device needs.
+    //
+    // vcsInfo embeds the HEAD commit SHA + remote URL into the AAB metadata so
+    // Play Console can deep-link crash stack traces back to the exact source
+    // revision — pairs with the R8 mapping upload from #110 for fully
+    // deobfuscated, source-linked traces in the Play Console crash dashboard.
     bundle {
         language {
             enableSplit = true
@@ -196,6 +201,9 @@ android {
         }
         abi {
             enableSplit = true
+        }
+        vcsInfo {
+            include = true
         }
     }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,13 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+
+# R8 full mode: more aggressive optimizations than the default. Pairs with the
+# release proguard-rules.pro shipped in #110 — those keep rules cover JNI,
+# flutter_blue_plus, sqflite, androidx.media, and Flutter framework reflection
+# entry points, which are the surfaces full mode is most likely to break.
+android.enableR8.fullMode=true
+
+# Non-transitive R classes: each module's R class only contains its own
+# resources, not its dependencies'. Smaller R classes, faster incremental
+# builds, and the recommended default for AGP 8.x.
+android.nonTransitiveRClass=true


### PR DESCRIPTION
## Summary

Three small Play Store / build-hygiene tunables from the #131 checklist. Each one is independently safe and pairs with prior infra work (R8 from #110, AAB splits from #119).

### 1. `bundle { vcsInfo { include = true } }` in `android/app/build.gradle.kts`
Embeds the HEAD commit SHA + git remote URL into the AAB metadata so Play Console can deep-link crash stack traces back to the exact source revision. Pairs with the R8 mapping upload from #110 for fully deobfuscated, source-linked traces in the Play Console crash dashboard.

### 2. `android.enableR8.fullMode=true` in `android/gradle.properties`
R8's more aggressive optimizations. Safe to flip now because the [`proguard-rules.pro`](android/app/proguard-rules.pro) shipped in #110 already keeps JNI methods, flutter_blue_plus, sqflite, androidx.media, and Flutter framework reflection entry points — the surfaces full mode is most likely to break.

### 3. `android.nonTransitiveRClass=true` in `android/gradle.properties`
Scopes each module's `R` class to its own resources (the AGP 8.x recommended default). Smaller R classes, faster incremental builds.

## Out of scope (deferred to follow-up PRs on #131)

- **AAB size budget enforcement** via bundletool in CI — needs a workflow step and a baseline number to alert on regression. Worth its own PR with the baseline measured first.
- **License audit / in-app LicensePage verification** — no Settings / About surface yet to host it; this is tracked alongside #121 (Settings screen).
- **SLSA provenance** generation for the AAB — substantial CI work, out of scope here.

## Test plan

- [x] `flutter analyze` — clean (run in WSL Debian per local workflow)
- [ ] CI green
- [ ] Manual: `flutter build appbundle --release` succeeds; `bundletool dump manifest --bundle build/app/outputs/bundle/release/app-release.aab` shows `vcsInfo` populated.
- [ ] Manual: smoke-test a release build on a real device (onboarding → discovery → room → leave) to confirm R8 full mode hasn't stripped a reflection-only class path.

## Wire-format / runtime behavior

No Dart, Kotlin, or C++ code touched. Pure build-config tweaks.

Refs #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Android build configuration with improved crash tracking metadata and code optimization settings, supporting better app reliability and performance on Google Play.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->