### PR TITLE
feat(#111): Privacy policy doc + in-app screen + Discovery footer link

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,112 @@
+# Frequency — Privacy Policy
+
+_Last updated: 2026-04-30_
+
+Frequency is an offline, peer-to-peer walkie-talkie app for Android. It runs
+entirely on the phones in the conversation — there is no Frequency server, no
+cloud sync, no analytics SDK, and no account system. This document describes
+exactly what data the app touches, where it lives, and how to remove it.
+
+## TL;DR
+
+- **No internet is required for voice or control.** The app does not declare
+  the `INTERNET` permission in its main manifest and cannot transmit your
+  audio off-device.
+- **No accounts.** There is nothing to sign up for and nothing to delete from
+  a server because no server exists.
+- **No third-party analytics, ads, or tracking.**
+- The only data Frequency stores is on your own device, and uninstalling the
+  app removes all of it.
+
+## Data the app processes
+
+### Audio (microphone)
+
+Frequency captures audio from your phone's microphone while you are in a
+voice room and you are talking (or transmitting if push-to-talk is held).
+The audio is encoded with Opus and streamed over a Bluetooth LE L2CAP
+channel directly to the other phones in the same room. **Audio is not
+recorded to disk, not sent to any server, and not retained after it has
+been transmitted.**
+
+### Bluetooth identifiers
+
+To find nearby phones running Frequency the app advertises and scans for a
+Frequency-specific Bluetooth service UUID. While in a room your phone
+exchanges its Bluetooth MAC address and a per-room session UUID with the
+host so packets can be routed to the right peer. Bluetooth identifiers are
+used solely to maintain the active connection and are not collected,
+aggregated, or sent anywhere.
+
+The Bluetooth scan permission is requested with the
+`neverForLocation` flag, and the app does not use Bluetooth scan results
+to derive your location.
+
+### On-device storage
+
+Frequency stores a small amount of data locally on your device so it can
+remember you between launches:
+
+- **Display name** — the handle you chose during onboarding. Shown to other
+  peers in the same room.
+- **Stable peer ID** — a random identifier generated on first launch so
+  other peers can recognize your phone across reconnects in the same room.
+- **Recent frequencies** — the most recently hosted channels, surfaced as
+  a "Recent" list on the Discovery screen.
+- **Blocked peers** — peer IDs you have muted so the mute persists across
+  reconnects.
+
+This data lives in the app's private storage on your phone (sqflite and a
+legacy Hive box that is being migrated). It is never transmitted off the
+device by Frequency.
+
+### Crash and diagnostic data
+
+Frequency does not include any crash reporter, telemetry SDK, or analytics
+library. If a crash reporter is added in a future version it will be
+**opt-in** and the in-app setting will state exactly what is sent.
+
+## Permissions and why each is requested
+
+| Permission | Why Frequency needs it |
+| --- | --- |
+| `BLUETOOTH_SCAN` (with `neverForLocation`) | Find other phones advertising the Frequency service nearby. |
+| `BLUETOOTH_CONNECT` | Open a GATT control connection to the host of the room you join. |
+| `BLUETOOTH_ADVERTISE` | Advertise your device when you are hosting a room so others can find it. |
+| `RECORD_AUDIO` | Capture your voice while you are talking in a room. |
+| `MODIFY_AUDIO_SETTINGS` | Route audio to the speaker, a wired headset, or a paired Bluetooth headset. |
+| `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_MICROPHONE` / `FOREGROUND_SERVICE_CONNECTED_DEVICE` | Keep the mic and Bluetooth radio running while the screen is off so the room does not drop when the phone locks. |
+| `POST_NOTIFICATIONS` | Show the foreground-service notification that lets you know a room is active and provides controls. |
+
+## Children's privacy
+
+Frequency captures audio. The app is targeted at users **13 and older**
+and we do not knowingly collect any data from children under that age.
+
+## Data retention and deletion
+
+There is no remote account, so there is nothing to delete from a server.
+All data Frequency stores lives on your phone. To remove every piece of
+data the app has ever stored:
+
+1. Open **Settings → Apps → Frequency → Storage** on your Android device.
+2. Tap **Clear storage** to wipe the app's data, or **Uninstall** to
+   remove the app entirely.
+
+Uninstalling the app removes the local database, the display name, the
+peer ID, the recent-frequencies list, and the blocked-peers list.
+
+## Changes to this policy
+
+If we change how Frequency processes data we will update this file and
+revise the "Last updated" date at the top. The canonical source of this
+policy is the
+[`docs/privacy-policy.md`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/docs/privacy-policy.md)
+file in the project's GitHub repository.
+
+## Contact
+
+Questions, concerns, or reports about Frequency's privacy practices can
+be filed as an issue on the project's GitHub repository:
+
+- <https://github.com/ElodinLaarz/walkie-talkie/issues>

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -10,8 +10,9 @@ exactly what data the app touches, where it lives, and how to remove it.
 ## TL;DR
 
 - **No internet is required for voice or control.** The app does not declare
