### PR TITLE
fix(#99): AudioMixer hot path — UAF-safe shared_ptr + JNI off audio thread

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -38,7 +38,9 @@ jobs:
               test/cpp/mixer_test.cpp \
               test/cpp/jitter_buffer_test.cpp \
               test/cpp/resampler_test.cpp \
-              android/app/src/main/cpp/audio_mixer.cpp; do
+              test/cpp/talking_event_queue_test.cpp \
+              android/app/src/main/cpp/audio_mixer.cpp \
+              android/app/src/main/cpp/talking_event_queue.h; do
             if [ ! -f "$required" ]; then
               echo "$required missing — failing fast"; exit 1
             fi
@@ -70,3 +72,12 @@ jobs:
               test/cpp/resampler_test.cpp \
               -o build/cpp_test/resampler_test
           build/cpp_test/resampler_test
+
+          # talking_event_queue_test exercises header-only talking_event_queue.h
+          # — the SPSC ring that moves JNI dispatch off the audio thread (#99).
+          ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+              -I test/cpp \
+              -I android/app/src/main/cpp \
+              test/cpp/talking_event_queue_test.cpp \
+              -o build/cpp_test/talking_event_queue_test
+          build/cpp_test/talking_event_queue_test

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -136,31 +136,18 @@ static TalkingEventQueue g_talkingQueue;
 static std::atomic<bool> g_talkingWorkerStop{false};
 static std::thread g_talkingWorkerThread;
 
-// JNI dispatch for a single VAD edge. Runs on the worker thread, NOT the
-// audio thread — taking g_jniMutex and attaching to the JVM here is fine.
-static void emitTalkingEventJni(bool talking) {
-    JavaVM* jvm = nullptr;
-    {
-        std::lock_guard<std::mutex> lock(g_jniMutex);
-        jvm = g_jvm;
-        if (jvm == nullptr || g_mainActivity == nullptr) return;
-    }
-
-    JNIEnv* env = nullptr;
-    bool needDetach = false;
-    if (jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
-        if (jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
-            return;
-        }
-        needDetach = true;
-    }
-
+// JNI dispatch for a single VAD edge. Called only from the worker thread,
+// which has long-attached itself to the JVM (see talkingEventWorkerLoop) —
+// so `env` is guaranteed non-null and the per-call AttachCurrent/DetachCurrent
+// dance from the previous design is gone (one attach per worker lifetime,
+// not one per VAD edge).
+static void emitTalkingEventJni(JNIEnv* env, bool talking) {
     // Snapshot the global ref into a local ref while holding g_jniMutex.
     // This rules out the race where nativeUnregisterCallbacks runs
-    // DeleteGlobalRef between our earlier null-check and the GetObjectClass
-    // below — the local ref keeps the underlying jobject alive across the
-    // JNI calls regardless of what happens to the global. Outside the lock,
-    // we do all the JNI work on the local ref.
+    // DeleteGlobalRef between our null-check and the GetObjectClass below —
+    // the local ref keeps the underlying jobject alive across the JNI calls
+    // regardless of what happens to the global. Outside the lock, we do all
+    // the JNI work on the local ref.
     jobject activity = nullptr;
     {
         std::lock_guard<std::mutex> lock(g_jniMutex);
@@ -169,7 +156,6 @@ static void emitTalkingEventJni(bool talking) {
         }
     }
     if (activity == nullptr) {
-        if (needDetach) jvm->DetachCurrentThread();
         return;
     }
 
@@ -187,30 +173,65 @@ static void emitTalkingEventJni(bool talking) {
         env->DeleteLocalRef(activityClass);
     }
     env->DeleteLocalRef(activity);
-
-    if (needDetach) {
-        jvm->DetachCurrentThread();
-    }
 }
 
-// Worker loop: drain everything in the queue, sleep, repeat. The 20 ms
-// cadence is below the human-perceivable limit for VAD UI feedback (typical
-// VAD edges fire on the order of seconds; 20 ms latency is invisible) while
-// keeping the worker mostly asleep — when no events are pending the loop is
+// Worker loop: drain the SPSC ring, sleep, repeat. The 20 ms cadence is
+// below the human-perceivable limit for VAD UI feedback (typical VAD edges
+// fire on the order of seconds; 20 ms latency is invisible) while keeping
+// the worker mostly asleep — when no events are pending the loop is
 // effectively a `nanosleep` once per tick.
+//
+// The worker attaches to the JVM ONCE at thread start and detaches ONCE at
+// thread exit, so the per-edge dispatch has zero attach/detach cost. If
+// the JVM isn't registered yet when the worker spins up (registerFor
+// Callbacks may race the engine start), we re-poll on each tick until it
+// appears. Once attached we stay attached for the rest of the worker's
+// lifetime.
 static void talkingEventWorkerLoop() {
-    while (!g_talkingWorkerStop.load(std::memory_order_acquire)) {
+    JNIEnv* env = nullptr;
+    JavaVM* attachedJvm = nullptr;  // non-null only if WE called AttachCurrentThread
+
+    auto ensureAttached = [&]() -> bool {
+        if (env != nullptr) return true;
+        JavaVM* jvm = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(g_jniMutex);
+            jvm = g_jvm;
+        }
+        if (jvm == nullptr) return false;
+        if (jvm->GetEnv((void**)&env, JNI_VERSION_1_6) == JNI_OK) {
+            // Already attached on this thread (Android may pre-attach
+            // worker threads under some configurations). Don't claim
+            // ownership of the eventual detach.
+            attachedJvm = nullptr;
+            return true;
+        }
+        if (jvm->AttachCurrentThread(&env, nullptr) == JNI_OK) {
+            attachedJvm = jvm;
+            return true;
+        }
+        env = nullptr;
+        return false;
+    };
+
+    auto drainQueue = [&]() {
+        if (!ensureAttached()) return;
         bool talking;
         while (g_talkingQueue.pop(talking)) {
-            emitTalkingEventJni(talking);
+            emitTalkingEventJni(env, talking);
         }
+    };
+
+    while (!g_talkingWorkerStop.load(std::memory_order_acquire)) {
+        drainQueue();
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
     }
-    // Drain any residual events queued just before the stop flag was set so
-    // the Dart side gets a final consistent talking-state.
-    bool talking;
-    while (g_talkingQueue.pop(talking)) {
-        emitTalkingEventJni(talking);
+    // Final drain so any events queued just before the stop flag was set
+    // still reach the Dart side.
+    drainQueue();
+
+    if (attachedJvm != nullptr) {
+        attachedJvm->DetachCurrentThread();
     }
 }
 

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -3,15 +3,18 @@
 #include <oboe/Oboe.h>
 
 #include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 #include "audio_config.h"
 #include "audio_mixer.h"
 #include "resampler.h"
+#include "talking_event_queue.h"
 
 #define LOG_TAG "WalkieTalkieAudio"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
@@ -117,6 +120,112 @@ static void emitAudioErrorEvent(oboe::Result error) {
     }
 }
 
+// Talking-event worker plumbing. The audio callback used to do its own JNI
+// dispatch (AttachCurrentThread, GetMethodID, CallVoidMethod) plus take
+// g_jniMutex for the global ref snapshot. Both are unbounded-latency
+// operations on a real-time audio thread — JVM safepoints can stall an
+// AttachCurrentThread for milliseconds at a time, which corrupts playback.
+//
+// New plumbing: the audio callback push()es a single bool onto a lock-free
+// SPSC ring (no allocation, no syscalls, no mutex). A worker thread polls
+// the ring at a 20 ms cadence and runs the JNI dispatch on its own
+// (long-attached) JNIEnv. The worker is owned by the engine — it starts in
+// `start()` after the streams open and stops in `stop()` before the streams
+// close, so an in-flight audio callback cannot push to a dead queue.
+static TalkingEventQueue g_talkingQueue;
+static std::atomic<bool> g_talkingWorkerStop{false};
+static std::thread g_talkingWorkerThread;
+
+// JNI dispatch for a single VAD edge. Runs on the worker thread, NOT the
+// audio thread — taking g_jniMutex and attaching to the JVM here is fine.
+static void emitTalkingEventJni(bool talking) {
+    JavaVM* jvm = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_jniMutex);
+        jvm = g_jvm;
+        if (jvm == nullptr || g_mainActivity == nullptr) return;
+    }
+
+    JNIEnv* env = nullptr;
+    bool needDetach = false;
+    if (jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
+        if (jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            return;
+        }
+        needDetach = true;
+    }
+
+    // Snapshot the global ref into a local ref while holding g_jniMutex.
+    // This rules out the race where nativeUnregisterCallbacks runs
+    // DeleteGlobalRef between our earlier null-check and the GetObjectClass
+    // below — the local ref keeps the underlying jobject alive across the
+    // JNI calls regardless of what happens to the global. Outside the lock,
+    // we do all the JNI work on the local ref.
+    jobject activity = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_jniMutex);
+        if (g_mainActivity != nullptr) {
+            activity = env->NewLocalRef(g_mainActivity);
+        }
+    }
+    if (activity == nullptr) {
+        if (needDetach) jvm->DetachCurrentThread();
+        return;
+    }
+
+    jclass activityClass = env->GetObjectClass(activity);
+    if (activityClass != nullptr) {
+        jmethodID method = env->GetMethodID(activityClass,
+                                            "sendLocalTalkingEvent", "(Z)V");
+        if (method != nullptr) {
+            env->CallVoidMethod(activity, method, talking);
+            if (env->ExceptionCheck()) {
+                env->ExceptionDescribe();
+                env->ExceptionClear();
+            }
+        }
+        env->DeleteLocalRef(activityClass);
+    }
+    env->DeleteLocalRef(activity);
+
+    if (needDetach) {
+        jvm->DetachCurrentThread();
+    }
+}
+
+// Worker loop: drain everything in the queue, sleep, repeat. The 20 ms
+// cadence is below the human-perceivable limit for VAD UI feedback (typical
+// VAD edges fire on the order of seconds; 20 ms latency is invisible) while
+// keeping the worker mostly asleep — when no events are pending the loop is
+// effectively a `nanosleep` once per tick.
+static void talkingEventWorkerLoop() {
+    while (!g_talkingWorkerStop.load(std::memory_order_acquire)) {
+        bool talking;
+        while (g_talkingQueue.pop(talking)) {
+            emitTalkingEventJni(talking);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    // Drain any residual events queued just before the stop flag was set so
+    // the Dart side gets a final consistent talking-state.
+    bool talking;
+    while (g_talkingQueue.pop(talking)) {
+        emitTalkingEventJni(talking);
+    }
+}
+
+static void startTalkingEventWorker() {
+    if (g_talkingWorkerThread.joinable()) return;
+    g_talkingWorkerStop.store(false, std::memory_order_release);
+    g_talkingWorkerThread = std::thread(talkingEventWorkerLoop);
+}
+
+static void stopTalkingEventWorker() {
+    if (!g_talkingWorkerThread.joinable()) return;
+    g_talkingWorkerStop.store(true, std::memory_order_release);
+    g_talkingWorkerThread.join();
+}
+
 // Error callback for Oboe streams. Emits structured events to Flutter rather
 // than crashing the foreground service. Handles permission revocation (which
 // presents as ErrorDisconnected or ErrorInternal) and other stream errors.
@@ -193,70 +302,17 @@ private:
         return std::sqrt(sum / numFrames);
     }
 
-    // Emit talking event to Flutter via JNI.
+    // Emit a VAD edge from the audio thread.
     //
-    // **Note on JNI from the audio callback.** This function is called from
-    // Oboe's audio thread, which is a strict-RT context. AttachCurrentThread
-    // and CallVoidMethod can both block / allocate, and the standard advice
-    // is to push these notifications onto a worker thread. We accept the
-    // current setup because (a) it fires only on VAD edges (~rare) and (b)
-    // the alternative — a lock-free queue + worker thread — is its own
-    // workstream. Tracked for follow-up.
+    // Lock-free, allocation-free, no JNI. We push onto a SPSC ring; a
+    // dedicated worker thread (see talkingEventWorkerLoop above) drains the
+    // ring and runs the actual JNI dispatch. If the ring is full the event
+    // is dropped — at the operating rate (one edge per VAD transition,
+    // hard-bounded by the audio callback cadence) the ring is effectively
+    // unfillable, so a drop signals catastrophic worker stall, not a
+    // recoverable condition.
     void emitTalkingEvent(bool talking) {
-        JavaVM* jvm = nullptr;
-        {
-            std::lock_guard<std::mutex> lock(g_jniMutex);
-            jvm = g_jvm;
-            // Defer the activity reference to a NewLocalRef *under* the lock
-            // (after we attach the thread) — see below.
-            if (jvm == nullptr || g_mainActivity == nullptr) return;
-        }
-
-        JNIEnv* env = nullptr;
-        bool needDetach = false;
-        if (jvm->GetEnv((void**)&env, JNI_VERSION_1_6) != JNI_OK) {
-            if (jvm->AttachCurrentThread(&env, nullptr) != JNI_OK) {
-                return;
-            }
-            needDetach = true;
-        }
-
-        // Snapshot the global ref into a local ref while holding g_jniMutex.
-        // This rules out the race where nativeUnregisterCallbacks runs
-        // DeleteGlobalRef between our earlier null-check and the
-        // GetObjectClass below — the local ref keeps the underlying jobject
-        // alive across the JNI calls regardless of what happens to the
-        // global. Outside the lock, we do all the JNI work on the local ref.
-        jobject activity = nullptr;
-        {
-            std::lock_guard<std::mutex> lock(g_jniMutex);
-            if (g_mainActivity != nullptr) {
-                activity = env->NewLocalRef(g_mainActivity);
-            }
-        }
-        if (activity == nullptr) {
-            if (needDetach) jvm->DetachCurrentThread();
-            return;
-        }
-
-        jclass activityClass = env->GetObjectClass(activity);
-        if (activityClass != nullptr) {
-            jmethodID method = env->GetMethodID(activityClass,
-                                                "sendLocalTalkingEvent", "(Z)V");
-            if (method != nullptr) {
-                env->CallVoidMethod(activity, method, talking);
-                if (env->ExceptionCheck()) {
-                    env->ExceptionDescribe();
-                    env->ExceptionClear();
-                }
-            }
-            env->DeleteLocalRef(activityClass);
-        }
-        env->DeleteLocalRef(activity);
-
-        if (needDetach) {
-            jvm->DetachCurrentThread();
-        }
+        g_talkingQueue.push(talking);
     }
 
 public:
@@ -310,6 +366,10 @@ public:
         micResampler_.reset();
         playbackResampler_.reset();
 
+        // Bring the worker thread up before starting the streams so any
+        // VAD edge from the very first callback finds a draining consumer.
+        startTalkingEventWorker();
+
         result = recordingStream->requestStart();
         if (result != oboe::Result::OK) {
             LOGE("Failed to start recording stream: %s",
@@ -330,6 +390,10 @@ public:
     }
 
     void stop() {
+        // Close streams first so no more audio callbacks can run — close()
+        // blocks until any in-flight callback returns. After both close
+        // calls return, the audio thread is guaranteed quiescent and no new
+        // events can be pushed onto the talking queue.
         if (recordingStream) {
             recordingStream->requestStop();
             recordingStream->close();
@@ -338,6 +402,9 @@ public:
             playbackStream->requestStop();
             playbackStream->close();
         }
+        // Now stop the worker. It will drain any remaining queued events
+        // (including ones pushed during the close() drain above) and exit.
+        stopTalkingEventWorker();
         LOGI("Audio engine stopped");
     }
 
@@ -445,9 +512,16 @@ public:
         const int codecFrames =
             micResampler_.process(inputData, numFrames, codecScratch_);
 
-        if (g_audioMixer != nullptr && codecFrames > 0) {
+        // Snapshot the mixer singleton into an owning local shared_ptr.
+        // Holding this strong reference for the rest of the callback rules
+        // out the use-after-free that the bare-pointer global allowed:
+        // nativeClear can run concurrently and reset the global, but the
+        // underlying AudioMixer cannot be destroyed until this local ref
+        // drops at the end of the callback.
+        auto mixer = std::atomic_load(&g_audioMixer);
+        if (mixer && codecFrames > 0) {
             // Local mic occupies device id 0 in the mix-minus matrix.
-            g_audioMixer->updateDeviceAudio(0, codecScratch_, codecFrames);
+            mixer->updateDeviceAudio(0, codecScratch_, codecFrames);
 
             // Pull this device's mix-minus (everyone but us) back from the
             // mixer. The buffer it returns is at the codec rate.
@@ -460,7 +534,7 @@ public:
                      kMaxBurstCodecFrames);
                 return oboe::DataCallbackResult::Continue;
             }
-            g_audioMixer->getMixedAudioForDevice(0, mixedCodec, codecFrames);
+            mixer->getMixedAudioForDevice(0, mixedCodec, codecFrames);
 
             // Codec 16 kHz → playout 48 kHz. Always 3:1, so output count is
             // exactly `codecFrames * kResampleRatio`.

--- a/android/app/src/main/cpp/audio_mixer.cpp
+++ b/android/app/src/main/cpp/audio_mixer.cpp
@@ -186,18 +186,27 @@ std::vector<int> AudioMixer::getActiveDevices() {
     return activeDevices;
 }
 
-// Global mixer instance
-AudioMixer* g_audioMixer = nullptr;
+// Global mixer instance. See header comment for why this is a shared_ptr
+// instead of a raw pointer.
+std::shared_ptr<AudioMixer> g_audioMixer;
 
 #ifdef __ANDROID__
 // JNI wrappers — only compiled on Android. Host CI tests link the mixer
 // directly via the C++ API above.
+//
+// All JNI methods access the global through `std::atomic_load` /
+// `std::atomic_store` so that the audio callback (which may be running on
+// another thread) can never see a torn pointer. The audio callback obtains
+// its own local shared_ptr copy in audio_engine.cpp and dereferences that
+// copy — the strong reference held there guarantees no use-after-free even
+// if `nativeClear` runs concurrently.
 extern "C" {
 
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_AudioMixerManager_nativeInit(JNIEnv *env, jobject thiz) {
-    if (g_audioMixer == nullptr) {
-        g_audioMixer = new AudioMixer();
+    auto current = std::atomic_load(&g_audioMixer);
+    if (!current) {
+        std::atomic_store(&g_audioMixer, std::make_shared<AudioMixer>());
         LOGI("Audio mixer initialized");
     }
 }
@@ -205,52 +214,61 @@ Java_com_elodin_walkie_1talkie_AudioMixerManager_nativeInit(JNIEnv *env, jobject
 JNIEXPORT jboolean JNICALL
 Java_com_elodin_walkie_1talkie_AudioMixerManager_nativeAddDevice(
         JNIEnv *env, jobject thiz, jint deviceId) {
-    if (g_audioMixer == nullptr) {
+    auto mixer = std::atomic_load(&g_audioMixer);
+    if (!mixer) {
         return JNI_FALSE;
     }
-    return g_audioMixer->addDevice(deviceId) ? JNI_TRUE : JNI_FALSE;
+    return mixer->addDevice(deviceId) ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_AudioMixerManager_nativeRemoveDevice(
         JNIEnv *env, jobject thiz, jint deviceId) {
-    if (g_audioMixer != nullptr) {
-        g_audioMixer->removeDevice(deviceId);
+    auto mixer = std::atomic_load(&g_audioMixer);
+    if (mixer) {
+        mixer->removeDevice(deviceId);
     }
 }
 
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_AudioMixerManager_nativeUpdateDeviceAudio(
         JNIEnv *env, jobject thiz, jint deviceId, jshortArray audioData) {
-    if (g_audioMixer == nullptr) {
+    auto mixer = std::atomic_load(&g_audioMixer);
+    if (!mixer) {
         return;
     }
     jsize length = env->GetArrayLength(audioData);
     jshort* buffer = env->GetShortArrayElements(audioData, nullptr);
-    g_audioMixer->updateDeviceAudio(deviceId, buffer, length);
+    mixer->updateDeviceAudio(deviceId, buffer, length);
     env->ReleaseShortArrayElements(audioData, buffer, JNI_ABORT);
 }
 
 JNIEXPORT jshortArray JNICALL
 Java_com_elodin_walkie_1talkie_AudioMixerManager_nativeGetMixedAudio(
         JNIEnv *env, jobject thiz, jint deviceId, jint numFrames) {
-    if (g_audioMixer == nullptr) {
+    auto mixer = std::atomic_load(&g_audioMixer);
+    if (!mixer) {
         return nullptr;
     }
     jshortArray result = env->NewShortArray(numFrames);
     jshort* buffer = env->GetShortArrayElements(result, nullptr);
-    g_audioMixer->getMixedAudioForDevice(deviceId, buffer, numFrames);
+    mixer->getMixedAudioForDevice(deviceId, buffer, numFrames);
     env->ReleaseShortArrayElements(result, buffer, 0);
     return result;
 }
 
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_AudioMixerManager_nativeClear(JNIEnv *env, jobject thiz) {
-    if (g_audioMixer != nullptr) {
-        g_audioMixer->clear();
-        delete g_audioMixer;
-        g_audioMixer = nullptr;
+    // Clear the registry first so any new audio-callback invocation sees an
+    // empty device list while we still hold the singleton reference.
+    auto mixer = std::atomic_load(&g_audioMixer);
+    if (mixer) {
+        mixer->clear();
     }
+    // Drop the global reference. The underlying AudioMixer is destroyed only
+    // when every other strong reference (notably the audio callback's local
+    // shared_ptr) drops — that is the UAF guarantee.
+    std::atomic_store(&g_audioMixer, std::shared_ptr<AudioMixer>{});
 }
 
 } // extern "C"

--- a/android/app/src/main/cpp/audio_mixer.h
+++ b/android/app/src/main/cpp/audio_mixer.h
@@ -99,6 +99,19 @@ public:
     std::vector<int> getActiveDevices();
 };
 
-extern AudioMixer* g_audioMixer;
+// The mixer singleton is a `shared_ptr` (not a raw pointer) so the audio
+// callback can take an owning local copy via `std::atomic_load` before
+// dereferencing — that local copy keeps the mixer alive even if a concurrent
+// `nativeClear` resets the global. With a raw pointer the audio thread's
+// load-then-deref window is a use-after-free; with the shared_ptr the
+// underlying mixer is destroyed only when the last reference drops, which
+// is necessarily after every in-flight callback has returned.
+//
+// Reads and writes of the global itself MUST go through `std::atomic_load`
+// and `std::atomic_store` (the C++17 free-function overloads on shared_ptr).
+// A plain assignment is not thread-safe for shared_ptr — even though the
+// underlying refcount is atomic, the pointer-to-control-block update is two
+// stores and would tear under contention.
+extern std::shared_ptr<AudioMixer> g_audioMixer;
 
 #endif // AUDIO_MIXER_H

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -48,8 +48,8 @@ int PeerAudioManager::registerPeer(const std::string& macAddress) {
     state->bitrate.store(audio_config::kDefaultBitrate,
                          std::memory_order_relaxed);
 
-    if (g_audioMixer) {
-        g_audioMixer->addDevice(state->deviceId);
+    if (auto mixer = std::atomic_load(&g_audioMixer)) {
+        mixer->addDevice(state->deviceId);
     }
 
     deviceIdToMac_[state->deviceId] = macAddress;
@@ -69,8 +69,8 @@ void PeerAudioManager::unregisterPeer(const std::string& macAddress) {
     }
     int deviceId = it->second->deviceId;
 
-    if (g_audioMixer) {
-        g_audioMixer->removeDevice(deviceId);
+    if (auto mixer = std::atomic_load(&g_audioMixer)) {
+        mixer->removeDevice(deviceId);
     }
 
     deviceIdToMac_.erase(deviceId);
@@ -250,6 +250,14 @@ void PeerAudioManager::mixerTickLoop() {
             }
         }
 
+        // Hoist the mixer snapshot to the top of the tick so the same
+        // strong reference covers both the decode pass and the mix-minus
+        // pass below — the load itself is cheap (one atomic word read) but
+        // doing it twice per tick would let `nativeClear` fire between the
+        // passes and leave the second one running against a stale or null
+        // pointer mid-encode.
+        auto mixer = std::atomic_load(&g_audioMixer);
+
         peerSnapshot.clear();
         macSnapshot.clear();
         {
@@ -309,9 +317,9 @@ void PeerAudioManager::mixerTickLoop() {
                 }
             }
 
-            if (decoded > 0 && g_audioMixer) {
-                g_audioMixer->updateDeviceAudio(state->deviceId,
-                                                decodedBuffer.data(), decoded);
+            if (decoded > 0 && mixer) {
+                mixer->updateDeviceAudio(state->deviceId,
+                                         decodedBuffer.data(), decoded);
             }
         }
 
@@ -320,8 +328,8 @@ void PeerAudioManager::mixerTickLoop() {
             auto& state = peerSnapshot[i];
             const std::string& mac = macSnapshot[i];
 
-            if (g_audioMixer) {
-                g_audioMixer->getMixedAudioForDevice(
+            if (mixer) {
+                mixer->getMixedAudioForDevice(
                     state->deviceId, mixedBuffer.data(), kFrameSize);
             } else {
                 std::fill(mixedBuffer.begin(), mixedBuffer.end(), 0);
@@ -464,9 +472,9 @@ void PeerAudioManager::clear() {
     stopMixerThread();
 
     std::lock_guard<std::mutex> lock(peerRegistryMutex_);
-    if (g_audioMixer) {
+    if (auto mixer = std::atomic_load(&g_audioMixer)) {
         for (const auto& [mac, state] : peers_) {
-            g_audioMixer->removeDevice(state->deviceId);
+            mixer->removeDevice(state->deviceId);
         }
     }
     peers_.clear();

--- a/android/app/src/main/cpp/talking_event_queue.h
+++ b/android/app/src/main/cpp/talking_event_queue.h
@@ -1,0 +1,73 @@
+#ifndef TALKING_EVENT_QUEUE_H
+#define TALKING_EVENT_QUEUE_H
+
+#include <atomic>
+#include <cstddef>
+
+// Single-producer, single-consumer ring buffer of VAD edge events.
+//
+// The Oboe audio callback (producer) historically called `AttachCurrentThread`
+// + `CallVoidMethod` directly on the audio thread, taking `g_jniMutex` along
+// the way. JVM safepoints can stall the callback unboundedly, which is
+// catastrophic on a real-time audio thread. This queue moves all JNI work to
+// a worker thread: the producer just stores a bool and bumps an atomic
+// counter (lock-free, allocation-free), and the worker drains and dispatches.
+//
+// Capacity sized for the worst-case burst between worker polls: at the
+// production 20 ms poll interval, even pathological VAD flapping at 50 Hz
+// (one edge per audio callback) would only deposit a single edge per poll.
+// 16 leaves nearly two orders of magnitude of headroom and aligns the index
+// modulo to a cheap mask.
+class TalkingEventQueue {
+public:
+    static constexpr size_t kCapacity = 16;
+    static_assert((kCapacity & (kCapacity - 1)) == 0,
+                  "kCapacity must be a power of two so we can use a mask");
+
+    // Producer-side push, called from the audio callback. Lock-free and
+    // wait-free; allocates nothing. Returns false if the ring is full, in
+    // which case the event is dropped — callers should treat that as a soft
+    // signal that the worker has fallen catastrophically behind, not as a
+    // recoverable error. At the operating rate (one push per VAD edge,
+    // ~1 Hz worst-case typical, hard-bounded at 50 Hz by the audio callback
+    // cadence) the ring is effectively unfillable.
+    bool push(bool talking) {
+        const size_t w = writeIdx_.load(std::memory_order_relaxed);
+        const size_t r = readIdx_.load(std::memory_order_acquire);
+        if (w - r >= kCapacity) {
+            return false;
+        }
+        slots_[w & (kCapacity - 1)] = talking;
+        writeIdx_.store(w + 1, std::memory_order_release);
+        return true;
+    }
+
+    // Consumer-side pop, called from the worker thread. Returns true and
+    // stores the value into `out` if a value was popped; returns false if
+    // the queue is empty.
+    bool pop(bool& out) {
+        const size_t r = readIdx_.load(std::memory_order_relaxed);
+        const size_t w = writeIdx_.load(std::memory_order_acquire);
+        if (r == w) {
+            return false;
+        }
+        out = slots_[r & (kCapacity - 1)];
+        readIdx_.store(r + 1, std::memory_order_release);
+        return true;
+    }
+
+    // Test-only helper for diagnostics. Not safe to call concurrently with
+    // push/pop; use only in tests where you control thread scheduling.
+    size_t sizeApprox() const {
+        const size_t w = writeIdx_.load(std::memory_order_relaxed);
+        const size_t r = readIdx_.load(std::memory_order_relaxed);
+        return w - r;
+    }
+
+private:
+    bool slots_[kCapacity]{};
+    std::atomic<size_t> writeIdx_{0};
+    std::atomic<size_t> readIdx_{0};
+};
+
+#endif  // TALKING_EVENT_QUEUE_H

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -16,7 +16,9 @@ for required in \
     test/cpp/mixer_test.cpp \
     test/cpp/jitter_buffer_test.cpp \
     test/cpp/resampler_test.cpp \
-    android/app/src/main/cpp/audio_mixer.cpp; do
+    test/cpp/talking_event_queue_test.cpp \
+    android/app/src/main/cpp/audio_mixer.cpp \
+    android/app/src/main/cpp/talking_event_queue.h; do
   if [ ! -f "$required" ]; then
     echo "$required missing — failing fast"
     exit 1
@@ -49,3 +51,12 @@ ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
     test/cpp/resampler_test.cpp \
     -o build/cpp_test/resampler_test
 build/cpp_test/resampler_test
+
+# talking_event_queue_test exercises header-only talking_event_queue.h —
+# the SPSC ring that moves JNI dispatch off the audio thread (#99).
+${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+    -I test/cpp \
+    -I android/app/src/main/cpp \
+    test/cpp/talking_event_queue_test.cpp \
+    -o build/cpp_test/talking_event_queue_test
+build/cpp_test/talking_event_queue_test

--- a/test/cpp/mixer_test.cpp
+++ b/test/cpp/mixer_test.cpp
@@ -1,6 +1,10 @@
-#include <iostream>
-#include <cstdio>
+#include <atomic>
 #include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <thread>
 
 // Include the production audio_mixer header. The build script compiles this
 // test with `-I test/cpp` before `-I android/app/src/main/cpp`, so both this
@@ -333,6 +337,116 @@ void testSeqWraparoundIsWrapSafe() {
     std::cout << "Test Seq Wraparound Is Wrap-Safe: PASSED" << std::endl;
 }
 
+// Lifetime regression for issue #99: the global mixer singleton is a
+// std::shared_ptr, accessed via std::atomic_load / std::atomic_store. The
+// audio callback used to read a bare `AudioMixer*` global that
+// `nativeClear` would `delete` concurrently — pure use-after-free.
+//
+// The fix is two-fold: (1) make the global a shared_ptr so the audio
+// thread's *local copy* keeps the mixer alive across the callback, and
+// (2) only ever swap the global through the atomic free functions so the
+// pointer-to-control-block update is non-tearing. This test pins the
+// lifetime contract: an "audio thread" reader holds a strong local
+// reference, then a "JNI thread" stores nullptr into the global, and the
+// reader still finds its mixer valid for as long as it holds the local.
+void testGlobalSharedPtrLifetime() {
+    // Static-assert the type so a future regression to a raw pointer fails
+    // at compile time, not just at runtime.
+    static_assert(
+        std::is_same<decltype(g_audioMixer), std::shared_ptr<AudioMixer>>::value,
+        "g_audioMixer must be a std::shared_ptr<AudioMixer> for the audio "
+        "callback's UAF-safe atomic_load contract");
+
+    // Seed the global.
+    auto seeded = std::make_shared<AudioMixer>();
+    std::atomic_store(&g_audioMixer, seeded);
+
+    // Simulate the audio callback: take a local owning copy.
+    std::shared_ptr<AudioMixer> readerLocal = std::atomic_load(&g_audioMixer);
+    assert(readerLocal);
+    // Two strong references now: the global, and the reader's local.
+    assert(readerLocal.use_count() >= 2);
+
+    // Concurrent "nativeClear" — drop the global ref.
+    std::atomic_store(&g_audioMixer, std::shared_ptr<AudioMixer>{});
+    // Global is now empty.
+    assert(!std::atomic_load(&g_audioMixer));
+    // But the reader's local copy is still alive — that is the UAF
+    // guarantee. Use the mixer through the local; if the underlying object
+    // had been freed this would crash under ASAN.
+    readerLocal->addDevice(1);
+    readerLocal->removeDevice(1);
+
+    // Drop the local. The original mixer is freed here, deterministically.
+    readerLocal.reset();
+    // Global already null; the local was the last ref. No leak.
+
+    // Also confirm `seeded` is still our local handle to the same object,
+    // and dropping it now finalizes destruction without a double-free.
+    seeded.reset();
+
+    std::cout << "Test Global Shared-Ptr Lifetime: PASSED" << std::endl;
+}
+
+// Concurrent stress: two threads continuously swap and load the global,
+// mirroring the worst case where `nativeClear` and the audio callback
+// race indefinitely. Without the atomic free functions a shared_ptr swap
+// would tear the control-block pointer; this test would then crash or
+// corrupt under ASAN/TSAN. With the atomic ops, the global is always
+// either null or a valid mixer, and the reader's local always either
+// fails to load or holds a live mixer for the duration of its use.
+void testConcurrentSwapAndLoadIsRaceFree() {
+    using namespace std::chrono_literals;
+
+    // Seed.
+    std::atomic_store(&g_audioMixer, std::make_shared<AudioMixer>());
+
+    std::atomic<bool> stop{false};
+    std::atomic<long> readerOps{0};
+    std::atomic<long> writerOps{0};
+
+    std::thread reader([&] {
+        while (!stop.load(std::memory_order_acquire)) {
+            auto local = std::atomic_load(&g_audioMixer);
+            if (local) {
+                // Touch the mixer's API on read-only paths only — if `local`
+                // aliased a freed mixer these would corrupt/crash. We avoid
+                // addDevice/removeDevice here because the LOG_TAG print
+                // floods CI output (the stress loop can spin millions of
+                // iterations under TSAN/ASAN).
+                (void)local->isPoisoned(0);
+                (void)local->getActiveDevices();
+            }
+            readerOps.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::thread writer([&] {
+        while (!stop.load(std::memory_order_acquire)) {
+            // Alternate: install a fresh mixer, then drop to null.
+            std::atomic_store(&g_audioMixer, std::make_shared<AudioMixer>());
+            std::atomic_store(&g_audioMixer, std::shared_ptr<AudioMixer>{});
+            writerOps.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    std::this_thread::sleep_for(100ms);
+    stop.store(true, std::memory_order_release);
+    reader.join();
+    writer.join();
+
+    // Both threads made progress — the test isn't trivially passing on a
+    // stalled thread.
+    assert(readerOps.load() > 0);
+    assert(writerOps.load() > 0);
+
+    // Restore a clean global for any test that runs after us.
+    std::atomic_store(&g_audioMixer, std::shared_ptr<AudioMixer>{});
+
+    std::cout << "Test Concurrent Swap And Load Is Race Free: PASSED"
+              << std::endl;
+}
+
 int main() {
     try {
         testMixMinus();
@@ -345,6 +459,8 @@ int main() {
         testOutOfOrderDoesNotPoisonOrAdvance();
         testRecoveryAcceptsAnyWithinThresholdFrame();
         testSeqWraparoundIsWrapSafe();
+        testGlobalSharedPtrLifetime();
+        testConcurrentSwapAndLoadIsRaceFree();
         std::cout << "All C++ Mixer tests passed!" << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;

--- a/test/cpp/mixer_test.cpp
+++ b/test/cpp/mixer_test.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <memory>
 #include <thread>
+#include <type_traits>
 
 // Include the production audio_mixer header. The build script compiles this
 // test with `-I test/cpp` before `-I android/app/src/main/cpp`, so both this
@@ -357,33 +358,40 @@ void testGlobalSharedPtrLifetime() {
         "g_audioMixer must be a std::shared_ptr<AudioMixer> for the audio "
         "callback's UAF-safe atomic_load contract");
 
-    // Seed the global.
+    // Seed the global. After the atomic_store there are TWO strong refs:
+    //   1. `seeded` — our local handle from make_shared
+    //   2. the global itself
     auto seeded = std::make_shared<AudioMixer>();
     std::atomic_store(&g_audioMixer, seeded);
+    assert(seeded.use_count() == 2);
 
-    // Simulate the audio callback: take a local owning copy.
+    // Simulate the audio callback: take a local owning copy. Now THREE
+    // strong refs: seeded, global, readerLocal. The use_count check pins
+    // that exact number — a future regression that aliases or leaks one of
+    // these refs would shift the count.
     std::shared_ptr<AudioMixer> readerLocal = std::atomic_load(&g_audioMixer);
     assert(readerLocal);
-    // Two strong references now: the global, and the reader's local.
-    assert(readerLocal.use_count() >= 2);
+    assert(readerLocal.use_count() == 3);
 
-    // Concurrent "nativeClear" — drop the global ref.
+    // Concurrent "nativeClear" — drop the global ref. Two refs left:
+    // seeded (test-local) and readerLocal (the audio-thread snapshot).
     std::atomic_store(&g_audioMixer, std::shared_ptr<AudioMixer>{});
-    // Global is now empty.
     assert(!std::atomic_load(&g_audioMixer));
-    // But the reader's local copy is still alive — that is the UAF
-    // guarantee. Use the mixer through the local; if the underlying object
-    // had been freed this would crash under ASAN.
+    assert(readerLocal.use_count() == 2);
+
+    // The reader's local copy is still alive — that is the UAF guarantee.
+    // Use the mixer through the local; if the underlying object had been
+    // freed this would crash under ASAN.
     readerLocal->addDevice(1);
     readerLocal->removeDevice(1);
 
-    // Drop the local. The original mixer is freed here, deterministically.
-    readerLocal.reset();
-    // Global already null; the local was the last ref. No leak.
-
-    // Also confirm `seeded` is still our local handle to the same object,
-    // and dropping it now finalizes destruction without a double-free.
+    // Drop seeded so readerLocal is the only remaining ref.
     seeded.reset();
+    assert(readerLocal.use_count() == 1);
+
+    // Drop the last ref. The mixer is freed here, deterministically. No
+    // double-free, no leak.
+    readerLocal.reset();
 
     std::cout << "Test Global Shared-Ptr Lifetime: PASSED" << std::endl;
 }

--- a/test/cpp/talking_event_queue_test.cpp
+++ b/test/cpp/talking_event_queue_test.cpp
@@ -1,0 +1,187 @@
+#include <atomic>
+#include <cassert>
+#include <cstdio>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "../../android/app/src/main/cpp/talking_event_queue.h"
+
+// Empty queue: pop must return false and leave the out-param untouched.
+void testEmptyPopReturnsFalse() {
+    TalkingEventQueue q;
+    bool out = true;  // sentinel — must remain untouched
+    assert(!q.pop(out));
+    assert(out == true);
+    std::cout << "Test Empty Pop Returns False: PASSED" << std::endl;
+}
+
+// Round-trip: a pushed value comes back.
+void testPushPopRoundTrip() {
+    TalkingEventQueue q;
+    assert(q.push(true));
+    bool out = false;
+    assert(q.pop(out));
+    assert(out == true);
+    // Now empty again.
+    assert(!q.pop(out));
+    std::cout << "Test Push/Pop Round Trip: PASSED" << std::endl;
+}
+
+// Order preservation across the wrap-around point. The ring uses a power-of-
+// two capacity with a mask, so the indices walk past kCapacity multiple times
+// without aliasing. This pins that the FIFO order survives that wraparound.
+void testFifoOrderAcrossWraparound() {
+    TalkingEventQueue q;
+    // Walk past the capacity twice. Push/pop alternated keeps the queue
+    // never-full but exercises every slot index.
+    const size_t kIters = TalkingEventQueue::kCapacity * 4;
+    for (size_t i = 0; i < kIters; ++i) {
+        const bool v = (i % 2) == 0;
+        assert(q.push(v));
+        bool out;
+        assert(q.pop(out));
+        assert(out == v);
+    }
+    assert(q.sizeApprox() == 0);
+    std::cout << "Test FIFO Order Across Wraparound: PASSED" << std::endl;
+}
+
+// Capacity boundary: pushing exactly kCapacity entries succeeds; the (k+1)th
+// push must be rejected. This is the load-shedding contract that the audio
+// callback relies on — a full ring drops new events rather than blocking.
+void testCapacityBoundaryDrops() {
+    TalkingEventQueue q;
+    for (size_t i = 0; i < TalkingEventQueue::kCapacity; ++i) {
+        assert(q.push(i % 2 == 0));
+    }
+    // Ring is full. Next push must be rejected.
+    assert(!q.push(true));
+    assert(q.sizeApprox() == TalkingEventQueue::kCapacity);
+
+    // Drain. Values must come back in push order.
+    for (size_t i = 0; i < TalkingEventQueue::kCapacity; ++i) {
+        bool out;
+        assert(q.pop(out));
+        assert(out == (i % 2 == 0));
+    }
+    bool out;
+    assert(!q.pop(out));
+    std::cout << "Test Capacity Boundary Drops: PASSED" << std::endl;
+}
+
+// After a drop on overflow, the queue must remain consistent — the next
+// pop cycle must still return the original (pre-drop) values in order, and
+// new pushes after a drain must succeed normally. Regression guard for an
+// off-by-one in the overflow check that would corrupt the read index.
+void testRecoversAfterOverflowDrop() {
+    TalkingEventQueue q;
+    // Fill, attempt one over, drain, fill again — the second fill must
+    // succeed exactly kCapacity times.
+    for (size_t i = 0; i < TalkingEventQueue::kCapacity; ++i) {
+        assert(q.push(true));
+    }
+    assert(!q.push(false));  // overflow drop
+
+    // Drain — must yield exactly kCapacity `true` values.
+    for (size_t i = 0; i < TalkingEventQueue::kCapacity; ++i) {
+        bool out;
+        assert(q.pop(out));
+        assert(out == true);
+    }
+
+    // Round 2: should be functionally identical to a fresh queue.
+    for (size_t i = 0; i < TalkingEventQueue::kCapacity; ++i) {
+        assert(q.push(false));
+    }
+    for (size_t i = 0; i < TalkingEventQueue::kCapacity; ++i) {
+        bool out = true;
+        assert(q.pop(out));
+        assert(out == false);
+    }
+    std::cout << "Test Recovers After Overflow Drop: PASSED" << std::endl;
+}
+
+// SPSC stress: a producer thread pushes a long alternating sequence and a
+// consumer thread pops everything. The expected count of `true` values is
+// known, so we can assert end-state equality. Drops are tolerated on
+// overflow (consumer can fall behind the producer briefly) — we encode
+// each event as a known pattern so the consumer can detect any
+// out-of-sequence delivery (corrupted slot indices, torn values).
+void testSpscStress() {
+    TalkingEventQueue q;
+    constexpr int kEvents = 100000;
+
+    std::atomic<int> producedTrue{0};
+    std::atomic<int> consumedTrue{0};
+    std::atomic<int> consumed{0};
+    std::atomic<bool> producerDone{false};
+
+    std::thread producer([&] {
+        for (int i = 0; i < kEvents; ++i) {
+            const bool v = (i & 1) == 0;
+            // Spin until accepted — we want every event to arrive so the
+            // FIFO contract can be verified end-to-end. (At kCapacity = 16
+            // and a fast consumer, this rarely spins more than a few times.)
+            while (!q.push(v)) {
+                std::this_thread::yield();
+            }
+            if (v) producedTrue.fetch_add(1, std::memory_order_relaxed);
+        }
+        producerDone.store(true, std::memory_order_release);
+    });
+
+    std::thread consumer([&] {
+        bool last = false;
+        bool seenAny = false;
+        int local = 0;
+        int localTrue = 0;
+        while (true) {
+            bool out;
+            if (q.pop(out)) {
+                // FIFO: alternating producer means every popped value must
+                // differ from the previous one (after the first).
+                if (seenAny) assert(out != last);
+                last = out;
+                seenAny = true;
+                ++local;
+                if (out) ++localTrue;
+            } else if (producerDone.load(std::memory_order_acquire)) {
+                // Producer done AND queue empty: we've seen everything.
+                bool out2;
+                if (!q.pop(out2)) break;
+                if (seenAny) assert(out2 != last);
+                last = out2;
+                ++local;
+                if (out2) ++localTrue;
+            } else {
+                std::this_thread::yield();
+            }
+        }
+        consumed.store(local, std::memory_order_release);
+        consumedTrue.store(localTrue, std::memory_order_release);
+    });
+
+    producer.join();
+    consumer.join();
+
+    assert(consumed.load() == kEvents);
+    assert(consumedTrue.load() == producedTrue.load());
+    std::cout << "Test SPSC Stress: PASSED" << std::endl;
+}
+
+int main() {
+    try {
+        testEmptyPopReturnsFalse();
+        testPushPopRoundTrip();
+        testFifoOrderAcrossWraparound();
+        testCapacityBoundaryDrops();
+        testRecoversAfterOverflowDrop();
+        testSpscStress();
+        std::cout << "All C++ TalkingEventQueue tests passed!" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "Test failed with exception: " << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Closes #99.

## Summary

The audio callback (`AudioEngine::onAudioReady` in [audio_engine.cpp](android/app/src/main/cpp/audio_engine.cpp)) had three real-time-safety bugs on the Oboe hot path. This PR fixes all three.

### 1. `g_audioMixer` use-after-free

`g_audioMixer` was a bare `AudioMixer*`. The audio callback dereferenced it while `Java_…_AudioMixerManager_nativeClear` could `delete` it concurrently on a JNI thread — pure UAF under teardown.

**Fix:** the global is now `std::shared_ptr<AudioMixer>`, accessed only through `std::atomic_load` / `std::atomic_store` (the C++17 free-function overloads on `shared_ptr`). The audio callback snapshots an owning local copy:

```cpp
auto mixer = std::atomic_load(&g_audioMixer);
if (mixer && codecFrames > 0) {
    mixer->updateDeviceAudio(...);
    mixer->getMixedAudioForDevice(...);
}
```

That local reference keeps the underlying mixer alive for the duration of the callback even if `nativeClear` runs concurrently. The mixer is destroyed only when the last strong reference drops — which is necessarily after every in-flight callback returns.

A plain `=` on a shared_ptr would not have been thread-safe even though the refcount is atomic, because the pointer-to-control-block update is two stores and would tear under contention. The atomic free functions serialize the write at a single point, so the global is always either null or a valid mixer.

### 2. JNI calls on the audio callback

`emitTalkingEvent` previously called `AttachCurrentThread` + `GetObjectClass` + `GetMethodID` + `CallVoidMethod` directly from `onAudioReady`. Any of these can hit a JVM safepoint and stall unboundedly, which corrupts playback on a strict-RT thread.

**Fix:** the new [`talking_event_queue.h`](android/app/src/main/cpp/talking_event_queue.h) provides a lock-free SPSC ring of bool VAD edges. The audio callback's `emitTalkingEvent` is now a single push (no allocation, no syscalls, no JNI). A dedicated worker thread polls the ring at 20 ms cadence and runs the JNI dispatch on its own attached `JNIEnv`. The worker is owned by `AudioEngine` — started in `start()` after both streams open, stopped in `stop()` after both streams close — so an in-flight audio callback can never push to a dead queue.

The 20 ms poll cadence is invisible for VAD UI feedback (typical edges fire on the order of seconds; the human-perceivable threshold is ~100 ms). When no events are pending the worker is effectively a `nanosleep` once per tick.

### 3. `g_jniMutex` on the audio callback

Same root cause as (2). The relocation of JNI dispatch to the worker thread removes the only place the audio thread used to take that mutex.

## Tests

[test/cpp/mixer_test.cpp](test/cpp/mixer_test.cpp) — two new regressions:

- **`testGlobalSharedPtrLifetime`** — static-asserts the global's type (a future regression to a raw pointer fails at compile time, not just runtime), then pins the lifetime contract: a JNI thread drops the global while a reader holds a local copy → reader's mixer is still valid; reader's drop deterministically finalizes destruction.
- **`testConcurrentSwapAndLoadIsRaceFree`** — 100 ms of two-thread stress swapping/loading the global. Both threads must make progress (the test isn't trivially passing on a stalled thread) and the reader exercises the mixer's read-only API on the loaded reference. Without the atomic free functions a torn control-block pointer would crash here under ASAN/TSAN.

[test/cpp/talking_event_queue_test.cpp](test/cpp/talking_event_queue_test.cpp) — new file, six tests:

- empty-pop returns false
- push/pop round-trip
- FIFO order survives index wraparound (4× the capacity in alternating push/pop)
- capacity-boundary drop semantics (the 17th push is rejected; queue stays consistent)
- queue recovers identically after an overflow drop
- 100 000-event SPSC stress with alternating-bit pattern; consumer asserts strict alternation between successive pops, proving FIFO and ruling out torn slots / corrupted indices

[scripts/presubmit.sh](scripts/presubmit.sh) and [.github/workflows/flutter.yml](.github/workflows/flutter.yml) build and run the new test.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 437 / 437 pass
- [x] `g++ -std=c++17 -Wall -Wextra -pthread …/mixer_test.cpp` — all 12 tests pass (10 existing + 2 new)
- [x] `…/talking_event_queue_test.cpp` — all 6 tests pass
- [x] `…/jitter_buffer_test.cpp` — unchanged, passes
- [x] `…/resampler_test.cpp` — unchanged, passes
- [ ] CI green
- [ ] Manual: ASAN build (`-fsanitize=address`) running a tight `nativeStart` / `nativeClear` loop shows no UAF — requires a real device

## Out of scope

- The issue mentions allocation guards on the audio thread. The new `emitTalkingEvent` allocates nothing (single relaxed atomic load + single bool store + release atomic store). The remaining audio-thread paths (`onAudioReady` body, mixer's `getMixedAudioForDevice`) were already allocation-free per #93 and remain so.
- Oboe `onError` callback handling on the audio thread is via `emitAudioErrorEvent`, but Oboe runs error callbacks on a non-audio thread by design, so it's safe to keep mutex+JNI there. Not changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight event queue for voice-activity callbacks to improve async delivery.

* **Performance Improvements**
  * Moved VAD event dispatch off the real-time audio callback to a background worker, reducing audio-thread work.

* **Reliability / Thread-safety**
  * Global audio mixer updated to a reference-counted, atomically accessed instance so in-flight audio operations remain safe during resets.

* **Tests**
  * Added unit and stress tests covering the event queue and mixer lifetime/thread-safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->