### PR TITLE
feat(#118): Upgrade permission_handler 11.3.1 → 12.0.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -673,18 +673,18 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "12.0.1"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "13.0.1"
   permission_handler_apple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   hive_flutter: ^1.1.0
 
   # Permissions Handling
-  permission_handler: ^11.3.1
+  permission_handler: ^12.0.0
   
   # Bluetooth LE
   flutter_blue_plus: ^2.2.1


### PR DESCRIPTION
## Summary

Completes the `permission_handler` portion of issue #118:
- ✅ `permission_handler` upgraded from `^11.3.1` to `^12.0.0` (resolves to 12.0.1)
- ℹ️ `flutter_bloc` 8.x → 9.x was already completed in PR #154
- ℹ️ `flutter_blue_plus` is already at 2.2.1 (issue mentioned 1.34.4 which was outdated)

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 457 tests pass
- [x] No breaking API changes in permission_handler 12.x
- [ ] Manual smoke test on Android 14 device (will verify post-merge in integration testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permission handling dependency to the latest major version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->