-  the `INTERNET` permission in its main manifest and cannot transmit your
-  audio off-device.
+  the `INTERNET` permission in its main manifest and does not send your
+  audio to the internet or any server; voice is transmitted directly to
+  nearby peers over Bluetooth.
 - **No accounts.** There is nothing to sign up for and nothing to delete from
   a server because no server exists.
 - **No third-party analytics, ads, or tracking.**

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -380,7 +380,7 @@
     "@privacyPolicySectionContactTitle": {
         "description": "Privacy policy section title — how to contact the maintainers."
     },
-    "privacyPolicySectionContactBody": "Questions, concerns, or reports about Frequency's privacy practices can be filed as an issue on the project's GitHub repository at github.com/ElodinLaarz/walkie-talkie/issues.",
+    "privacyPolicySectionContactBody": "Questions, concerns, or reports about Frequency's privacy practices can be filed as an issue on the project's GitHub repository at https://github.com/ElodinLaarz/walkie-talkie/issues.",
     "@privacyPolicySectionContactBody": {
         "description": "Privacy policy body — contact."
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -316,7 +316,7 @@
     "@privacyPolicySectionTldrTitle": {
         "description": "Section title — short summary of the privacy policy."
     },
-    "privacyPolicySectionTldrBody": "Frequency runs entirely on the phones in the conversation. There is no Frequency server, no cloud, no account system, no analytics SDK, and no ads. The app does not declare the INTERNET permission and cannot send your audio off-device. The only data Frequency stores lives on your phone, and uninstalling the app removes all of it.",
+    "privacyPolicySectionTldrBody": "Frequency is an offline, peer-to-peer walkie-talkie app. It runs entirely on the phones in the conversation — there is no Frequency server, no cloud sync, no analytics SDK, and no account system. The app does not declare the INTERNET permission and does not send your audio to the internet or any server; voice is transmitted directly to nearby peers over Bluetooth. The only data Frequency stores is on your own device, and uninstalling the app removes all of it.",
     "@privacyPolicySectionTldrBody": {
         "description": "TL;DR section body of the privacy policy."
     },
@@ -324,7 +324,7 @@
     "@privacyPolicySectionAudioTitle": {
         "description": "Privacy policy section title — what happens to mic audio."
     },
-    "privacyPolicySectionAudioBody": "Frequency captures audio from your phone's microphone while you are in a voice room and you are talking. The audio is encoded with Opus and streamed over a Bluetooth LE channel directly to the other phones in the same room. Audio is not recorded to disk, not sent to any server, and not retained after it has been transmitted.",
+    "privacyPolicySectionAudioBody": "Frequency captures audio from your phone's microphone while you are in a voice room and you are talking (or transmitting if push-to-talk is held). The audio is encoded with Opus and streamed over a Bluetooth LE L2CAP channel directly to the other phones in the same room. Audio is not recorded to disk, not sent to any server, and not retained after it has been transmitted.",
     "@privacyPolicySectionAudioBody": {
         "description": "Privacy policy body — audio handling."
     },
@@ -332,7 +332,7 @@
     "@privacyPolicySectionBluetoothTitle": {
         "description": "Privacy policy section title — Bluetooth identifiers."
     },
-    "privacyPolicySectionBluetoothBody": "To find nearby phones running Frequency the app advertises and scans for a Frequency-specific Bluetooth service UUID. While in a room your phone exchanges its Bluetooth address and a per-room session UUID with the host so packets can be routed to the right peer. Bluetooth scanning is requested with the neverForLocation flag, and Frequency does not derive your location from scan results.",
+    "privacyPolicySectionBluetoothBody": "To find nearby phones running Frequency the app advertises and scans for a Frequency-specific Bluetooth service UUID. While in a room your phone exchanges its Bluetooth MAC address and a per-room session UUID with the host so packets can be routed to the right peer. Bluetooth identifiers are used solely to maintain the active connection and are not collected, aggregated, or sent anywhere. The Bluetooth scan permission is requested with the neverForLocation flag, and the app does not use scan results to derive your location.",
     "@privacyPolicySectionBluetoothBody": {
         "description": "Privacy policy body — Bluetooth identifiers."
     },
@@ -340,7 +340,7 @@
     "@privacyPolicySectionStorageTitle": {
         "description": "Privacy policy section title — what is stored locally."
     },
-    "privacyPolicySectionStorageBody": "Frequency stores a small amount of data locally so it can remember you between launches: your display name, a stable peer ID generated on first launch, the most recently hosted frequencies, and any peers you have muted. This data lives in the app's private storage on your phone and is never transmitted off the device by Frequency.",
+    "privacyPolicySectionStorageBody": "Frequency stores a small amount of data locally on your device so it can remember you between launches: the display name you chose during onboarding (shown to other peers in the same room), a stable peer ID generated on first launch so other peers can recognize your phone across reconnects, the most recently hosted frequencies surfaced as the Recent list on Discovery, and the peer IDs you have muted so the mute persists across reconnects. This data lives in the app's private storage on your phone and is never transmitted off the device by Frequency.",
     "@privacyPolicySectionStorageBody": {
         "description": "Privacy policy body — on-device storage."
     },
@@ -356,7 +356,7 @@
     "@privacyPolicySectionPermissionsTitle": {
         "description": "Privacy policy section title — Android permissions and why each is requested."
     },
-    "privacyPolicySectionPermissionsBody": "Bluetooth scan, connect, and advertise are required to find nearby phones, open a control connection to the host, and broadcast your own room while hosting. Microphone is required to capture your voice. Modify audio settings is used to route audio to the speaker, a wired headset, or a paired Bluetooth headset. Foreground service permissions keep the mic and Bluetooth radio running when the screen is off so the room does not drop. Post notifications shows the foreground-service notification while a room is active.",
+    "privacyPolicySectionPermissionsBody": "Bluetooth scan (with neverForLocation), connect, and advertise are required to find nearby phones, open a GATT control connection to the host of the room you join, and advertise your own device when you are hosting. Microphone is required to capture your voice while you are talking. Modify audio settings is used to route audio to the speaker, a wired headset, or a paired Bluetooth headset. Foreground service permissions keep the mic and Bluetooth radio running while the screen is off so the room does not drop when the phone locks. Post notifications is used to show the foreground-service notification that lets you know a room is active.",
     "@privacyPolicySectionPermissionsBody": {
         "description": "Privacy policy body — permissions justification."
     },
@@ -364,7 +364,7 @@
     "@privacyPolicySectionChildrenTitle": {
         "description": "Privacy policy section title — children's privacy."
     },
-    "privacyPolicySectionChildrenBody": "Frequency captures audio. The app is targeted at users 13 and older, and we do not knowingly collect any data from children under that age.",
+    "privacyPolicySectionChildrenBody": "Frequency captures audio. The app is targeted at users 13 and older and we do not knowingly collect any data from children under that age.",
     "@privacyPolicySectionChildrenBody": {
         "description": "Privacy policy body — children's privacy."
     },
@@ -372,7 +372,7 @@
     "@privacyPolicySectionDeletionTitle": {
         "description": "Privacy policy section title — retention and deletion."
     },
-    "privacyPolicySectionDeletionBody": "There is no remote account, so there is nothing to delete from a server. To remove every piece of data the app has ever stored, open Settings → Apps → Frequency → Storage on your Android device, then tap Clear storage to wipe the app's data, or Uninstall to remove the app entirely.",
+    "privacyPolicySectionDeletionBody": "There is no remote account, so there is nothing to delete from a server. All data Frequency stores lives on your phone. To remove every piece of data the app has ever stored, open Settings → Apps → Frequency → Storage on your Android device, then tap Clear storage to wipe the app's data, or Uninstall to remove the app entirely. Uninstalling the app removes the local database, the display name, the peer ID, the recent-frequencies list, and the blocked-peers list.",
     "@privacyPolicySectionDeletionBody": {
         "description": "Privacy policy body — retention and deletion."
     },
@@ -380,7 +380,7 @@
     "@privacyPolicySectionContactTitle": {
         "description": "Privacy policy section title — how to contact the maintainers."
     },
-    "privacyPolicySectionContactBody": "Questions, concerns, or reports about Frequency's privacy practices can be filed as an issue on the project's GitHub repository at github.com/ElodinLaarz/walkie-talkie.",
+    "privacyPolicySectionContactBody": "Questions, concerns, or reports about Frequency's privacy practices can be filed as an issue on the project's GitHub repository at github.com/ElodinLaarz/walkie-talkie/issues.",
     "@privacyPolicySectionContactBody": {
         "description": "Privacy policy body — contact."
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -289,5 +289,99 @@
     "renameSheetSave": "Save",
     "@renameSheetSave": {
         "description": "Save button inside the rename bottom sheet."
+    },
+
+    "discoveryFooterPrivacy": "Privacy",
+    "@discoveryFooterPrivacy": {
+        "description": "Footer link below the discovery list — opens the in-app privacy policy screen."
+    },
+
+    "privacyPolicyEyebrow": "POLICY",
+    "@privacyPolicyEyebrow": {
+        "description": "All-caps eyebrow above the privacy policy headline."
+    },
+    "privacyPolicyHeadline": "Privacy policy",
+    "@privacyPolicyHeadline": {
+        "description": "Headline of the privacy policy screen."
+    },
+    "privacyPolicyLastUpdated": "Last updated 2026-04-30",
+    "@privacyPolicyLastUpdated": {
+        "description": "Subhead under the privacy policy headline showing when the policy was last revised. Update this date when docs/privacy-policy.md is revised."
+    },
+    "privacyPolicyClose": "Close privacy policy",
+    "@privacyPolicyClose": {
+        "description": "TalkBack/Semantics label for the close button on the privacy policy screen."
+    },
+    "privacyPolicySectionTldrTitle": "TL;DR",
+    "@privacyPolicySectionTldrTitle": {
+        "description": "Section title — short summary of the privacy policy."
+    },
+    "privacyPolicySectionTldrBody": "Frequency runs entirely on the phones in the conversation. There is no Frequency server, no cloud, no account system, no analytics SDK, and no ads. The app does not declare the INTERNET permission and cannot send your audio off-device. The only data Frequency stores lives on your phone, and uninstalling the app removes all of it.",
+    "@privacyPolicySectionTldrBody": {
+        "description": "TL;DR section body of the privacy policy."
+    },
+    "privacyPolicySectionAudioTitle": "Audio (microphone)",
+    "@privacyPolicySectionAudioTitle": {
+        "description": "Privacy policy section title — what happens to mic audio."
+    },
+    "privacyPolicySectionAudioBody": "Frequency captures audio from your phone's microphone while you are in a voice room and you are talking. The audio is encoded with Opus and streamed over a Bluetooth LE channel directly to the other phones in the same room. Audio is not recorded to disk, not sent to any server, and not retained after it has been transmitted.",
+    "@privacyPolicySectionAudioBody": {
+        "description": "Privacy policy body — audio handling."
+    },
+    "privacyPolicySectionBluetoothTitle": "Bluetooth identifiers",
+    "@privacyPolicySectionBluetoothTitle": {
+        "description": "Privacy policy section title — Bluetooth identifiers."
+    },
+    "privacyPolicySectionBluetoothBody": "To find nearby phones running Frequency the app advertises and scans for a Frequency-specific Bluetooth service UUID. While in a room your phone exchanges its Bluetooth address and a per-room session UUID with the host so packets can be routed to the right peer. Bluetooth scanning is requested with the neverForLocation flag, and Frequency does not derive your location from scan results.",
+    "@privacyPolicySectionBluetoothBody": {
+        "description": "Privacy policy body — Bluetooth identifiers."
+    },
+    "privacyPolicySectionStorageTitle": "On-device storage",
+    "@privacyPolicySectionStorageTitle": {
+        "description": "Privacy policy section title — what is stored locally."
+    },
+    "privacyPolicySectionStorageBody": "Frequency stores a small amount of data locally so it can remember you between launches: your display name, a stable peer ID generated on first launch, the most recently hosted frequencies, and any peers you have muted. This data lives in the app's private storage on your phone and is never transmitted off the device by Frequency.",
+    "@privacyPolicySectionStorageBody": {
+        "description": "Privacy policy body — on-device storage."
+    },
+    "privacyPolicySectionCrashTitle": "Crash and diagnostic data",
+    "@privacyPolicySectionCrashTitle": {
+        "description": "Privacy policy section title — crash and diagnostics."
+    },
+    "privacyPolicySectionCrashBody": "Frequency does not include any crash reporter, telemetry SDK, or analytics library. If a crash reporter is added in a future version it will be opt-in and the in-app setting will state exactly what is sent.",
+    "@privacyPolicySectionCrashBody": {
+        "description": "Privacy policy body — crash reporting."
+    },
+    "privacyPolicySectionPermissionsTitle": "Permissions",
+    "@privacyPolicySectionPermissionsTitle": {
+        "description": "Privacy policy section title — Android permissions and why each is requested."
+    },
+    "privacyPolicySectionPermissionsBody": "Bluetooth scan, connect, and advertise are required to find nearby phones, open a control connection to the host, and broadcast your own room while hosting. Microphone is required to capture your voice. Modify audio settings is used to route audio to the speaker, a wired headset, or a paired Bluetooth headset. Foreground service permissions keep the mic and Bluetooth radio running when the screen is off so the room does not drop. Post notifications shows the foreground-service notification while a room is active.",
+    "@privacyPolicySectionPermissionsBody": {
+        "description": "Privacy policy body — permissions justification."
+    },
+    "privacyPolicySectionChildrenTitle": "Children's privacy",
+    "@privacyPolicySectionChildrenTitle": {
+        "description": "Privacy policy section title — children's privacy."
+    },
+    "privacyPolicySectionChildrenBody": "Frequency captures audio. The app is targeted at users 13 and older, and we do not knowingly collect any data from children under that age.",
+    "@privacyPolicySectionChildrenBody": {
+        "description": "Privacy policy body — children's privacy."
+    },
+    "privacyPolicySectionDeletionTitle": "Data retention and deletion",
+    "@privacyPolicySectionDeletionTitle": {
+        "description": "Privacy policy section title — retention and deletion."
+    },
+    "privacyPolicySectionDeletionBody": "There is no remote account, so there is nothing to delete from a server. To remove every piece of data the app has ever stored, open Settings → Apps → Frequency → Storage on your Android device, then tap Clear storage to wipe the app's data, or Uninstall to remove the app entirely.",
+    "@privacyPolicySectionDeletionBody": {
+        "description": "Privacy policy body — retention and deletion."
+    },
+    "privacyPolicySectionContactTitle": "Contact",
+    "@privacyPolicySectionContactTitle": {
+        "description": "Privacy policy section title — how to contact the maintainers."
+    },
+    "privacyPolicySectionContactBody": "Questions, concerns, or reports about Frequency's privacy practices can be filed as an issue on the project's GitHub repository at github.com/ElodinLaarz/walkie-talkie.",
+    "@privacyPolicySectionContactBody": {
+        "description": "Privacy policy body — contact."
     }
 }

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -158,15 +158,14 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                       ),
                     ),
                   ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: 4),
                   Center(
                     child: TextButton(
                       onPressed: _openPrivacyPolicy,
                       style: TextButton.styleFrom(
-                        padding:
-                            const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                        minimumSize: const Size(0, 0),
-                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 8),
+                        minimumSize: const Size(48, 48),
                         foregroundColor: c.ink2,
                       ),
                       child: Text(

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -12,6 +12,7 @@ import '../protocol/discovery.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
 import 'frequency_explainer_screen.dart';
+import 'frequency_privacy_policy_screen.dart';
 
 class DiscoveryResult {
   final String freq;
@@ -154,6 +155,29 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                         fontFamily: 'Inter',
                         fontSize: 12,
                         color: c.ink3,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Center(
+                    child: TextButton(
+                      onPressed: _openPrivacyPolicy,
+                      style: TextButton.styleFrom(
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        minimumSize: const Size(0, 0),
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        foregroundColor: c.ink2,
+                      ),
+                      child: Text(
+                        l10n.discoveryFooterPrivacy,
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 12,
+                          color: c.ink2,
+                          decoration: TextDecoration.underline,
+                          decorationColor: c.line2,
+                        ),
                       ),
                     ),
                   ),
@@ -379,6 +403,14 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
         builder: (_) => FrequencyExplainerScreen(
           onDone: () => Navigator.of(context).pop(),
         ),
+      ),
+    );
+  }
+
+  Future<void> _openPrivacyPolicy() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => const FrequencyPrivacyPolicyScreen(),
       ),
     );
   }

--- a/lib/screens/frequency_privacy_policy_screen.dart
+++ b/lib/screens/frequency_privacy_policy_screen.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/generated/app_localizations.dart';
+import '../theme/app_theme.dart';
+import '../widgets/frequency_atoms.dart';
+
+/// Renders the Frequency privacy policy. The canonical text lives in
+/// `docs/privacy-policy.md` and is mirrored here so the in-app copy
+/// matches the public file. When you edit one, edit the other.
+class FrequencyPrivacyPolicyScreen extends StatelessWidget {
+  const FrequencyPrivacyPolicyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      backgroundColor: c.bg,
+      body: SafeArea(
+        child: Column(
+          children: [
+            FreqChrome(
+              left: const FrequencyWordmark(),
+              right: [
+                _CloseButton(
+                  semanticLabel: l10n.privacyPolicyClose,
+                  onTap: () => Navigator.of(context).maybePop(),
+                ),
+              ],
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+                children: [
+                  _Header(l10n: l10n),
+                  const SizedBox(height: 18),
+                  _Body(l10n: l10n),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final AppLocalizations l10n;
+  const _Header({required this.l10n});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.privacyPolicyEyebrow,
+          style: TextStyle(
+            fontFamily: 'Inter',
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
+            letterSpacing: 1.2,
+            color: c.ink3,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          l10n.privacyPolicyHeadline,
+          style: Theme.of(context).textTheme.displayMedium,
+        ),
+        const SizedBox(height: 10),
+        Text(
+          l10n.privacyPolicyLastUpdated,
+          style: Theme.of(context)
+              .textTheme
+              .bodySmall
+              ?.copyWith(color: c.ink3),
+        ),
+      ],
+    );
+  }
+}
+
+class _Body extends StatelessWidget {
+  final AppLocalizations l10n;
+  const _Body({required this.l10n});
+
+  @override
+  Widget build(BuildContext context) {
+    final sections = <_Section>[
+      _Section(
+        title: l10n.privacyPolicySectionTldrTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionTldrBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionAudioTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionAudioBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionBluetoothTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionBluetoothBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionStorageTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionStorageBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionCrashTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionCrashBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionPermissionsTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionPermissionsBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionChildrenTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionChildrenBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionDeletionTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionDeletionBody,
+        ],
+      ),
+      _Section(
+        title: l10n.privacyPolicySectionContactTitle,
+        paragraphs: [
+          l10n.privacyPolicySectionContactBody,
+        ],
+      ),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final s in sections) ...[
+          _SectionView(section: s),
+          const SizedBox(height: 14),
+        ],
+      ],
+    );
+  }
+}
+
+class _Section {
+  final String title;
+  final List<String> paragraphs;
+  const _Section({required this.title, required this.paragraphs});
+}
+
+class _SectionView extends StatelessWidget {
+  final _Section section;
+  const _SectionView({required this.section});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return FreqCard(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            section.title,
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: c.ink,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (int i = 0; i < section.paragraphs.length; i++) ...[
+            if (i > 0) const SizedBox(height: 8),
+            Text(
+              section.paragraphs[i],
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: c.ink2,
+                    height: 1.5,
+                  ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _CloseButton extends StatelessWidget {
+  final VoidCallback onTap;
+  final String semanticLabel;
+  const _CloseButton({required this.onTap, required this.semanticLabel});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Material(
+      color: Colors.transparent,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: 48,
+          height: 48,
+          child: Center(
+            child: Semantics(
+              button: true,
+              label: semanticLabel,
+              child: Icon(Icons.close, size: 20, color: c.ink2),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -246,6 +246,53 @@ void main() {
         expect(picked!.freq, '92.4');
       },
     );
+
+    testWidgets(
+      'tapping the footer Privacy link pushes the privacy policy screen, '
+      'and the close button pops back to Discovery',
+      (tester) async {
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+          ),
+        ));
+        await tester.pump();
+
+        // The link sits below the footer copy, so scroll the discovery
+        // ListView until the Privacy text is visible before tapping it.
+        final list = find.byType(ListView);
+        final privacyButton = find.widgetWithText(TextButton, 'Privacy');
+        await tester.dragUntilVisible(
+          privacyButton,
+          list,
+          const Offset(0, -120),
+        );
+        await tester.pump();
+        await tester.tap(privacyButton);
+        // Two pumps cover the route transition: one to start the push,
+        // one (with the settle window) to land the new page on top. We
+        // can't pumpAndSettle because Discovery's perpetual PulseDot
+        // animation never settles.
+        await tester.pump();
+        await tester.pump(_settleWindow);
+
+        // The privacy policy screen has a unique POLICY eyebrow that the
+        // discovery screen does not — anchoring on that avoids matching
+        // discovery's own "Privacy" footer link.
+        expect(find.text('POLICY'), findsOneWidget);
+        expect(find.text('Privacy policy'), findsOneWidget);
+
+        await tester.tap(find.bySemanticsLabel('Close privacy policy'));
+        await tester.pump();
+        await tester.pump(_settleWindow);
+
+        expect(find.text('POLICY'), findsNothing);
+        // We are back on Discovery, so its footer link is visible again.
+        expect(privacyButton, findsOneWidget);
+      },
+    );
   });
 
   group('DiscoveryResult invariants', () {

--- a/test/screens/frequency_privacy_policy_screen_test.dart
+++ b/test/screens/frequency_privacy_policy_screen_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/l10n/generated/app_localizations.dart';
+import 'package:walkie_talkie/screens/frequency_privacy_policy_screen.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: AppTheme.light(),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: child,
+  );
+}
+
+void main() {
+  group('FrequencyPrivacyPolicyScreen', () {
+    testWidgets('renders headline, eyebrow, and last-updated stamp',
+        (tester) async {
+      await tester
+          .pumpWidget(_wrap(const FrequencyPrivacyPolicyScreen()));
+
+      expect(find.text('Privacy policy'), findsOneWidget);
+      expect(find.text('POLICY'), findsOneWidget);
+      expect(find.textContaining('Last updated'), findsOneWidget);
+    });
+
+    testWidgets('renders all required Play Console policy sections',
+        (tester) async {
+      await tester
+          .pumpWidget(_wrap(const FrequencyPrivacyPolicyScreen()));
+
+      // Scroll through to make sure every section is built.
+      final list = find.byType(ListView);
+      expect(list, findsOneWidget);
+      await tester.dragUntilVisible(
+        find.text('Contact'),
+        list,
+        const Offset(0, -200),
+      );
+
+      for (final title in const [
+        'TL;DR',
+        'Audio (microphone)',
+        'Bluetooth identifiers',
+        'On-device storage',
+        'Crash and diagnostic data',
+        'Permissions',
+        "Children's privacy",
+        'Data retention and deletion',
+        'Contact',
+      ]) {
+        expect(find.text(title), findsOneWidget,
+            reason: 'Missing required policy section: $title');
+      }
+    });
+
+    testWidgets('close button pops the screen', (tester) async {
+      await tester.pumpWidget(_wrap(Builder(builder: (context) {
+        return Scaffold(
+          body: Center(
+            child: Builder(builder: (innerContext) {
+              return ElevatedButton(
+                onPressed: () => Navigator.of(innerContext).push(
+                  MaterialPageRoute(
+                    builder: (_) => const FrequencyPrivacyPolicyScreen(),
+                  ),
+                ),
+                child: const Text('open'),
+              );
+            }),
+          ),
+        );
+      })));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(find.byType(FrequencyPrivacyPolicyScreen), findsOneWidget);
+
+      await tester.tap(find.bySemanticsLabel('Close privacy policy'));
+      await tester.pumpAndSettle();
+      expect(find.byType(FrequencyPrivacyPolicyScreen), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Closes #111.

## Summary

- New `docs/privacy-policy.md` — Play-Console-ready policy text: what data is processed (mic audio, BT identifiers, on-device storage), permissions justification, no analytics / no crash reporter, retention/deletion via Uninstall, contact via GitHub Issues.
- New `FrequencyPrivacyPolicyScreen` mirrors the policy section-by-section using the existing `FreqChrome`/`FreqCard` atoms — no new deps, no markdown parser; the in-app copy is kept in sync with the `.md` file by hand (a comment on the screen calls out the dual-edit rule).
- Discovery footer gets a small "Privacy" link below the existing "Bluetooth LE Audio · No internet required" line so users can reach the policy before any Settings screen exists. The dedicated Settings screen will move/duplicate the link when #121 lands.
- Every user-visible string was added to `lib/l10n/app_en.arb` so the policy is ready for translation when other locales come online.

## Acceptance criteria from #111

- [x] Policy file lives at a stable URL once GitHub Pages renders `/docs` (the file is the source; hosting setup is a separate ops task).
- [x] In-app entry point opens the policy (Discovery → "Privacy" footer link).
- [x] Play Console listing prep (#126) can reference the GH Pages URL once published.

## What is intentionally not in this PR

- No new package dependency. Markdown rendering would require `flutter_markdown` (~ +1 dep) or asset loading; for v1 the policy is short enough to hand-render with the existing atoms, and reviewers can diff the screen against the canonical `.md` directly.
- No Settings screen entry point — that lives in #121. The Discovery footer link is the v1 touchpoint.
- No GitHub Pages workflow change — the repo can either be configured to publish from `/docs` in the existing repo settings (one-click) or via a new workflow in a follow-up.

## Test plan

- [x] `flutter analyze` — no issues.
- [x] `flutter test` — all 460 tests pass, including the new `frequency_privacy_policy_screen_test.dart` (header + every required policy section + close-button pop behaviour).
- [ ] Manual smoke (reviewer): Discovery → tap "Privacy" → confirm every section renders + close arrow returns to Discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app privacy policy accessible from the discovery screen with a close control and scrollable, sectioned content including “Last updated.”

* **Documentation**
  * Full privacy policy added covering offline/peer-to-peer behavior, microphone handling, Bluetooth identifiers, on-device storage, permissions, children’s privacy, deletion, and contact.

* **Localization**
  * English UI strings added for the discovery link and complete policy screen.

* **Tests**
  * Widget tests for discovery footer navigation and privacy screen content/close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->