### PR TITLE
feat(#125): Frequency naming + pinning — extend recents store + Discovery UI

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1311,9 +1311,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// Failures from the store are logged and swallowed so the user isn't
   /// blocked on a transient sqlite error; the in-memory state is rolled
   /// back to whatever the next read sees by re-loading the list.
+  ///
+  /// `myName` is read from the **latest** [SessionDiscovery] right
+  /// before emit (not from a snapshot taken before the awaits) so a
+  /// concurrent [rename] landing during the sqlite round-trip can't be
+  /// silently clobbered by a stale name.
   Future<void> setRecentNickname(String freq, String? nickname) async {
-    final current = state;
-    if (current is! SessionDiscovery) return;
+    if (state is! SessionDiscovery) return;
     try {
       await recentFrequenciesStore.setNickname(freq, nickname);
     } catch (error, stackTrace) {
@@ -1323,19 +1327,20 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     final refreshed = await _loadRecentFrequencies();
     if (isClosed) return;
-    if (state is! SessionDiscovery) return;
+    final latest = state;
+    if (latest is! SessionDiscovery) return;
     emit(SessionDiscovery(
-      myName: current.myName,
+      myName: latest.myName,
       recentHostedFrequencies: refreshed,
     ));
   }
 
   /// Pins or unpins [freq] in the persisted recents, then re-emits
   /// [SessionDiscovery] so the Discovery list resorts (pinned rows float
-  /// to the top). Same scope and failure behavior as [setRecentNickname].
+  /// to the top). Same scope, failure, and rename-race semantics as
+  /// [setRecentNickname].
   Future<void> setRecentPinned(String freq, bool pinned) async {
-    final current = state;
-    if (current is! SessionDiscovery) return;
+    if (state is! SessionDiscovery) return;
     try {
       await recentFrequenciesStore.setPinned(freq, pinned);
     } catch (error, stackTrace) {
@@ -1345,9 +1350,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     final refreshed = await _loadRecentFrequencies();
     if (isClosed) return;
-    if (state is! SessionDiscovery) return;
+    final latest = state;
+    if (latest is! SessionDiscovery) return;
     emit(SessionDiscovery(
-      myName: current.myName,
+      myName: latest.myName,
       recentHostedFrequencies: refreshed,
     ));
   }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1283,9 +1283,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     await _permissionWatcher?.checkNow();
   }
 
-  Future<List<String>> _loadRecentFrequencies() async {
+  Future<List<RecentFrequency>> _loadRecentFrequencies() async {
     try {
-      return await recentFrequenciesStore.getRecent();
+      return await recentFrequenciesStore.getRecentDetailed();
     } catch (error, stackTrace) {
       if (kDebugMode) debugPrint('Failed to load recent frequencies: $error');
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
@@ -1300,6 +1300,56 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       if (kDebugMode) debugPrint('Failed to record recent frequency: $error');
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
     }
+  }
+
+  /// Persists [nickname] (or clears it when null/empty) for the recent
+  /// frequency [freq], then re-emits [SessionDiscovery] so the Discovery
+  /// list updates without waiting for a leave/rejoin to refresh state.
+  /// No-op when the cubit is not in [SessionDiscovery] — naming a recent
+  /// only makes sense from the screen that renders them.
+  ///
+  /// Failures from the store are logged and swallowed so the user isn't
+  /// blocked on a transient sqlite error; the in-memory state is rolled
+  /// back to whatever the next read sees by re-loading the list.
+  Future<void> setRecentNickname(String freq, String? nickname) async {
+    final current = state;
+    if (current is! SessionDiscovery) return;
+    try {
+      await recentFrequenciesStore.setNickname(freq, nickname);
+    } catch (error, stackTrace) {
+      if (kDebugMode) debugPrint('Failed to set recent nickname: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+    }
+    if (isClosed) return;
+    final refreshed = await _loadRecentFrequencies();
+    if (isClosed) return;
+    if (state is! SessionDiscovery) return;
+    emit(SessionDiscovery(
+      myName: current.myName,
+      recentHostedFrequencies: refreshed,
+    ));
+  }
+
+  /// Pins or unpins [freq] in the persisted recents, then re-emits
+  /// [SessionDiscovery] so the Discovery list resorts (pinned rows float
+  /// to the top). Same scope and failure behavior as [setRecentNickname].
+  Future<void> setRecentPinned(String freq, bool pinned) async {
+    final current = state;
+    if (current is! SessionDiscovery) return;
+    try {
+      await recentFrequenciesStore.setPinned(freq, pinned);
+    } catch (error, stackTrace) {
+      if (kDebugMode) debugPrint('Failed to set recent pinned: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+    }
+    if (isClosed) return;
+    final refreshed = await _loadRecentFrequencies();
+    if (isClosed) return;
+    if (state is! SessionDiscovery) return;
+    emit(SessionDiscovery(
+      myName: current.myName,
+      recentHostedFrequencies: refreshed,
+    ));
   }
 
   /// Apply a `JoinAccepted` from the host. Replaces the room's snapshot

--- a/lib/bloc/frequency_session_state.dart
+++ b/lib/bloc/frequency_session_state.dart
@@ -3,6 +3,7 @@ import 'package:equatable/equatable.dart';
 import '../protocol/messages.dart';
 import '../protocol/peer.dart';
 import '../services/permission_watcher.dart';
+import '../services/recent_frequencies_store.dart';
 
 /// Sentinel marking an argument-not-supplied position in `copyWith`. A
 /// caller passing `null` explicitly is distinguishable from omitting
@@ -36,16 +37,18 @@ final class SessionOnboarding extends FrequencySessionState {
 /// User has a persisted display name and is on Discovery, but hasn't
 /// joined or created a frequency yet.
 ///
-/// [recentHostedFrequencies] is the most-recent-first list of channels
-/// the local user has hosted on this device, sourced from
-/// `RecentFrequenciesStore`. Empty when the user hasn't hosted before
-/// or the persisted store couldn't be read. The list is expected to
-/// already be unmodifiable (Equatable diffs it element-wise, so a
-/// caller mutating it in place would silently break state-change
-/// detection).
+/// [recentHostedFrequencies] is the pinned-first then most-recent-first
+/// list of channels the local user has hosted on this device, sourced
+/// from `RecentFrequenciesStore`. Each entry carries the freq itself
+/// plus the user-curated nickname / pin metadata so the Discovery row
+/// can render a label and a pin affordance without a follow-up read.
+/// Empty when the user hasn't hosted before or the persisted store
+/// couldn't be read. The list is expected to already be unmodifiable
+/// (Equatable diffs it element-wise, so a caller mutating it in place
+/// would silently break state-change detection).
 final class SessionDiscovery extends FrequencySessionState {
   final String myName;
-  final List<String> recentHostedFrequencies;
+  final List<RecentFrequency> recentHostedFrequencies;
   const SessionDiscovery({
     required this.myName,
     this.recentHostedFrequencies = const [],

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -277,6 +277,49 @@
     "@discoveryRecentRowResume": {
         "description": "Action button — re-host this previously-used freq."
     },
+    "discoveryRecentRowMenuTooltip": "Recent options",
+    "@discoveryRecentRowMenuTooltip": {
+        "description": "TalkBack/long-press tooltip on the per-row overflow (three-dot) menu in the Recent list — opens a popup with rename and pin actions."
+    },
+    "discoveryRecentMenuRename": "Rename",
+    "@discoveryRecentMenuRename": {
+        "description": "Item in the per-row Recent overflow menu — opens the nickname bottom sheet."
+    },
+    "discoveryRecentMenuPin": "Pin to top",
+    "@discoveryRecentMenuPin": {
+        "description": "Item in the per-row Recent overflow menu when the row is currently unpinned — pinning floats it above unpinned rows and exempts it from the rolling cap."
+    },
+    "discoveryRecentMenuUnpin": "Unpin",
+    "@discoveryRecentMenuUnpin": {
+        "description": "Item in the per-row Recent overflow menu when the row is currently pinned — removes the pin and re-subjects the row to the rolling cap."
+    },
+    "discoveryRecentPinnedBadge": "PINNED",
+    "@discoveryRecentPinnedBadge": {
+        "description": "Small all-caps eyebrow shown next to the title of a pinned recent row — a redundant cue alongside the pin glyph in the row's icon disc."
+    },
+    "discoveryRecentNicknameSheetTitle": "Nickname this channel",
+    "@discoveryRecentNicknameSheetTitle": {
+        "description": "Heading inside the bottom sheet that lets the user assign or change a nickname for one of their recent frequencies."
+    },
+    "discoveryRecentNicknameSheetSubtitle": "Shown only on your device, on the Recent row for {freq} MHz.",
+    "@discoveryRecentNicknameSheetSubtitle": {
+        "description": "Subhead inside the recent-nickname bottom sheet. {freq} is the recent frequency the nickname will apply to (rendered mono-styled). The subhead reassures the user that the nickname is local — it doesn't propagate to peers in the room.",
+        "placeholders": {
+            "freq": { "type": "String", "example": "92.5" }
+        }
+    },
+    "discoveryRecentNicknameHint": "e.g. Family channel",
+    "@discoveryRecentNicknameHint": {
+        "description": "Placeholder text inside the recent-nickname text field — suggests the kind of label the user might pick."
+    },
+    "discoveryRecentNicknameSheetSave": "Save",
+    "@discoveryRecentNicknameSheetSave": {
+        "description": "Save button inside the recent-nickname bottom sheet."
+    },
+    "discoveryRecentNicknameSheetClear": "Remove nickname",
+    "@discoveryRecentNicknameSheetClear": {
+        "description": "Secondary action inside the recent-nickname bottom sheet — only shown when the row already has a nickname. Clears the existing nickname so the row falls back to the default 'Your channel' label."
+    },
 
     "renameSheetTitle": "Your handle",
     "@renameSheetTitle": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -219,6 +219,12 @@ class FrequencyApp extends StatelessWidget {
           onRename: (name) {
             cubit.rename(name);
           },
+          onSetRecentNickname: (freq, nickname) {
+            unawaited(cubit.setRecentNickname(freq, nickname));
+          },
+          onSetRecentPinned: (freq, pinned) {
+            unawaited(cubit.setRecentPinned(freq, pinned));
+          },
           // joinRoom is a Future<void> now that it persists; the cubit
           // tolerates a fire-and-forget call (the user has already
           // committed to entering the room).

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -738,11 +738,9 @@ class _PinnedBadge extends StatelessWidget {
 }
 
 /// Overflow menu attached to a recent row. Renders a `PopupMenuButton`
-/// keyed by `Key('recent-menu-${entry.freq}')` so widget tests can target
-/// a specific row's menu without hunting for the icon. Items are
-/// conditionally included based on which callbacks the parent supplied —
-/// a row that opts into rename only (or pin only) doesn't get a stub
-/// "no-op" entry.
+/// whose items are conditionally included based on which callbacks the
+/// parent supplied — a row that opts into rename only (or pin only)
+/// doesn't get a stub "no-op" entry.
 class _RecentRowMenu extends StatelessWidget {
   final bool pinned;
   final VoidCallback? onRename;

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -9,6 +9,7 @@ import '../bloc/discovery_state.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../l10n/styled_template.dart';
 import '../protocol/discovery.dart';
+import '../services/recent_frequencies_store.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
 import 'frequency_explainer_screen.dart';
@@ -57,12 +58,24 @@ class FrequencyDiscoveryScreen extends StatefulWidget {
   /// confirms an edit in the rename sheet.
   final ValueChanged<String> onRename;
 
-  /// Most-recent-first list of frequencies the local user has hosted on
-  /// this device. Surfaced as a "Recent" section so the user can re-host
-  /// a personal channel with one tap instead of accepting whichever
-  /// random frequency the create card happens to have minted this visit.
-  /// Empty (the default) hides the section entirely.
-  final List<String> recentHostedFrequencies;
+  /// Pinned-first then most-recent-first list of frequencies the local
+  /// user has hosted on this device. Surfaced as a "Recent" section so
+  /// the user can re-host a personal channel with one tap instead of
+  /// accepting whichever random frequency the create card happens to
+  /// have minted this visit. Each entry carries an optional nickname
+  /// and a `pinned` flag so the row can render a label and a pin
+  /// affordance. Empty (the default) hides the section entirely.
+  final List<RecentFrequency> recentHostedFrequencies;
+
+  /// Persists a nickname change for a recent frequency. Pass `null` (or an
+  /// empty string, which the store normalizes to null) to clear the
+  /// nickname so the row falls back to the default `discoveryRecentRowTitle`
+  /// label. No-op when the freq isn't already in the persisted list.
+  final void Function(String freq, String? nickname)? onSetRecentNickname;
+
+  /// Persists a pin/unpin toggle for a recent frequency. Pinned rows float
+  /// to the top of the list and are exempt from the cap.
+  final void Function(String freq, bool pinned)? onSetRecentPinned;
 
   const FrequencyDiscoveryScreen({
     super.key,
@@ -70,6 +83,8 @@ class FrequencyDiscoveryScreen extends StatefulWidget {
     required this.myName,
     required this.onRename,
     this.recentHostedFrequencies = const [],
+    this.onSetRecentNickname,
+    this.onSetRecentPinned,
   });
 
   @override
@@ -340,19 +355,54 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
         children: [
           for (int i = 0; i < widget.recentHostedFrequencies.length; i++)
             _RecentRow(
-              key: ValueKey('recent-${widget.recentHostedFrequencies[i]}'),
-              freq: widget.recentHostedFrequencies[i],
+              // Key on freq alone — nickname / pinned can change without
+              // the row identity changing, so the framework can reuse the
+              // same Element and animate the label / pin badge in place.
+              key: ValueKey('recent-${widget.recentHostedFrequencies[i].freq}'),
+              entry: widget.recentHostedFrequencies[i],
               first: i == 0,
               accent: c.accentSoft,
               accentInk: c.accentInk,
               onResume: () => widget.onPick(DiscoveryResult(
-                freq: widget.recentHostedFrequencies[i],
+                freq: widget.recentHostedFrequencies[i].freq,
                 isHost: true,
               )),
+              onRename: widget.onSetRecentNickname == null
+                  ? null
+                  : () => _openRecentNicknameSheet(
+                        widget.recentHostedFrequencies[i],
+                      ),
+              onTogglePin: widget.onSetRecentPinned == null
+                  ? null
+                  : () => widget.onSetRecentPinned!(
+                        widget.recentHostedFrequencies[i].freq,
+                        !widget.recentHostedFrequencies[i].pinned,
+                      ),
             ),
         ],
       ),
     );
+  }
+
+  /// Bottom-sheet entry point for editing the nickname of a recent
+  /// frequency. Returns through `_RecentNicknameSheet`'s pop value, which
+  /// signals one of three intents: a new label to set, an explicit clear
+  /// of an existing label, or a cancel (no callback fired).
+  Future<void> _openRecentNicknameSheet(RecentFrequency entry) async {
+    final c = FrequencyTheme.of(context).colors;
+    final result = await showModalBottomSheet<_NicknameSheetResult>(
+      context: context,
+      backgroundColor: c.bg,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => _RecentNicknameSheet(entry: entry),
+    );
+    if (result == null) return;
+    final cb = widget.onSetRecentNickname;
+    if (cb == null) return;
+    cb(entry.freq, result.nickname);
   }
 
   Widget _buildNearbyList(BuildContext context) {
@@ -521,26 +571,38 @@ class _NearbyRow extends StatelessWidget {
 /// language (icon disc + title + freq mono), but the trailing affordance
 /// is a "Resume" hint instead of signal bars + selection state since
 /// recents are a one-tap action with no per-row sub-selection.
+///
+/// When [onRename] / [onTogglePin] are provided, an overflow menu
+/// appears between the title and the Resume button so the user can
+/// name or pin the recent without leaving Discovery. Both callbacks
+/// are nullable so test fixtures (and any embedding that doesn't wire
+/// up persistence) can render the row without inventing no-op handlers.
 class _RecentRow extends StatelessWidget {
-  final String freq;
+  final RecentFrequency entry;
   final bool first;
   final Color accent;
   final Color accentInk;
   final VoidCallback onResume;
+  final VoidCallback? onRename;
+  final VoidCallback? onTogglePin;
 
   const _RecentRow({
     super.key,
-    required this.freq,
+    required this.entry,
     required this.first,
     required this.accent,
     required this.accentInk,
     required this.onResume,
+    this.onRename,
+    this.onTogglePin,
   });
 
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
     final l10n = AppLocalizations.of(context);
+    final hasMenu = onRename != null || onTogglePin != null;
+    final title = entry.nickname ?? l10n.discoveryRecentRowTitle;
     return Material(
       color: c.surface,
       child: InkWell(
@@ -562,21 +624,41 @@ class _RecentRow extends StatelessWidget {
                   borderRadius: BorderRadius.circular(10),
                 ),
                 alignment: Alignment.center,
-                child: Icon(Icons.history, size: 16, color: accentInk),
+                // Pinned rows trade the generic history glyph for a pin
+                // so the user can tell at a glance which recents are
+                // user-curated vs auto-recorded.
+                child: Icon(
+                  entry.pinned ? Icons.push_pin : Icons.history,
+                  size: 16,
+                  color: accentInk,
+                ),
               ),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      l10n.discoveryRecentRowTitle,
-                      style: TextStyle(
-                        fontFamily: 'Inter',
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
-                        color: c.ink,
-                      ),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Flexible(
+                          child: Text(
+                            title,
+                            style: TextStyle(
+                              fontFamily: 'Inter',
+                              fontSize: 14,
+                              fontWeight: FontWeight.w500,
+                              color: c.ink,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        if (entry.pinned) ...[
+                          const SizedBox(width: 6),
+                          _PinnedBadge(),
+                        ],
+                      ],
                     ),
                     // Text.rich (rather than a Row of Texts) so the
                     // freq + unit string can ellipsize gracefully when
@@ -591,7 +673,7 @@ class _RecentRow extends StatelessWidget {
                         ),
                         children: styledTemplate(
                           template: l10n.discoveryRecentRowHostFreq,
-                          value: freq,
+                          value: entry.freq,
                           valueStyle: kMonoStyle.copyWith(fontSize: 12),
                         ),
                       ),
@@ -601,7 +683,15 @@ class _RecentRow extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(width: 8),
+              if (hasMenu) ...[
+                const SizedBox(width: 4),
+                _RecentRowMenu(
+                  pinned: entry.pinned,
+                  onRename: onRename,
+                  onTogglePin: onTogglePin,
+                ),
+              ],
+              const SizedBox(width: 4),
               FreqButton(
                 accent: true,
                 label: l10n.discoveryRecentRowResume,
@@ -613,6 +703,251 @@ class _RecentRow extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Compact "PINNED" eyebrow shown next to the title of a pinned recent
+/// row. Pinned items already lead with a pin icon in the disc, so this
+/// is a redundant cue rather than the only one — it exists for users
+/// who skim row titles rather than glyphs.
+class _PinnedBadge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: c.accentSoft,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        l10n.discoveryRecentPinnedBadge,
+        style: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 9,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.6,
+          color: c.accentInk,
+        ),
+      ),
+    );
+  }
+}
+
+/// Overflow menu attached to a recent row. Renders a `PopupMenuButton`
+/// keyed by `Key('recent-menu-${entry.freq}')` so widget tests can target
+/// a specific row's menu without hunting for the icon. Items are
+/// conditionally included based on which callbacks the parent supplied —
+/// a row that opts into rename only (or pin only) doesn't get a stub
+/// "no-op" entry.
+class _RecentRowMenu extends StatelessWidget {
+  final bool pinned;
+  final VoidCallback? onRename;
+  final VoidCallback? onTogglePin;
+
+  const _RecentRowMenu({
+    required this.pinned,
+    required this.onRename,
+    required this.onTogglePin,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    return PopupMenuButton<_RecentRowMenuAction>(
+      tooltip: l10n.discoveryRecentRowMenuTooltip,
+      icon: Icon(Icons.more_vert, size: 18, color: c.ink2),
+      itemBuilder: (_) => [
+        if (onRename != null)
+          PopupMenuItem<_RecentRowMenuAction>(
+            value: _RecentRowMenuAction.rename,
+            child: Text(l10n.discoveryRecentMenuRename),
+          ),
+        if (onTogglePin != null)
+          PopupMenuItem<_RecentRowMenuAction>(
+            value: _RecentRowMenuAction.togglePin,
+            child: Text(
+              pinned
+                  ? l10n.discoveryRecentMenuUnpin
+                  : l10n.discoveryRecentMenuPin,
+            ),
+          ),
+      ],
+      onSelected: (action) {
+        switch (action) {
+          case _RecentRowMenuAction.rename:
+            onRename?.call();
+          case _RecentRowMenuAction.togglePin:
+            onTogglePin?.call();
+        }
+      },
+    );
+  }
+}
+
+enum _RecentRowMenuAction { rename, togglePin }
+
+/// Result of [_RecentNicknameSheet]'s submission. Wrapped in a class
+/// rather than passing a bare `String?` because a null pop value already
+/// means "user dismissed without saving" — we need a third state to
+/// distinguish "user cleared the existing nickname" from "user closed
+/// the sheet."
+class _NicknameSheetResult {
+  /// New nickname to persist, or `null` to clear an existing one. The
+  /// store treats `null` and empty/whitespace-only equivalently, but the
+  /// sheet sends `null` explicitly so the intent is unambiguous.
+  final String? nickname;
+
+  const _NicknameSheetResult(this.nickname);
+}
+
+/// Bottom sheet for editing the nickname of a recent frequency. Same
+/// visual language as [_RenameSheet] (the identity rename), but with a
+/// secondary "Clear" affordance so a user with an existing nickname can
+/// remove it without typing in an empty string and tapping Save.
+class _RecentNicknameSheet extends StatefulWidget {
+  final RecentFrequency entry;
+  const _RecentNicknameSheet({required this.entry});
+
+  @override
+  State<_RecentNicknameSheet> createState() => _RecentNicknameSheetState();
+}
+
+class _RecentNicknameSheetState extends State<_RecentNicknameSheet> {
+  late final TextEditingController _ctrl =
+      TextEditingController(text: widget.entry.nickname ?? '');
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final n = _ctrl.text.trim();
+    // An empty submission collapses to "clear the nickname" — the same
+    // intent as tapping the Clear button. Pop with an explicit null so
+    // the parent's "user closed the sheet" branch (also null) doesn't
+    // fire instead.
+    Navigator.pop(
+      context,
+      n.isEmpty ? const _NicknameSheetResult(null) : _NicknameSheetResult(n),
+    );
+  }
+
+  void _clear() {
+    Navigator.pop(context, const _NicknameSheetResult(null));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    final hasExistingNickname = widget.entry.nickname != null;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        20,
+        8,
+        20,
+        MediaQuery.of(context).viewInsets.bottom + 28,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(top: 8, bottom: 14),
+              decoration: BoxDecoration(
+                color: c.line2,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+          ),
+          Text(
+            l10n.discoveryRecentNicknameSheetTitle,
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: c.ink,
+            ),
+          ),
+          Text.rich(
+            TextSpan(
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 12,
+                color: c.ink3,
+              ),
+              children: styledTemplate(
+                template: l10n.discoveryRecentNicknameSheetSubtitle,
+                value: widget.entry.freq,
+                valueStyle: kMonoStyle.copyWith(fontSize: 12),
+              ),
+            ),
+          ),
+          const SizedBox(height: 18),
+          FreqCard(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            child: TextField(
+              controller: _ctrl,
+              autofocus: true,
+              maxLength: 24,
+              onChanged: (_) => setState(() {}),
+              onSubmitted: (_) => _submit(),
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 17,
+                fontWeight: FontWeight.w500,
+                color: c.ink,
+              ),
+              decoration: InputDecoration(
+                isDense: true,
+                counterText: '',
+                border: InputBorder.none,
+                hintText: l10n.discoveryRecentNicknameHint,
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          PrimaryButton(
+            label: l10n.discoveryRecentNicknameSheetSave,
+            block: true,
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            fontSize: 15,
+            onPressed: _submit,
+          ),
+          if (hasExistingNickname) ...[
+            const SizedBox(height: 8),
+            Center(
+              child: TextButton(
+                onPressed: _clear,
+                style: TextButton.styleFrom(
+                  foregroundColor: c.ink2,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 10,
+                  ),
+                ),
+                child: Text(
+                  l10n.discoveryRecentNicknameSheetClear,
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 13,
+                    color: c.ink2,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -13,10 +13,11 @@ class RecentFrequency {
   /// `recent_frequencies` table.
   final String freq;
 
-  /// Optional user-supplied label. `null` (and only `null`) means "no
-  /// nickname set" — the empty string would round-trip as a stored value
-  /// and shadow the freq in the UI, so callers that want to clear the
-  /// nickname must pass `null`, not `""`.
+  /// Optional user-supplied label. `null` means "no nickname set". On the
+  /// read side, `null` is the only "cleared" sentinel — the store
+  /// normalizes blank labels to `null` on write (see
+  /// [RecentFrequenciesStore.setNickname]), so a row will never surface
+  /// here with an empty string.
   final String? nickname;
 
   /// Whether the user has pinned this freq. Pinned rows render with a pin
@@ -143,26 +144,30 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
   @override
   Future<List<RecentFrequency>> getRecentDetailed() async {
     final db = await WalkieTalkieDatabase.open();
-    // Pinned rows always sit above unpinned rows (`pinned DESC` puts the
-    // 1s before the 0s); within each group the most-recent host wins.
-    // Unpinned rows are capped at `maxEntries`; pinned rows are user-
-    // curated and exempt — see the comments on [record] for why a
-    // capped pin would feel arbitrary to the user.
-    final pinned = await db.query(
+    // Single snapshot query: pinned rows sit above unpinned rows
+    // (`pinned DESC` puts the 1s before the 0s); within each group the
+    // most-recent host wins. The unpinned cap is applied in-memory
+    // because sqlite has no `LIMIT` that's conditional on a column —
+    // splitting into two queries would race with concurrent
+    // [record] / [setPinned] calls and let a row disappear from the
+    // combined list (or land in the wrong half) if a flag flipped
+    // between the reads.
+    final rows = await db.query(
       _table,
       columns: ['freq', 'nickname', 'pinned'],
-      where: 'pinned = 1',
-      orderBy: 'recorded_at DESC',
+      orderBy: 'pinned DESC, recorded_at DESC',
     );
-    final unpinned = await db.query(
-      _table,
-      columns: ['freq', 'nickname', 'pinned'],
-      where: 'pinned = 0',
-      orderBy: 'recorded_at DESC',
-      limit: RecentFrequenciesStore.maxEntries,
-    );
-    final rows = [...pinned, ...unpinned];
-    return List<RecentFrequency>.unmodifiable(rows.map(_rowToRecent));
+    final result = <RecentFrequency>[];
+    var unpinnedCount = 0;
+    for (final row in rows) {
+      final recent = _rowToRecent(row);
+      if (!recent.pinned) {
+        if (unpinnedCount >= RecentFrequenciesStore.maxEntries) continue;
+        unpinnedCount++;
+      }
+      result.add(recent);
+    }
+    return List<RecentFrequency>.unmodifiable(result);
   }
 
   RecentFrequency _rowToRecent(Map<String, Object?> r) {

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -1,3 +1,5 @@
+import 'package:sqflite/sqflite.dart' show Transaction;
+
 import 'walkie_talkie_database.dart';
 
 /// One persisted "recent" entry — the freq itself plus the user-curated
@@ -212,26 +214,32 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
         ''',
         [trimmed, orderingTimestamp],
       );
-      // Cap: keep only the top-N UNPINNED by recorded_at. NOT IN with a
-      // top-N sub-select is one round-trip and the table is bounded to
-      // ~maxEntries + however many pins the user has set, so the scan
-      // cost is trivial. Pinned rows are excluded from both the keep set
-      // and the delete predicate so they stick around regardless of how
-      // many fresh records arrive.
-      await txn.execute(
-        '''
-        DELETE FROM $_table
-        WHERE pinned = 0
-          AND freq NOT IN (
-            SELECT freq FROM $_table
-            WHERE pinned = 0
-            ORDER BY recorded_at DESC
-            LIMIT ?
-          )
-        ''',
-        [RecentFrequenciesStore.maxEntries],
-      );
+      await _capUnpinnedRows(txn);
     });
+  }
+
+  /// Keeps only the top-`maxEntries` UNPINNED rows by `recorded_at`. Both
+  /// [_doRecord] and [_doSetPinned] (on unpin) need to enforce this
+  /// invariant — the helper is here so the SQL lives in one place. NOT
+  /// IN with a top-N sub-select is one round-trip and the table is
+  /// bounded to ~maxEntries + however many pins the user has set, so
+  /// the scan cost is trivial. Pinned rows are excluded from both the
+  /// keep set and the delete predicate so they stick around regardless
+  /// of how many fresh records arrive.
+  Future<void> _capUnpinnedRows(Transaction txn) async {
+    await txn.execute(
+      '''
+      DELETE FROM $_table
+      WHERE pinned = 0
+        AND freq NOT IN (
+          SELECT freq FROM $_table
+          WHERE pinned = 0
+          ORDER BY recorded_at DESC
+          LIMIT ?
+        )
+      ''',
+      [RecentFrequenciesStore.maxEntries],
+    );
   }
 
   @override
@@ -291,19 +299,7 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
       // already unpinned, is documented as a no-op and shouldn't trigger
       // a defensive evict.
       if (!pinned && affected > 0) {
-        await txn.execute(
-          '''
-          DELETE FROM $_table
-          WHERE pinned = 0
-            AND freq NOT IN (
-              SELECT freq FROM $_table
-              WHERE pinned = 0
-              ORDER BY recorded_at DESC
-              LIMIT ?
-            )
-          ''',
-          [RecentFrequenciesStore.maxEntries],
-        );
+        await _capUnpinnedRows(txn);
       }
     });
   }

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -272,7 +272,7 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
     if (trimmedFreq.isEmpty) return;
     final db = await WalkieTalkieDatabase.open();
     await db.transaction((txn) async {
-      await txn.update(
+      final affected = await txn.update(
         _table,
         {'pinned': pinned ? 1 : 0},
         where: 'freq = ?',
@@ -285,7 +285,12 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
       // bucket stays bounded — without this, the next [getRecentDetailed]
       // would silently truncate in-memory but the on-disk row would
       // linger forever.
-      if (!pinned) {
+      //
+      // Only run the cap when the UPDATE actually changed a row — calling
+      // `setPinned(false)` for an unknown freq, or for a freq that was
+      // already unpinned, is documented as a no-op and shouldn't trigger
+      // a defensive evict.
+      if (!pinned && affected > 0) {
         await txn.execute(
           '''
           DELETE FROM $_table

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -271,12 +271,36 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
     final trimmedFreq = freq.trim();
     if (trimmedFreq.isEmpty) return;
     final db = await WalkieTalkieDatabase.open();
-    await db.update(
-      _table,
-      {'pinned': pinned ? 1 : 0},
-      where: 'freq = ?',
-      whereArgs: [trimmedFreq],
-    );
+    await db.transaction((txn) async {
+      await txn.update(
+        _table,
+        {'pinned': pinned ? 1 : 0},
+        where: 'freq = ?',
+        whereArgs: [trimmedFreq],
+      );
+      // Unpinning can push the unpinned-row count past `maxEntries`: the
+      // pinned row was exempt from the cap, so dropping its exemption can
+      // leave the table with more unpinned rows than [record] would ever
+      // allow. Re-run the same cap query [_doRecord] uses so the unpinned
+      // bucket stays bounded — without this, the next [getRecentDetailed]
+      // would silently truncate in-memory but the on-disk row would
+      // linger forever.
+      if (!pinned) {
+        await txn.execute(
+          '''
+          DELETE FROM $_table
+          WHERE pinned = 0
+            AND freq NOT IN (
+              SELECT freq FROM $_table
+              WHERE pinned = 0
+              ORDER BY recorded_at DESC
+              LIMIT ?
+            )
+          ''',
+          [RecentFrequenciesStore.maxEntries],
+        );
+      }
+    });
   }
 
   @override

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -1,6 +1,49 @@
-import 'package:sqflite/sqflite.dart';
-
 import 'walkie_talkie_database.dart';
+
+/// One persisted "recent" entry — the freq itself plus the user-curated
+/// nickname and pin state added in the #125 naming/pinning sub-feature.
+///
+/// Pinned entries float to the top of the Discovery list and are exempt
+/// from the rolling cap so a user-curated pin can't be quietly evicted by
+/// hosting a few new channels. Nickname is purely a display label on the
+/// row — joining behavior is unaffected (the freq is still the
+/// authoritative key the room is dialed on).
+class RecentFrequency {
+  /// The MHz string the user hosted, e.g. `"92.4"`. PRIMARY KEY in the
+  /// `recent_frequencies` table.
+  final String freq;
+
+  /// Optional user-supplied label. `null` (and only `null`) means "no
+  /// nickname set" — the empty string would round-trip as a stored value
+  /// and shadow the freq in the UI, so callers that want to clear the
+  /// nickname must pass `null`, not `""`.
+  final String? nickname;
+
+  /// Whether the user has pinned this freq. Pinned rows render with a pin
+  /// affordance, sort above unpinned rows, and survive the rolling cap
+  /// applied during [RecentFrequenciesStore.record].
+  final bool pinned;
+
+  const RecentFrequency({
+    required this.freq,
+    this.nickname,
+    this.pinned = false,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is RecentFrequency &&
+      other.freq == freq &&
+      other.nickname == nickname &&
+      other.pinned == pinned;
+
+  @override
+  int get hashCode => Object.hash(freq, nickname, pinned);
+
+  @override
+  String toString() =>
+      'RecentFrequency(freq: $freq, nickname: $nickname, pinned: $pinned)';
+}
 
 /// Persisted "frequencies the local user has hosted" list, most-recent
 /// first, capped at [RecentFrequenciesStore.maxEntries]. Lets the
@@ -13,21 +56,54 @@ import 'walkie_talkie_database.dart';
 /// them in one box would conflate "rename me" with "forget my channel
 /// history".
 abstract class RecentFrequenciesStore {
-  /// Cap on retained entries. The Discovery screen renders all of them
-  /// inline, so the bound is a UX choice rather than a storage one.
+  /// Cap on retained **unpinned** entries. Pinned entries are user-curated
+  /// and exempt — the cap exists so the auto-recorded list of "channels I
+  /// happened to host" can't grow without bound, not to evict things the
+  /// user explicitly asked us to remember. The Discovery screen renders
+  /// every row inline, so the bound is a UX choice rather than a storage
+  /// one.
   static const int maxEntries = 5;
 
-  /// Returns the persisted list, most-recent first. Empty when nothing
-  /// has been recorded yet. The returned list is unmodifiable; callers
-  /// that need to mutate must copy.
+  /// Returns the persisted list as bare freq strings, pinned-first then
+  /// most-recent first within each group. Empty when nothing has been
+  /// recorded yet. The returned list is unmodifiable; callers that need to
+  /// mutate must copy.
+  ///
+  /// Equivalent to projecting [getRecentDetailed] onto its `freq` column —
+  /// kept as the back-compat surface for callers that don't need the
+  /// nickname / pinned metadata. The cubit + Discovery screen use
+  /// [getRecentDetailed] instead so the row UI can render a pin affordance
+  /// and a nickname label.
   Future<List<String>> getRecent();
+
+  /// Returns the persisted list as full [RecentFrequency] records, pinned
+  /// rows first (most-recent within pinned), then unpinned rows by
+  /// recorded_at DESC. Empty when nothing has been recorded yet. The
+  /// returned list is unmodifiable.
+  Future<List<RecentFrequency>> getRecentDetailed();
 
   /// Records [freq] as the most-recent host frequency. Trims; an empty
   /// or whitespace-only value is ignored. Existing entries equal to the
-  /// trimmed value are de-duplicated (the entry moves to the front
-  /// rather than being added a second time). The list is capped at
-  /// [maxEntries] — older entries roll off the end.
+  /// trimmed value are de-duplicated (the entry's recorded_at is bumped
+  /// to "now" rather than inserting a second row), and any nickname /
+  /// pinned state already on the row is preserved — re-hosting a channel
+  /// you've nicknamed or pinned must not silently strip the metadata.
+  /// Unpinned entries past [maxEntries] roll off; pinned entries are
+  /// exempt from the cap.
   Future<void> record(String freq);
+
+  /// Sets (or clears, when [nickname] is `null`) the display label for
+  /// [freq]. No-op when [freq] hasn't been recorded yet — nicknames
+  /// belong to existing rows and there's no creation side-effect (the
+  /// Discovery UI surfaces this option only on rendered rows). Trims
+  /// non-null nicknames; an empty / whitespace-only nickname is treated
+  /// as a clear so callers don't accidentally store a blank label that
+  /// would render as zero-width text.
+  Future<void> setNickname(String freq, String? nickname);
+
+  /// Pins or unpins [freq]. No-op when [freq] hasn't been recorded yet,
+  /// for the same reason as [setNickname].
+  Future<void> setPinned(String freq, bool pinned);
 
   /// Drops every persisted entry. The next [getRecent] returns empty.
   Future<void> clear();
@@ -36,18 +112,19 @@ abstract class RecentFrequenciesStore {
 /// sqflite-backed [RecentFrequenciesStore]. Schema: one row per freq with
 /// a sortable `recorded_at` derived from epoch milliseconds (see
 /// [_nextOrderingTimestamp] — it's `(epochMs << 16) + seqWithinMs`, not raw
-/// epoch ms); ordering is by `recorded_at DESC`. We dedupe on `freq`
-/// (PRIMARY KEY) so re-recording the same channel just bumps its ordering
-/// timestamp instead of inserting a duplicate.
+/// epoch ms); ordering is pinned-first then by `recorded_at DESC`. We
+/// dedupe on `freq` (PRIMARY KEY) so re-recording the same channel just
+/// bumps its ordering timestamp instead of inserting a duplicate, and
+/// preserves any `nickname` / `pinned` state already on the row.
 class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
   static const String _table = 'recent_frequencies';
 
-  /// Serializes [record] against itself. Each call chains onto the
-  /// previous, so two concurrent records can't both observe the same
-  /// pre-write state and last-write-wins one of them out of the list.
-  /// Errors on the chain are swallowed for the purpose of *chaining*
-  /// only — the original future still surfaces the failure to its
-  /// caller (and the cubit logs + drops it).
+  /// Serializes [record] / [setNickname] / [setPinned] / [clear] against
+  /// each other. Each call chains onto the previous, so two concurrent
+  /// writers can't both observe the same pre-write state and last-write-
+  /// wins one of them. Errors on the chain are swallowed for the purpose
+  /// of *chaining* only — the original future still surfaces the failure
+  /// to its caller (and the cubit logs + drops it).
   Future<void> _writeChain = Future.value();
 
   /// Monotonic counter so two `record` calls in the same millisecond still
@@ -59,15 +136,47 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
 
   @override
   Future<List<String>> getRecent() async {
+    final detailed = await getRecentDetailed();
+    return List<String>.unmodifiable(detailed.map((e) => e.freq));
+  }
+
+  @override
+  Future<List<RecentFrequency>> getRecentDetailed() async {
     final db = await WalkieTalkieDatabase.open();
-    final rows = await db.query(
+    // Pinned rows always sit above unpinned rows (`pinned DESC` puts the
+    // 1s before the 0s); within each group the most-recent host wins.
+    // Unpinned rows are capped at `maxEntries`; pinned rows are user-
+    // curated and exempt — see the comments on [record] for why a
+    // capped pin would feel arbitrary to the user.
+    final pinned = await db.query(
       _table,
-      columns: ['freq'],
+      columns: ['freq', 'nickname', 'pinned'],
+      where: 'pinned = 1',
+      orderBy: 'recorded_at DESC',
+    );
+    final unpinned = await db.query(
+      _table,
+      columns: ['freq', 'nickname', 'pinned'],
+      where: 'pinned = 0',
       orderBy: 'recorded_at DESC',
       limit: RecentFrequenciesStore.maxEntries,
     );
-    return List<String>.unmodifiable(
-      rows.map((r) => r['freq']).whereType<String>(),
+    final rows = [...pinned, ...unpinned];
+    return List<RecentFrequency>.unmodifiable(rows.map(_rowToRecent));
+  }
+
+  RecentFrequency _rowToRecent(Map<String, Object?> r) {
+    final rawNickname = r['nickname'] as String?;
+    return RecentFrequency(
+      freq: r['freq']! as String,
+      // NULL stays null; an empty string in storage (shouldn't happen via
+      // [setNickname], but defend against legacy data) is normalized to
+      // null so the UI's "render label or fall back" branch lines up with
+      // "no nickname set" semantics.
+      nickname: (rawNickname == null || rawNickname.isEmpty)
+          ? null
+          : rawNickname,
+      pinned: (r['pinned'] as int? ?? 0) != 0,
     );
   }
 
@@ -84,26 +193,36 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
     final db = await WalkieTalkieDatabase.open();
     final orderingTimestamp = _nextOrderingTimestamp();
     await db.transaction((txn) async {
-      // Upsert keyed on freq: same freq → bump recorded_at (move to front);
-      // new freq → insert. ConflictAlgorithm.replace preserves the row's
-      // primary key (freq) so the in-place bump is visible to the next
-      // ORDER BY recorded_at DESC.
-      await txn.insert(
-        _table,
-        {'freq': trimmed, 'recorded_at': orderingTimestamp},
-        conflictAlgorithm: ConflictAlgorithm.replace,
+      // Upsert keyed on freq: same freq → bump recorded_at (move to front
+      // of its group), preserving any nickname / pinned the user has
+      // already set; new freq → insert with no nickname and unpinned.
+      // ConflictAlgorithm.replace would wipe nickname + pinned, so use a
+      // sqlite UPSERT (INSERT ... ON CONFLICT DO UPDATE) that touches
+      // only `recorded_at` on conflict.
+      await txn.rawInsert(
+        '''
+        INSERT INTO $_table (freq, recorded_at, nickname, pinned)
+        VALUES (?, ?, NULL, 0)
+        ON CONFLICT(freq) DO UPDATE SET recorded_at = excluded.recorded_at
+        ''',
+        [trimmed, orderingTimestamp],
       );
-      // Cap: keep only the top-N by recorded_at. NOT IN with a top-N
-      // sub-select is one round-trip and the table is bounded to ~maxEntries
-      // so the scan cost is trivial.
+      // Cap: keep only the top-N UNPINNED by recorded_at. NOT IN with a
+      // top-N sub-select is one round-trip and the table is bounded to
+      // ~maxEntries + however many pins the user has set, so the scan
+      // cost is trivial. Pinned rows are excluded from both the keep set
+      // and the delete predicate so they stick around regardless of how
+      // many fresh records arrive.
       await txn.execute(
         '''
         DELETE FROM $_table
-        WHERE freq NOT IN (
-          SELECT freq FROM $_table
-          ORDER BY recorded_at DESC
-          LIMIT ?
-        )
+        WHERE pinned = 0
+          AND freq NOT IN (
+            SELECT freq FROM $_table
+            WHERE pinned = 0
+            ORDER BY recorded_at DESC
+            LIMIT ?
+          )
         ''',
         [RecentFrequenciesStore.maxEntries],
       );
@@ -111,7 +230,58 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
   }
 
   @override
+  Future<void> setNickname(String freq, String? nickname) {
+    final next = _writeChain.then((_) => _doSetNickname(freq, nickname));
+    _writeChain = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _doSetNickname(String freq, String? nickname) async {
+    final trimmedFreq = freq.trim();
+    if (trimmedFreq.isEmpty) return;
+    // Trim a non-null nickname; an empty/whitespace-only nickname collapses
+    // to null so the UI's "fall back to default label" branch fires
+    // instead of rendering a zero-width nickname.
+    final normalized = nickname?.trim();
+    final value = (normalized == null || normalized.isEmpty)
+        ? null
+        : normalized;
+    final db = await WalkieTalkieDatabase.open();
+    await db.update(
+      _table,
+      {'nickname': value},
+      where: 'freq = ?',
+      whereArgs: [trimmedFreq],
+    );
+  }
+
+  @override
+  Future<void> setPinned(String freq, bool pinned) {
+    final next = _writeChain.then((_) => _doSetPinned(freq, pinned));
+    _writeChain = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _doSetPinned(String freq, bool pinned) async {
+    final trimmedFreq = freq.trim();
+    if (trimmedFreq.isEmpty) return;
+    final db = await WalkieTalkieDatabase.open();
+    await db.update(
+      _table,
+      {'pinned': pinned ? 1 : 0},
+      where: 'freq = ?',
+      whereArgs: [trimmedFreq],
+    );
+  }
+
+  @override
   Future<void> clear() async {
+    final next = _writeChain.then((_) => _doClear());
+    _writeChain = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _doClear() async {
     final db = await WalkieTalkieDatabase.open();
     await db.delete(_table);
   }

--- a/lib/services/walkie_talkie_database.dart
+++ b/lib/services/walkie_talkie_database.dart
@@ -165,4 +165,15 @@ class WalkieTalkieDatabase {
       await db.close();
     }
   }
+
+  /// Test seam: drop the FFI factory + path overrides so a later test
+  /// that doesn't install one falls back to the platform default. Without
+  /// this, the override leaks process-wide and a later test relying on
+  /// the real factory either picks up the previous test's path or fails
+  /// because the FFI factory isn't available on its platform.
+  @visibleForTesting
+  static void clearDatabaseFactoryOverride() {
+    _factoryOverride = null;
+    _pathOverride = null;
+  }
 }

--- a/lib/services/walkie_talkie_database.dart
+++ b/lib/services/walkie_talkie_database.dart
@@ -14,9 +14,11 @@ class WalkieTalkieDatabase {
 
   static const String _dbName = 'walkie_talkie.db';
   // v2 (2026-04): added `blocked_peers` for #125 (persistent block list).
-  // Existing v1 installs hit `_onUpgrade` which CREATE TABLE IF NOT EXISTS
-  // the new table without touching any data the user already has.
-  static const int _dbVersion = 2;
+  // v3 (2026-04): added `nickname` + `pinned` to `recent_frequencies` for
+  // the #125 naming/pinning sub-feature. Existing rows get `nickname=NULL`
+  // and `pinned=0`, so the legacy unpinned-most-recent-first ordering is
+  // unchanged for users who upgrade with no pinned entries.
+  static const int _dbVersion = 3;
 
   static DatabaseFactory? _factoryOverride;
   static String? _pathOverride;
@@ -75,7 +77,9 @@ class WalkieTalkieDatabase {
     await db.execute('''
       CREATE TABLE recent_frequencies (
         freq TEXT PRIMARY KEY NOT NULL,
-        recorded_at INTEGER NOT NULL
+        recorded_at INTEGER NOT NULL,
+        nickname TEXT,
+        pinned INTEGER NOT NULL DEFAULT 0
       )
     ''');
     await db.execute(
@@ -95,6 +99,31 @@ class WalkieTalkieDatabase {
   ) async {
     if (oldVersion < 2) {
       await _createBlockedPeersTable(db);
+    }
+    if (oldVersion < 3) {
+      await _addRecentFrequenciesNicknameAndPinned(db);
+    }
+  }
+
+  /// Adds the v3 `nickname` (TEXT, NULL for "no nickname set") and `pinned`
+  /// (INTEGER, 0/1 boolean — sqlite has no native bool) columns to
+  /// `recent_frequencies`. `IF NOT EXISTS` guards each ALTER so re-running
+  /// the migration on an install that's already at v3 (manual migration
+  /// scripts, partial upgrades) is a no-op rather than a hard error.
+  static Future<void> _addRecentFrequenciesNicknameAndPinned(
+    Database db,
+  ) async {
+    final cols = await db.rawQuery('PRAGMA table_info(recent_frequencies)');
+    final existing = cols.map((r) => r['name'] as String?).toSet();
+    if (!existing.contains('nickname')) {
+      await db.execute(
+        'ALTER TABLE recent_frequencies ADD COLUMN nickname TEXT',
+      );
+    }
+    if (!existing.contains('pinned')) {
+      await db.execute(
+        'ALTER TABLE recent_frequencies ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0',
+      );
     }
   }
 

--- a/lib/services/walkie_talkie_database.dart
+++ b/lib/services/walkie_talkie_database.dart
@@ -107,9 +107,12 @@ class WalkieTalkieDatabase {
 
   /// Adds the v3 `nickname` (TEXT, NULL for "no nickname set") and `pinned`
   /// (INTEGER, 0/1 boolean — sqlite has no native bool) columns to
-  /// `recent_frequencies`. `IF NOT EXISTS` guards each ALTER so re-running
-  /// the migration on an install that's already at v3 (manual migration
-  /// scripts, partial upgrades) is a no-op rather than a hard error.
+  /// `recent_frequencies`. sqlite has no `ALTER TABLE … ADD COLUMN IF NOT
+  /// EXISTS`, so each ALTER is gated by a `PRAGMA table_info` check that
+  /// skips the statement when the column is already present — the migration
+  /// stays a no-op on installs that have already been upgraded (manual
+  /// migration scripts, partial upgrades) instead of throwing
+  /// `duplicate column` and stranding the user.
   static Future<void> _addRecentFrequenciesNicknameAndPinned(
     Database db,
   ) async {

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1060,6 +1060,38 @@ void main() {
     );
 
     test(
+      'setRecentPinned swallows store failures and still completes',
+      () async {
+        // Same failure-path coverage as the setRecentNickname test —
+        // user has already committed the toggle from the UI; a disk
+        // hiccup must not bubble up as an unhandled async error.
+        final recent = _FakeRecentFrequenciesStore(
+          initial: const ['100.1'],
+        )..throwOnSetPinned = true;
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+        );
+        await cubit.bootstrap();
+
+        await expectLater(
+          cubit.setRecentPinned('100.1', true),
+          completes,
+        );
+
+        // Pin write failed → on-disk row stays unpinned, and the
+        // cubit's reload reflects the on-disk truth.
+        final after = cubit.state as SessionDiscovery;
+        expect(after.recentHostedFrequencies.single.freq, '100.1');
+        expect(after.recentHostedFrequencies.single.pinned, isFalse);
+        // Exactly one attempt — the cubit doesn't retry past the failure.
+        expect(recent.setPinnedCalls, 1);
+
+        await cubit.close();
+      },
+    );
+
+    test(
       'setRecentPinned is a no-op outside Discovery',
       () async {
         final recent = _FakeRecentFrequenciesStore();

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -1001,12 +1001,20 @@ void main() {
     );
 
     test(
-      'setRecentPinned(false) demotes a previously-pinned row',
+      'setRecentPinned(false) demotes a previously-pinned row to its real recency position',
       () async {
+        // Seed order (newest → oldest): 100.1, 88.7, 92.4-pinned. The pin
+        // floats 92.4 to the top in the list view, but its underlying
+        // recordedAt is the oldest. After unpinning, 92.4 must land at
+        // the *bottom*, behind 100.1 and 88.7 — not stick at the top
+        // just because it used to be pinned. Asserting `every (!pinned)`
+        // alone would have passed even if the demotion logic were wrong;
+        // assert the full ordering instead.
         final recent = _FakeRecentFrequenciesStore(
           detailed: const [
-            RecentFrequency(freq: '92.4', pinned: true),
             RecentFrequency(freq: '100.1'),
+            RecentFrequency(freq: '88.7'),
+            RecentFrequency(freq: '92.4', pinned: true),
           ],
         );
         final cubit = _makeCubit(
@@ -1015,10 +1023,23 @@ void main() {
         );
         await cubit.bootstrap();
 
+        // Pre-condition: pin floats 92.4 to the top.
+        var s = cubit.state as SessionDiscovery;
+        expect(
+          s.recentHostedFrequencies.map((e) => e.freq).toList(),
+          ['92.4', '100.1', '88.7'],
+        );
+
         await cubit.setRecentPinned('92.4', false);
 
-        final s = cubit.state as SessionDiscovery;
+        s = cubit.state as SessionDiscovery;
         expect(s.recentHostedFrequencies.every((e) => !e.pinned), isTrue);
+        // 92.4 demotes to its real recency position (oldest), so the
+        // unpinned-by-recency order is 100.1, 88.7, 92.4.
+        expect(
+          s.recentHostedFrequencies.map((e) => e.freq).toList(),
+          ['100.1', '88.7', '92.4'],
+        );
 
         await cubit.close();
       },

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -173,6 +173,20 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
     // Intentionally do NOT touch recordedAt — unpinning should demote a
     // row back to its real recency position relative to other unpinned
     // rows, matching the production store's `recorded_at`-driven order.
+    //
+    // Mirror production's cap-on-unpin: pinning exempts a row from the
+    // cap, so unpinning can push the unpinned bucket past maxEntries.
+    // Drop the oldest unpinned rows so the fake doesn't silently let
+    // tests drift past the on-disk semantics.
+    if (!pinned) {
+      final unpinnedSorted = _rows.where((r) => !r.entry.pinned).toList()
+        ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+      final toDrop = unpinnedSorted
+          .skip(RecentFrequenciesStore.maxEntries)
+          .map((r) => r.entry.freq)
+          .toSet();
+      _rows.removeWhere((r) => toDrop.contains(r.entry.freq));
+    }
   }
 
   @override

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -49,18 +49,36 @@ class _FakeStore implements IdentityStore {
 }
 
 class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
-  final List<String> _entries;
+  final List<RecentFrequency> _entries;
   bool throwOnGet = false;
   bool throwOnRecord = false;
+  bool throwOnSetNickname = false;
+  bool throwOnSetPinned = false;
   int recordCalls = 0;
+  int setNicknameCalls = 0;
+  int setPinnedCalls = 0;
 
-  _FakeRecentFrequenciesStore({List<String>? initial})
-      : _entries = List<String>.of(initial ?? const []);
+  _FakeRecentFrequenciesStore({
+    List<String>? initial,
+    List<RecentFrequency>? detailed,
+  }) : _entries = List<RecentFrequency>.of(
+          detailed ??
+              (initial ?? const <String>[])
+                  .map((f) => RecentFrequency(freq: f)),
+        );
 
   @override
   Future<List<String>> getRecent() async {
+    final detailed = await getRecentDetailed();
+    return List<String>.unmodifiable(detailed.map((e) => e.freq));
+  }
+
+  @override
+  Future<List<RecentFrequency>> getRecentDetailed() async {
     if (throwOnGet) throw StateError('boom');
-    return List<String>.unmodifiable(_entries);
+    final pinned = _entries.where((e) => e.pinned).toList();
+    final unpinned = _entries.where((e) => !e.pinned).toList();
+    return List<RecentFrequency>.unmodifiable([...pinned, ...unpinned]);
   }
 
   @override
@@ -69,17 +87,49 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
     if (throwOnRecord) throw StateError('boom');
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
-    _entries
-      ..remove(trimmed)
-      ..insert(0, trimmed);
-    // Mirror the production cap so the fake doesn't silently let tests
-    // drift past behavior the real store enforces.
-    if (_entries.length > RecentFrequenciesStore.maxEntries) {
-      _entries.removeRange(
-        RecentFrequenciesStore.maxEntries,
-        _entries.length,
-      );
+    final existingIdx = _entries.indexWhere((e) => e.freq == trimmed);
+    final existing =
+        existingIdx >= 0 ? _entries.removeAt(existingIdx) : null;
+    _entries.insert(0, existing ?? RecentFrequency(freq: trimmed));
+    // Mirror the production cap on UNPINNED entries so the fake doesn't
+    // silently let tests drift past the behavior the real store enforces;
+    // pinned entries are exempt from the cap (#125).
+    final unpinned = _entries.where((e) => !e.pinned).toList();
+    if (unpinned.length > RecentFrequenciesStore.maxEntries) {
+      final toDrop = unpinned
+          .skip(RecentFrequenciesStore.maxEntries)
+          .map((e) => e.freq)
+          .toSet();
+      _entries.removeWhere((e) => toDrop.contains(e.freq));
     }
+  }
+
+  @override
+  Future<void> setNickname(String freq, String? nickname) async {
+    setNicknameCalls++;
+    if (throwOnSetNickname) throw StateError('boom');
+    final idx = _entries.indexWhere((e) => e.freq == freq);
+    if (idx < 0) return;
+    final trimmed = nickname?.trim();
+    final value = (trimmed == null || trimmed.isEmpty) ? null : trimmed;
+    _entries[idx] = RecentFrequency(
+      freq: _entries[idx].freq,
+      nickname: value,
+      pinned: _entries[idx].pinned,
+    );
+  }
+
+  @override
+  Future<void> setPinned(String freq, bool pinned) async {
+    setPinnedCalls++;
+    if (throwOnSetPinned) throw StateError('boom');
+    final idx = _entries.indexWhere((e) => e.freq == freq);
+    if (idx < 0) return;
+    _entries[idx] = RecentFrequency(
+      freq: _entries[idx].freq,
+      nickname: _entries[idx].nickname,
+      pinned: pinned,
+    );
   }
 
   @override
@@ -607,9 +657,12 @@ void main() {
       ),
       act: (cubit) => cubit.bootstrap(),
       expect: () => [
-        const SessionDiscovery(
+        SessionDiscovery(
           myName: 'Maya',
-          recentHostedFrequencies: ['100.1', '92.4'],
+          recentHostedFrequencies: const [
+            RecentFrequency(freq: '100.1'),
+            RecentFrequency(freq: '92.4'),
+          ],
         ),
       ],
     );
@@ -648,9 +701,11 @@ void main() {
       seed: () => const SessionOnboarding(),
       act: (cubit) => cubit.completeOnboarding('Devon'),
       expect: () => [
-        const SessionDiscovery(
+        SessionDiscovery(
           myName: 'Devon',
-          recentHostedFrequencies: ['92.4'],
+          recentHostedFrequencies: const [
+            RecentFrequency(freq: '92.4'),
+          ],
         ),
       ],
     );
@@ -663,15 +718,21 @@ void main() {
       build: () => _makeCubit(
         identityStore: _FakeStore(initial: 'Maya'),
       ),
-      seed: () => const SessionDiscovery(
+      seed: () => SessionDiscovery(
         myName: 'Maya',
-        recentHostedFrequencies: ['100.1', '92.4'],
+        recentHostedFrequencies: const [
+          RecentFrequency(freq: '100.1'),
+          RecentFrequency(freq: '92.4'),
+        ],
       ),
       act: (cubit) => cubit.rename('Maya R.'),
       expect: () => [
-        const SessionDiscovery(
+        SessionDiscovery(
           myName: 'Maya R.',
-          recentHostedFrequencies: ['100.1', '92.4'],
+          recentHostedFrequencies: const [
+            RecentFrequency(freq: '100.1'),
+            RecentFrequency(freq: '92.4'),
+          ],
         ),
       ],
     );
@@ -751,11 +812,192 @@ void main() {
       ),
       act: (cubit) => cubit.leaveRoom(),
       expect: () => [
-        const SessionDiscovery(
+        SessionDiscovery(
           myName: 'Maya',
-          recentHostedFrequencies: ['104.3', '92.4'],
+          recentHostedFrequencies: const [
+            RecentFrequency(freq: '104.3'),
+            RecentFrequency(freq: '92.4'),
+          ],
         ),
       ],
+    );
+
+    // ── Recent-frequencies naming + pinning (#125) ─────────────────────
+
+    test(
+      'setRecentNickname persists the nickname and re-emits Discovery',
+      () async {
+        final recent = _FakeRecentFrequenciesStore(
+          initial: const ['100.1'],
+        );
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+        );
+        await cubit.bootstrap();
+
+        await cubit.setRecentNickname('100.1', '  Family channel  ');
+
+        expect(recent.setNicknameCalls, 1);
+        final s = cubit.state as SessionDiscovery;
+        expect(s.recentHostedFrequencies, [
+          // The fake mirrors the production trim/normalize, so the
+          // surfaced state already shows the trimmed nickname.
+          const RecentFrequency(
+            freq: '100.1',
+            nickname: 'Family channel',
+          ),
+        ]);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'setRecentNickname with null clears an existing nickname',
+      () async {
+        final recent = _FakeRecentFrequenciesStore(
+          detailed: const [
+            RecentFrequency(freq: '100.1', nickname: 'Family channel'),
+          ],
+        );
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+        );
+        await cubit.bootstrap();
+
+        await cubit.setRecentNickname('100.1', null);
+
+        final s = cubit.state as SessionDiscovery;
+        expect(s.recentHostedFrequencies.single.nickname, isNull);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'setRecentNickname is a no-op outside Discovery',
+      () async {
+        final recent = _FakeRecentFrequenciesStore();
+        final cubit = _makeCubit(recentFrequenciesStore: recent);
+        cubit.emit(const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: true,
+        ));
+
+        await cubit.setRecentNickname('104.3', 'Whatever');
+
+        // The store is never touched — naming a recent only makes sense
+        // from the screen that renders the recents list.
+        expect(recent.setNicknameCalls, 0);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'setRecentNickname swallows store failures and still completes',
+      () async {
+        final recent = _FakeRecentFrequenciesStore(
+          initial: const ['100.1'],
+        )..throwOnSetNickname = true;
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+        );
+        await cubit.bootstrap();
+
+        // The user has already committed the action from the UI; a disk
+        // hiccup must not bubble up as an unhandled async error.
+        await expectLater(
+          cubit.setRecentNickname('100.1', 'Family channel'),
+          completes,
+        );
+
+        // The persisted nickname remained absent (write failed) — the
+        // cubit's reload reflects the on-disk truth.
+        final after = cubit.state as SessionDiscovery;
+        expect(after.recentHostedFrequencies.single.freq, '100.1');
+        expect(after.recentHostedFrequencies.single.nickname, isNull);
+        // The setNickname call was attempted exactly once — the cubit
+        // didn't retry past the failure.
+        expect(recent.setNicknameCalls, 1);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'setRecentPinned floats the pinned row to the top and re-emits Discovery',
+      () async {
+        final recent = _FakeRecentFrequenciesStore(
+          initial: const ['100.1', '92.4', '88.7'],
+        );
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+        );
+        await cubit.bootstrap();
+
+        await cubit.setRecentPinned('92.4', true);
+
+        expect(recent.setPinnedCalls, 1);
+        final s = cubit.state as SessionDiscovery;
+        // Pinned row floats above the unpinned rows; relative order
+        // among the unpinned rows is preserved.
+        expect(
+          s.recentHostedFrequencies.map((e) => e.freq).toList(),
+          ['92.4', '100.1', '88.7'],
+        );
+        expect(s.recentHostedFrequencies.first.pinned, isTrue);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'setRecentPinned(false) demotes a previously-pinned row',
+      () async {
+        final recent = _FakeRecentFrequenciesStore(
+          detailed: const [
+            RecentFrequency(freq: '92.4', pinned: true),
+            RecentFrequency(freq: '100.1'),
+          ],
+        );
+        final cubit = _makeCubit(
+          identityStore: _FakeStore(initial: 'Maya'),
+          recentFrequenciesStore: recent,
+        );
+        await cubit.bootstrap();
+
+        await cubit.setRecentPinned('92.4', false);
+
+        final s = cubit.state as SessionDiscovery;
+        expect(s.recentHostedFrequencies.every((e) => !e.pinned), isTrue);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'setRecentPinned is a no-op outside Discovery',
+      () async {
+        final recent = _FakeRecentFrequenciesStore();
+        final cubit = _makeCubit(recentFrequenciesStore: recent);
+        cubit.emit(const SessionRoom(
+          myName: 'Maya',
+          roomFreq: '104.3',
+          roomIsHost: true,
+        ));
+
+        await cubit.setRecentPinned('104.3', true);
+
+        expect(recent.setPinnedCalls, 0);
+
+        await cubit.close();
+      },
     );
 
     // ── Wire-protocol surface ──────────────────────────────────────────
@@ -2610,7 +2852,8 @@ void main() {
         final s = cubit.state;
         expect(s, isA<SessionDiscovery>());
         expect((s as SessionDiscovery).myName, 'Maya');
-        expect(s.recentHostedFrequencies, ['100.1']);
+        expect(s.recentHostedFrequencies.map((e) => e.freq).toList(),
+            ['100.1']);
 
         await cubit.close();
         await watcher.dispose();
@@ -2755,8 +2998,8 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         expect(cubit.state, isA<SessionPermissionDenied>());
 
-        // Wedge the next getRecent call so recovery's await blocks.
-        final blocker = Completer<List<String>>();
+        // Wedge the next getRecentDetailed call so recovery's await blocks.
+        final blocker = Completer<List<RecentFrequency>>();
         recent.gate = blocker.future;
 
         // User re-grants — recovery starts and awaits the slow disk read.
@@ -3278,19 +3521,26 @@ void main() {
   });
 }
 
-/// RecentFrequenciesStore whose `getRecent()` blocks on a caller-supplied
-/// future, letting a test wedge an awaiting cubit method mid-await to
-/// exercise races against state transitions that fire during the gap.
+/// RecentFrequenciesStore whose `getRecentDetailed()` blocks on a
+/// caller-supplied future, letting a test wedge an awaiting cubit method
+/// mid-await to exercise races against state transitions that fire
+/// during the gap.
 ///
 /// The first call always resolves immediately (so bootstrap can finish)
 /// and only later calls block. Tests that want to wedge mid-recovery set
 /// the gate before triggering the recovery path.
 class _GatedRecentFrequenciesStore implements RecentFrequenciesStore {
-  Future<List<String>>? gate;
+  Future<List<RecentFrequency>>? gate;
   int callCount = 0;
 
   @override
   Future<List<String>> getRecent() async {
+    final detailed = await getRecentDetailed();
+    return detailed.map((e) => e.freq).toList();
+  }
+
+  @override
+  Future<List<RecentFrequency>> getRecentDetailed() async {
     callCount++;
     final g = gate;
     if (g == null) return const [];
@@ -3299,6 +3549,12 @@ class _GatedRecentFrequenciesStore implements RecentFrequenciesStore {
 
   @override
   Future<void> record(String freq) async {}
+
+  @override
+  Future<void> setNickname(String freq, String? nickname) async {}
+
+  @override
+  Future<void> setPinned(String freq, bool pinned) async {}
 
   @override
   Future<void> clear() async {}

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -48,8 +48,21 @@ class _FakeStore implements IdentityStore {
   }
 }
 
+/// Internal row carrying the public [RecentFrequency] plus a synthetic
+/// `recordedAt` ordering key. Mirrors the real store's `(epochMs << 16) +
+/// seqWithinMs` sort key so flipping `pinned` doesn't change the row's
+/// recency — and unpinning a row demotes it back to its real recency
+/// position relative to other unpinned rows, the way the production
+/// store does.
+class _FakeRecentRow {
+  RecentFrequency entry;
+  int recordedAt;
+  _FakeRecentRow(this.entry, this.recordedAt);
+}
+
 class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
-  final List<RecentFrequency> _entries;
+  final List<_FakeRecentRow> _rows;
+  int _nextRecordedAt;
   bool throwOnGet = false;
   bool throwOnRecord = false;
   bool throwOnSetNickname = false;
@@ -61,11 +74,17 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
   _FakeRecentFrequenciesStore({
     List<String>? initial,
     List<RecentFrequency>? detailed,
-  }) : _entries = List<RecentFrequency>.of(
-          detailed ??
-              (initial ?? const <String>[])
-                  .map((f) => RecentFrequency(freq: f)),
-        );
+  })  : _rows = [],
+        _nextRecordedAt = 0 {
+    final seed = detailed ??
+        (initial ?? const <String>[]).map((f) => RecentFrequency(freq: f));
+    // Seed with descending recordedAt so the first item in the supplied
+    // list is the most-recent (matches how callers think of recents).
+    final asList = seed.toList();
+    for (var i = asList.length - 1; i >= 0; i--) {
+      _rows.add(_FakeRecentRow(asList[i], _nextRecordedAt++));
+    }
+  }
 
   @override
   Future<List<String>> getRecent() async {
@@ -76,9 +95,26 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
   @override
   Future<List<RecentFrequency>> getRecentDetailed() async {
     if (throwOnGet) throw StateError('boom');
-    final pinned = _entries.where((e) => e.pinned).toList();
-    final unpinned = _entries.where((e) => !e.pinned).toList();
-    return List<RecentFrequency>.unmodifiable([...pinned, ...unpinned]);
+    // Pinned-first then recordedAt DESC, mirroring the production
+    // `ORDER BY pinned DESC, recorded_at DESC`. Cap unpinned at
+    // maxEntries; pinned rows are exempt (#125).
+    final sorted = [..._rows]
+      ..sort((a, b) {
+        if (a.entry.pinned != b.entry.pinned) {
+          return a.entry.pinned ? -1 : 1;
+        }
+        return b.recordedAt.compareTo(a.recordedAt);
+      });
+    final result = <RecentFrequency>[];
+    var unpinnedCount = 0;
+    for (final row in sorted) {
+      if (!row.entry.pinned) {
+        if (unpinnedCount >= RecentFrequenciesStore.maxEntries) continue;
+        unpinnedCount++;
+      }
+      result.add(row.entry);
+    }
+    return List<RecentFrequency>.unmodifiable(result);
   }
 
   @override
@@ -87,35 +123,39 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
     if (throwOnRecord) throw StateError('boom');
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
-    final existingIdx = _entries.indexWhere((e) => e.freq == trimmed);
-    final existing =
-        existingIdx >= 0 ? _entries.removeAt(existingIdx) : null;
-    _entries.insert(0, existing ?? RecentFrequency(freq: trimmed));
-    // Mirror the production cap on UNPINNED entries so the fake doesn't
-    // silently let tests drift past the behavior the real store enforces;
-    // pinned entries are exempt from the cap (#125).
-    final unpinned = _entries.where((e) => !e.pinned).toList();
-    if (unpinned.length > RecentFrequenciesStore.maxEntries) {
-      final toDrop = unpinned
-          .skip(RecentFrequenciesStore.maxEntries)
-          .map((e) => e.freq)
-          .toSet();
-      _entries.removeWhere((e) => toDrop.contains(e.freq));
+    final existing = _rows.firstWhere(
+      (r) => r.entry.freq == trimmed,
+      orElse: () => _FakeRecentRow(RecentFrequency(freq: trimmed), -1),
+    );
+    if (existing.recordedAt < 0) {
+      _rows.add(_FakeRecentRow(existing.entry, _nextRecordedAt++));
+    } else {
+      // Bump the existing row's recordedAt; nickname + pinned preserved
+      // so re-recording a curated entry doesn't silently strip metadata.
+      existing.recordedAt = _nextRecordedAt++;
     }
+    // Mirror the production cap on UNPINNED entries; pinned rows exempt.
+    final unpinnedSorted = _rows.where((r) => !r.entry.pinned).toList()
+      ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+    final toDrop = unpinnedSorted
+        .skip(RecentFrequenciesStore.maxEntries)
+        .map((r) => r.entry.freq)
+        .toSet();
+    _rows.removeWhere((r) => toDrop.contains(r.entry.freq));
   }
 
   @override
   Future<void> setNickname(String freq, String? nickname) async {
     setNicknameCalls++;
     if (throwOnSetNickname) throw StateError('boom');
-    final idx = _entries.indexWhere((e) => e.freq == freq);
+    final idx = _rows.indexWhere((r) => r.entry.freq == freq);
     if (idx < 0) return;
     final trimmed = nickname?.trim();
     final value = (trimmed == null || trimmed.isEmpty) ? null : trimmed;
-    _entries[idx] = RecentFrequency(
-      freq: _entries[idx].freq,
+    _rows[idx].entry = RecentFrequency(
+      freq: _rows[idx].entry.freq,
       nickname: value,
-      pinned: _entries[idx].pinned,
+      pinned: _rows[idx].entry.pinned,
     );
   }
 
@@ -123,17 +163,20 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
   Future<void> setPinned(String freq, bool pinned) async {
     setPinnedCalls++;
     if (throwOnSetPinned) throw StateError('boom');
-    final idx = _entries.indexWhere((e) => e.freq == freq);
+    final idx = _rows.indexWhere((r) => r.entry.freq == freq);
     if (idx < 0) return;
-    _entries[idx] = RecentFrequency(
-      freq: _entries[idx].freq,
-      nickname: _entries[idx].nickname,
+    _rows[idx].entry = RecentFrequency(
+      freq: _rows[idx].entry.freq,
+      nickname: _rows[idx].entry.nickname,
       pinned: pinned,
     );
+    // Intentionally do NOT touch recordedAt — unpinning should demote a
+    // row back to its real recency position relative to other unpinned
+    // rows, matching the production store's `recorded_at`-driven order.
   }
 
   @override
-  Future<void> clear() async => _entries.clear();
+  Future<void> clear() async => _rows.clear();
 }
 
 // Zero delays so reconnect tests don't actually wait.

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:walkie_talkie/bloc/discovery_cubit.dart';
 import 'package:walkie_talkie/bloc/discovery_state.dart';
 import 'package:walkie_talkie/l10n/generated/app_localizations.dart';
 import 'package:walkie_talkie/screens/frequency_discovery_screen.dart';
+import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 
 class MockDiscoveryCubit extends Mock implements DiscoveryCubit {}
@@ -207,7 +208,10 @@ void main() {
             myName: 'Maya',
             onPick: (_) {},
             onRename: (_) {},
-            recentHostedFrequencies: const ['100.1', '92.4'],
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1'),
+              RecentFrequency(freq: '92.4'),
+            ],
           ),
         ));
         await tester.pump();
@@ -232,7 +236,10 @@ void main() {
             myName: 'Maya',
             onPick: (r) => picked = r,
             onRename: (_) {},
-            recentHostedFrequencies: const ['100.1', '92.4'],
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1'),
+              RecentFrequency(freq: '92.4'),
+            ],
           ),
         ));
         await tester.pump();
@@ -244,6 +251,226 @@ void main() {
         expect(picked, isNotNull);
         expect(picked!.isHost, isTrue);
         expect(picked!.freq, '92.4');
+      },
+    );
+
+    testWidgets(
+      'renders nickname instead of default title when one is set on a recent',
+      (tester) async {
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1', nickname: 'Family channel'),
+              RecentFrequency(freq: '92.4'),
+            ],
+          ),
+        ));
+        await tester.pump();
+
+        // The nickname replaces the default 'Your channel' title for the
+        // nicknamed row; the un-nicknamed row still shows the default.
+        expect(find.text('Family channel'), findsOneWidget);
+        expect(find.text('Your channel'), findsOneWidget);
+        // Both rows still surface the freq subtitle so the user can see the
+        // underlying channel even after assigning a label.
+        expect(find.textContaining('Host on 100.1'), findsOneWidget);
+        expect(find.textContaining('Host on 92.4'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'renders the PINNED badge on rows that are pinned',
+      (tester) async {
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1', pinned: true),
+              RecentFrequency(freq: '92.4'),
+            ],
+          ),
+        ));
+        await tester.pump();
+
+        expect(find.text('PINNED'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'opening the recent overflow menu and tapping Pin fires onSetRecentPinned',
+      (tester) async {
+        ({String freq, bool pinned})? pinned;
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1'),
+            ],
+            onSetRecentNickname: (_, _) {},
+            onSetRecentPinned: (freq, p) =>
+                pinned = (freq: freq, pinned: p),
+          ),
+        ));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // Tap the InkWell wrapping the menu item rather than its Text — the
+        // Text's centre lands on RenderAbsorbPointer (the modal barrier of
+        // the popup), which dismisses the menu instead of triggering the
+        // item.
+        await tester.tap(find.widgetWithText(InkWell, 'Pin to top'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(pinned, isNotNull);
+        expect(pinned!.freq, '100.1');
+        expect(pinned!.pinned, isTrue);
+      },
+    );
+
+    testWidgets(
+      'opening the recent overflow menu on a pinned row shows Unpin and fires onSetRecentPinned(false)',
+      (tester) async {
+        ({String freq, bool pinned})? pinned;
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1', pinned: true),
+            ],
+            onSetRecentNickname: (_, _) {},
+            onSetRecentPinned: (freq, p) =>
+                pinned = (freq: freq, pinned: p),
+          ),
+        ));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        // Pinned rows offer "Unpin" instead of "Pin to top".
+        expect(find.text('Unpin'), findsOneWidget);
+        expect(find.text('Pin to top'), findsNothing);
+
+        // Tap the InkWell wrapping the Text — the Text's centre lands on
+        // the popup's modal barrier in the test environment, so a direct
+        // text tap dismisses the menu without triggering the item.
+        await tester.tap(find.widgetWithText(InkWell, 'Unpin'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(pinned, isNotNull);
+        expect(pinned!.freq, '100.1');
+        expect(pinned!.pinned, isFalse);
+      },
+    );
+
+    testWidgets(
+      'opening Rename and saving a nickname fires onSetRecentNickname with the trimmed value',
+      (tester) async {
+        ({String freq, String? nickname})? saved;
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1'),
+            ],
+            onSetRecentNickname: (freq, n) =>
+                saved = (freq: freq, nickname: n),
+            onSetRecentPinned: (_, _) {},
+          ),
+        ));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.tap(find.widgetWithText(InkWell, 'Rename'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        await tester.enterText(find.byType(TextField), '  Family channel  ');
+        // Submit through the IME `done` action — same submit path as the
+        // Save button. Avoids the test-environment quirk where the Save
+        // button can sit below the simulated keyboard inset.
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pump(_settleWindow);
+
+        expect(saved, isNotNull);
+        expect(saved!.freq, '100.1');
+        expect(saved!.nickname, 'Family channel');
+      },
+    );
+
+    testWidgets(
+      'submitting an empty nickname clears the existing one (passes null)',
+      (tester) async {
+        ({String freq, String? nickname})? saved;
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1', nickname: 'Family channel'),
+            ],
+            onSetRecentNickname: (freq, n) =>
+                saved = (freq: freq, nickname: n),
+            onSetRecentPinned: (_, _) {},
+          ),
+        ));
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.more_vert));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.tap(find.widgetWithText(InkWell, 'Rename'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        await tester.enterText(find.byType(TextField), '');
+        await tester.testTextInput.receiveAction(TextInputAction.done);
+        await tester.pump(_settleWindow);
+
+        expect(saved, isNotNull);
+        expect(saved!.freq, '100.1');
+        expect(saved!.nickname, isNull);
+      },
+    );
+
+    testWidgets(
+      'overflow menu is omitted when both nickname / pin callbacks are null',
+      (tester) async {
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '100.1'),
+            ],
+            // Both nickname/pin handlers omitted — back-compat path for
+            // embeddings that don't wire the persistence layer.
+          ),
+        ));
+        await tester.pump();
+
+        expect(find.byTooltip('Recent options'), findsNothing);
       },
     );
 

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -833,7 +833,13 @@ class _NullRecentFrequenciesStore implements RecentFrequenciesStore {
   @override
   Future<List<String>> getRecent() async => const [];
   @override
+  Future<List<RecentFrequency>> getRecentDetailed() async => const [];
+  @override
   Future<void> record(String freq) async {}
+  @override
+  Future<void> setNickname(String freq, String? nickname) async {}
+  @override
+  Future<void> setPinned(String freq, bool pinned) async {}
   @override
   Future<void> clear() async {}
 }

--- a/test/services/recent_frequencies_store_test.dart
+++ b/test/services/recent_frequencies_store_test.dart
@@ -234,6 +234,34 @@ void main() {
       expect(detailed.single.pinned, isTrue);
     });
 
+    test('unpinning re-applies the cap so the unpinned bucket stays bounded',
+        () async {
+      // The cap is on UNPINNED rows only, so a pinned row "borrows" a
+      // slot. Unpinning it can push the unpinned count past `maxEntries`
+      // — `_doSetPinned(false)` must drop the oldest unpinned to stay
+      // bounded, otherwise the on-disk row count drifts upward whenever
+      // a user pins-then-unpins.
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('70.0');
+      await store.setPinned('70.0', true);
+      // Fill the unpinned bucket to the cap with newer records.
+      for (var i = 0; i < RecentFrequenciesStore.maxEntries; i++) {
+        await store.record('${88 + i}.0');
+      }
+      // Pre-condition: maxEntries unpinned + 1 pinned = maxEntries + 1.
+      var detailed = await store.getRecentDetailed();
+      expect(detailed.length, RecentFrequenciesStore.maxEntries + 1);
+
+      // Unpin 70.0. It's the oldest unpinned now, so it itself should
+      // roll off the bottom of the unpinned bucket.
+      await store.setPinned('70.0', false);
+
+      detailed = await store.getRecentDetailed();
+      expect(detailed.length, RecentFrequenciesStore.maxEntries);
+      expect(detailed.every((e) => !e.pinned), isTrue);
+      expect(detailed.any((e) => e.freq == '70.0'), isFalse);
+    });
+
     test('pinned entries are exempt from the rolling cap', () async {
       // Otherwise a user-curated pin would silently roll off as soon as
       // the user hosted a few new channels — pinning would be meaningless.

--- a/test/services/recent_frequencies_store_test.dart
+++ b/test/services/recent_frequencies_store_test.dart
@@ -122,5 +122,206 @@ void main() {
       final recent = await store.getRecent();
       expect(() => recent.add('100.1'), throwsUnsupportedError);
     });
+
+    // ── Naming + pinning (#125) ──────────────────────────────────────
+
+    test('getRecentDetailed returns RecentFrequency records', () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('100.1');
+      await store.record('92.4');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.map((e) => e.freq).toList(), ['92.4', '100.1']);
+      // Fresh records start with no nickname and unpinned.
+      expect(detailed.every((e) => e.nickname == null), isTrue);
+      expect(detailed.every((e) => !e.pinned), isTrue);
+    });
+
+    test('getRecentDetailed returns an unmodifiable list', () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+      final detailed = await store.getRecentDetailed();
+      expect(
+        () => detailed.add(const RecentFrequency(freq: '100.1')),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('setNickname trims and round-trips through getRecentDetailed',
+        () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.setNickname('92.4', '  Family channel  ');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.nickname, 'Family channel');
+    });
+
+    test('setNickname with null clears an existing nickname', () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.setNickname('92.4', 'Family channel');
+      await store.setNickname('92.4', null);
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.nickname, isNull);
+    });
+
+    test('setNickname with whitespace-only collapses to null', () async {
+      // Otherwise the row would render as zero-width text in the Discovery
+      // UI and feel like "the nickname disappeared but isn't gone".
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.setNickname('92.4', 'Family channel');
+      await store.setNickname('92.4', '   ');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.nickname, isNull);
+    });
+
+    test('setNickname on an unrecorded freq is a no-op', () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.setNickname('92.4', 'Family channel');
+      expect(await store.getRecentDetailed(), isEmpty);
+    });
+
+    test('record preserves an existing nickname when re-hosted', () async {
+      // Re-hosting a channel must not silently strip the user-curated
+      // nickname — the upsert touches only `recorded_at`.
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.setNickname('92.4', 'Family channel');
+      await store.record('92.4');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.nickname, 'Family channel');
+    });
+
+    test('setPinned floats a pinned row to the top of getRecentDetailed',
+        () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('100.1');
+      await store.record('92.4');
+      await store.record('88.7');
+      // Without the pin, ordering is recorded_at DESC: 88.7, 92.4, 100.1.
+      await store.setPinned('100.1', true);
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.first.freq, '100.1');
+      expect(detailed.first.pinned, isTrue);
+      // Unpinned rows retain their relative recorded_at DESC ordering.
+      expect(detailed.skip(1).map((e) => e.freq).toList(), ['88.7', '92.4']);
+    });
+
+    test('setPinned(false) demotes a row back into the unpinned group',
+        () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.setPinned('92.4', true);
+      await store.setPinned('92.4', false);
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.pinned, isFalse);
+    });
+
+    test('record preserves an existing pinned flag when re-hosted', () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+      await store.setPinned('92.4', true);
+      await store.record('92.4');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.pinned, isTrue);
+    });
+
+    test('pinned entries are exempt from the rolling cap', () async {
+      // Otherwise a user-curated pin would silently roll off as soon as
+      // the user hosted a few new channels — pinning would be meaningless.
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('70.0');
+      await store.setPinned('70.0', true);
+      // Now record more than maxEntries fresh unpinned channels.
+      for (var i = 0; i <= RecentFrequenciesStore.maxEntries; i++) {
+        await store.record('${88 + i}.0');
+      }
+
+      final detailed = await store.getRecentDetailed();
+      // The pin is still there even though we've crossed the cap.
+      expect(detailed.any((e) => e.freq == '70.0' && e.pinned), isTrue);
+      // Only `maxEntries` unpinned rows survive — the pin doesn't
+      // consume one of the unpinned slots.
+      final unpinned = detailed.where((e) => !e.pinned).toList();
+      expect(unpinned.length, RecentFrequenciesStore.maxEntries);
+    });
+
+    test('getRecent projects getRecentDetailed onto its freq column',
+        () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('100.1');
+      await store.record('92.4');
+      await store.setPinned('100.1', true);
+
+      // Pinned-first ordering applies to both surfaces.
+      expect(await store.getRecent(), ['100.1', '92.4']);
+    });
+
+    test('setPinned on an unrecorded freq is a no-op', () async {
+      final store = SqfliteRecentFrequenciesStore();
+      await store.setPinned('92.4', true);
+      expect(await store.getRecentDetailed(), isEmpty);
+    });
+
+    test('nickname + pinned both persist across new store instances',
+        () async {
+      final first = SqfliteRecentFrequenciesStore();
+      await first.record('92.4');
+      await first.setNickname('92.4', 'Family channel');
+      await first.setPinned('92.4', true);
+
+      final second = SqfliteRecentFrequenciesStore();
+      final detailed = await second.getRecentDetailed();
+      expect(detailed.single.freq, '92.4');
+      expect(detailed.single.nickname, 'Family channel');
+      expect(detailed.single.pinned, isTrue);
+    });
+  });
+
+  group('RecentFrequency value type', () {
+    test('value equality covers freq + nickname + pinned', () {
+      const a = RecentFrequency(
+        freq: '92.4',
+        nickname: 'Family',
+        pinned: true,
+      );
+      const b = RecentFrequency(
+        freq: '92.4',
+        nickname: 'Family',
+        pinned: true,
+      );
+      const cDifferentNickname = RecentFrequency(
+        freq: '92.4',
+        nickname: 'Other',
+        pinned: true,
+      );
+      const dDifferentPinned = RecentFrequency(
+        freq: '92.4',
+        nickname: 'Family',
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a == cDifferentNickname, isFalse);
+      expect(a == dDifferentPinned, isFalse);
+    });
+
+    test('toString surfaces every field for debug logs', () {
+      const r = RecentFrequency(
+        freq: '92.4',
+        nickname: 'Family',
+        pinned: true,
+      );
+      expect(r.toString(), contains('92.4'));
+      expect(r.toString(), contains('Family'));
+      expect(r.toString(), contains('true'));
+    });
   });
 }

--- a/test/services/walkie_talkie_database_test.dart
+++ b/test/services/walkie_talkie_database_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:walkie_talkie/services/recent_frequencies_store.dart';
+import 'package:walkie_talkie/services/walkie_talkie_database.dart';
+
+/// Schema-migration tests. The store-level tests run against the current
+/// `_dbVersion`'s `onCreate` schema; this file pins the v2 → v3
+/// `recent_frequencies` upgrade specifically (#125), since a botched
+/// ALTER would silently strand users with the v2 schema and the new
+/// nickname / pin actions would throw at runtime.
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+  });
+
+  setUp(() async {
+    // File-backed (not :memory:) so the same path can be re-opened by the
+    // production code under a fresh `_dbVersion` and exercise the upgrade
+    // path. In-memory databases are per-connection, which would defeat the
+    // point of the test.
+    tempDir = await Directory.systemTemp.createTemp('wt_db_v3_migration_');
+    WalkieTalkieDatabase.overrideDatabaseFactoryForTesting(
+      databaseFactoryFfi,
+      path: p.join(tempDir.path, 'wt.db'),
+    );
+    await WalkieTalkieDatabase.resetForTesting();
+  });
+
+  tearDown(() async {
+    await WalkieTalkieDatabase.resetForTesting();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('recent_frequencies v2 → v3 migration', () {
+    test(
+      'existing v2 rows pick up nickname=NULL + pinned=0 after upgrade',
+      () async {
+        // Manually stand up a v2-shaped database with a couple of rows, the
+        // way an installed-on-v2 user would have it on disk.
+        final dbPath = p.join(tempDir.path, 'wt.db');
+        final v2 = await databaseFactoryFfi.openDatabase(
+          dbPath,
+          options: OpenDatabaseOptions(version: 2, onCreate: (db, _) async {
+            await db.execute('''
+              CREATE TABLE recent_frequencies (
+                freq TEXT PRIMARY KEY NOT NULL,
+                recorded_at INTEGER NOT NULL
+              )
+            ''');
+          }),
+        );
+        await v2.insert(
+          'recent_frequencies',
+          {'freq': '92.4', 'recorded_at': 1000},
+        );
+        await v2.insert(
+          'recent_frequencies',
+          {'freq': '100.1', 'recorded_at': 2000},
+        );
+        await v2.close();
+
+        // Now open via the production path which runs `_onUpgrade` to v3.
+        final detailed =
+            await SqfliteRecentFrequenciesStore().getRecentDetailed();
+
+        // Both rows survive the migration with the v3 default values.
+        expect(detailed.length, 2);
+        for (final row in detailed) {
+          expect(row.nickname, isNull);
+          expect(row.pinned, isFalse);
+        }
+        // Setting a nickname / pin after the migration round-trips —
+        // proves the new columns are actually writable, not just present.
+        await SqfliteRecentFrequenciesStore()
+            .setNickname('92.4', 'Family channel');
+        await SqfliteRecentFrequenciesStore().setPinned('100.1', true);
+        final after =
+            await SqfliteRecentFrequenciesStore().getRecentDetailed();
+        final nicknamed = after.firstWhere((e) => e.freq == '92.4');
+        final pinned = after.firstWhere((e) => e.freq == '100.1');
+        expect(nicknamed.nickname, 'Family channel');
+        expect(pinned.pinned, isTrue);
+      },
+    );
+
+    test(
+      're-opening a v3 database is a no-op (idempotent ALTER)',
+      () async {
+        // First open creates fresh at the current version.
+        await SqfliteRecentFrequenciesStore().record('92.4');
+
+        // Re-open the same file. The migration won't fire because the
+        // version matches, but if it ever does (e.g. someone bumps the
+        // version then later reverts), the IF NOT EXISTS guards in
+        // `_addRecentFrequenciesNicknameAndPinned` keep this from
+        // double-ALTERing and crashing.
+        await WalkieTalkieDatabase.resetForTesting();
+        await expectLater(
+          SqfliteRecentFrequenciesStore().getRecentDetailed(),
+          completion(hasLength(1)),
+        );
+      },
+    );
+  });
+}

--- a/test/services/walkie_talkie_database_test.dart
+++ b/test/services/walkie_talkie_database_test.dart
@@ -36,6 +36,10 @@ void main() {
     if (await tempDir.exists()) {
       await tempDir.delete(recursive: true);
     }
+    // Drop the process-wide FFI factory + path override so a later test
+    // that doesn't install one (or that runs in a file ordering after
+    // this suite) doesn't accidentally pick up our temp path.
+    WalkieTalkieDatabase.clearDatabaseFactoryOverride();
   });
 
   group('recent_frequencies v2 → v3 migration', () {

--- a/test/services/walkie_talkie_database_test.dart
+++ b/test/services/walkie_talkie_database_test.dart
@@ -91,6 +91,58 @@ void main() {
     );
 
     test(
+      'partial v3 schema (only one of nickname / pinned exists) is recovered',
+      () async {
+        // Models a worst-case partial-migration corruption: someone
+        // ran the v2→v3 step halfway (e.g. process killed mid-ALTER on
+        // an old sqflite version), so the table is at version=2 on disk
+        // but already has the `nickname` column added. The PRAGMA
+        // table_info guard in _addRecentFrequenciesNicknameAndPinned
+        // must skip the duplicate ADD COLUMN and only run the missing
+        // `pinned` ADD — without the guard sqlite would throw
+        // `duplicate column name: nickname` and the install would be
+        // bricked.
+        final dbPath = p.join(tempDir.path, 'wt.db');
+        final partial = await databaseFactoryFfi.openDatabase(
+          dbPath,
+          options: OpenDatabaseOptions(version: 2, onCreate: (db, _) async {
+            await db.execute('''
+              CREATE TABLE recent_frequencies (
+                freq TEXT PRIMARY KEY NOT NULL,
+                recorded_at INTEGER NOT NULL,
+                nickname TEXT
+              )
+            ''');
+          }),
+        );
+        await partial.insert(
+          'recent_frequencies',
+          {'freq': '92.4', 'recorded_at': 1000, 'nickname': 'Family'},
+        );
+        await partial.close();
+
+        // Open via the production path — _onUpgrade fires (oldVersion < 3),
+        // and the guarded migration only adds the missing `pinned` column.
+        final detailed =
+            await SqfliteRecentFrequenciesStore().getRecentDetailed();
+
+        expect(detailed.length, 1);
+        expect(detailed.single.freq, '92.4');
+        // The pre-existing nickname survived (the migration didn't drop it).
+        expect(detailed.single.nickname, 'Family');
+        // The newly-added `pinned` column defaulted to 0 / unpinned.
+        expect(detailed.single.pinned, isFalse);
+
+        // Writing through the new API works end-to-end against the
+        // recovered schema.
+        await SqfliteRecentFrequenciesStore().setPinned('92.4', true);
+        final after =
+            await SqfliteRecentFrequenciesStore().getRecentDetailed();
+        expect(after.single.pinned, isTrue);
+      },
+    );
+
+    test(
       're-opening a v3 database is a no-op (idempotent ALTER)',
       () async {
         // First open creates fresh at the current version.
@@ -98,8 +150,8 @@ void main() {
 
         // Re-open the same file. The migration won't fire because the
         // version matches, but if it ever does (e.g. someone bumps the
-        // version then later reverts), the IF NOT EXISTS guards in
-        // `_addRecentFrequenciesNicknameAndPinned` keep this from
+        // version then later reverts), the PRAGMA table_info guard in
+        // `_addRecentFrequenciesNicknameAndPinned` keeps this from
         // double-ALTERing and crashing.
         await WalkieTalkieDatabase.resetForTesting();
         await expectLater(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -125,7 +125,17 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
     );
     // Intentionally do NOT touch recordedAt — unpinning should demote a
     // row back to its real recency position relative to other unpinned
-    // rows, matching the production store.
+    // rows. Mirror production's cap-on-unpin so unpinning can't leave
+    // the fake holding more unpinned rows than maxEntries.
+    if (!pinned) {
+      final unpinnedSorted = _rows.where((r) => !r.entry.pinned).toList()
+        ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+      final toDrop = unpinnedSorted
+          .skip(RecentFrequenciesStore.maxEntries)
+          .map((r) => r.entry.freq)
+          .toSet();
+      _rows.removeWhere((r) => toDrop.contains(r.entry.freq));
+    }
   }
 
   @override

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -25,12 +25,29 @@ class _FakeIdentityStore implements IdentityStore {
   Future<String> getPeerId() async => _peerId ??= 'fake-peer-id';
 }
 
+/// Internal row carrying the public [RecentFrequency] plus a synthetic
+/// `recordedAt` ordering key. Mirrors the real store's recency sort so
+/// flipping `pinned` doesn't change the row's recency position.
+class _FakeRecentRow {
+  RecentFrequency entry;
+  int recordedAt;
+  _FakeRecentRow(this.entry, this.recordedAt);
+}
+
 class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
-  final List<RecentFrequency> _entries;
+  final List<_FakeRecentRow> _rows;
+  int _nextRecordedAt;
   _FakeRecentFrequenciesStore({List<String>? initial})
-      : _entries = List<RecentFrequency>.of(
-          (initial ?? const []).map((f) => RecentFrequency(freq: f)),
-        );
+      : _rows = [],
+        _nextRecordedAt = 0 {
+    final asList = (initial ?? const <String>[]).toList();
+    // Seed in reverse so the first item ends up most-recent.
+    for (var i = asList.length - 1; i >= 0; i--) {
+      _rows.add(
+        _FakeRecentRow(RecentFrequency(freq: asList[i]), _nextRecordedAt++),
+      );
+    }
+  }
 
   @override
   Future<List<String>> getRecent() async {
@@ -40,58 +57,79 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
 
   @override
   Future<List<RecentFrequency>> getRecentDetailed() async {
-    final pinned = _entries.where((e) => e.pinned).toList();
-    final unpinned = _entries.where((e) => !e.pinned).toList();
-    return List<RecentFrequency>.unmodifiable([...pinned, ...unpinned]);
+    // Pinned-first then recordedAt DESC, mirroring the production
+    // `ORDER BY pinned DESC, recorded_at DESC`. Cap unpinned at
+    // maxEntries; pinned rows are exempt.
+    final sorted = [..._rows]
+      ..sort((a, b) {
+        if (a.entry.pinned != b.entry.pinned) {
+          return a.entry.pinned ? -1 : 1;
+        }
+        return b.recordedAt.compareTo(a.recordedAt);
+      });
+    final result = <RecentFrequency>[];
+    var unpinnedCount = 0;
+    for (final row in sorted) {
+      if (!row.entry.pinned) {
+        if (unpinnedCount >= RecentFrequenciesStore.maxEntries) continue;
+        unpinnedCount++;
+      }
+      result.add(row.entry);
+    }
+    return List<RecentFrequency>.unmodifiable(result);
   }
 
   @override
   Future<void> record(String freq) async {
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
-    final existingIdx = _entries.indexWhere((e) => e.freq == trimmed);
-    final existing =
-        existingIdx >= 0 ? _entries.removeAt(existingIdx) : null;
-    _entries.insert(0, existing ?? RecentFrequency(freq: trimmed));
-    // Mirror the production cap on UNPINNED entries so the fake doesn't
-    // silently let tests drift past the behavior the real store enforces;
-    // pinned entries are exempt from the cap (#125).
-    final unpinned = _entries.where((e) => !e.pinned).toList();
-    if (unpinned.length > RecentFrequenciesStore.maxEntries) {
-      final toDrop = unpinned
-          .skip(RecentFrequenciesStore.maxEntries)
-          .map((e) => e.freq)
-          .toSet();
-      _entries.removeWhere((e) => toDrop.contains(e.freq));
+    final existing = _rows.firstWhere(
+      (r) => r.entry.freq == trimmed,
+      orElse: () => _FakeRecentRow(RecentFrequency(freq: trimmed), -1),
+    );
+    if (existing.recordedAt < 0) {
+      _rows.add(_FakeRecentRow(existing.entry, _nextRecordedAt++));
+    } else {
+      existing.recordedAt = _nextRecordedAt++;
     }
+    final unpinnedSorted = _rows.where((r) => !r.entry.pinned).toList()
+      ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));
+    final toDrop = unpinnedSorted
+        .skip(RecentFrequenciesStore.maxEntries)
+        .map((r) => r.entry.freq)
+        .toSet();
+    _rows.removeWhere((r) => toDrop.contains(r.entry.freq));
   }
 
   @override
   Future<void> setNickname(String freq, String? nickname) async {
-    final idx = _entries.indexWhere((e) => e.freq == freq);
+    final idx = _rows.indexWhere((r) => r.entry.freq == freq);
     if (idx < 0) return;
     final trimmed = nickname?.trim();
     final value = (trimmed == null || trimmed.isEmpty) ? null : trimmed;
-    _entries[idx] = RecentFrequency(
-      freq: _entries[idx].freq,
+    _rows[idx].entry = RecentFrequency(
+      freq: _rows[idx].entry.freq,
       nickname: value,
-      pinned: _entries[idx].pinned,
+      pinned: _rows[idx].entry.pinned,
     );
   }
 
   @override
   Future<void> setPinned(String freq, bool pinned) async {
-    final idx = _entries.indexWhere((e) => e.freq == freq);
+    final idx = _rows.indexWhere((r) => r.entry.freq == freq);
     if (idx < 0) return;
-    _entries[idx] = RecentFrequency(
-      freq: _entries[idx].freq,
-      nickname: _entries[idx].nickname,
+    _rows[idx].entry = RecentFrequency(
+      freq: _rows[idx].entry.freq,
+      nickname: _rows[idx].entry.nickname,
       pinned: pinned,
     );
+    // Intentionally do NOT touch recordedAt — unpinning should demote a
+    // row back to its real recency position relative to other unpinned
+    // rows, matching the production store.
   }
 
   @override
-  Future<void> clear() async => _entries.clear();
+  Future<void> clear() async => _rows.clear();
 }
 
 class _FakeDiscoveryService implements DiscoveryService {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -26,28 +26,68 @@ class _FakeIdentityStore implements IdentityStore {
 }
 
 class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
-  final List<String> _entries;
+  final List<RecentFrequency> _entries;
   _FakeRecentFrequenciesStore({List<String>? initial})
-      : _entries = List<String>.of(initial ?? const []);
+      : _entries = List<RecentFrequency>.of(
+          (initial ?? const []).map((f) => RecentFrequency(freq: f)),
+        );
 
   @override
-  Future<List<String>> getRecent() async => List<String>.unmodifiable(_entries);
+  Future<List<String>> getRecent() async {
+    final detailed = await getRecentDetailed();
+    return List<String>.unmodifiable(detailed.map((e) => e.freq));
+  }
+
+  @override
+  Future<List<RecentFrequency>> getRecentDetailed() async {
+    final pinned = _entries.where((e) => e.pinned).toList();
+    final unpinned = _entries.where((e) => !e.pinned).toList();
+    return List<RecentFrequency>.unmodifiable([...pinned, ...unpinned]);
+  }
 
   @override
   Future<void> record(String freq) async {
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
-    _entries
-      ..remove(trimmed)
-      ..insert(0, trimmed);
-    // Mirror the production cap so the fake doesn't silently let tests
-    // drift past behavior the real store enforces.
-    if (_entries.length > RecentFrequenciesStore.maxEntries) {
-      _entries.removeRange(
-        RecentFrequenciesStore.maxEntries,
-        _entries.length,
-      );
+    final existingIdx = _entries.indexWhere((e) => e.freq == trimmed);
+    final existing =
+        existingIdx >= 0 ? _entries.removeAt(existingIdx) : null;
+    _entries.insert(0, existing ?? RecentFrequency(freq: trimmed));
+    // Mirror the production cap on UNPINNED entries so the fake doesn't
+    // silently let tests drift past the behavior the real store enforces;
+    // pinned entries are exempt from the cap (#125).
+    final unpinned = _entries.where((e) => !e.pinned).toList();
+    if (unpinned.length > RecentFrequenciesStore.maxEntries) {
+      final toDrop = unpinned
+          .skip(RecentFrequenciesStore.maxEntries)
+          .map((e) => e.freq)
+          .toSet();
+      _entries.removeWhere((e) => toDrop.contains(e.freq));
     }
+  }
+
+  @override
+  Future<void> setNickname(String freq, String? nickname) async {
+    final idx = _entries.indexWhere((e) => e.freq == freq);
+    if (idx < 0) return;
+    final trimmed = nickname?.trim();
+    final value = (trimmed == null || trimmed.isEmpty) ? null : trimmed;
+    _entries[idx] = RecentFrequency(
+      freq: _entries[idx].freq,
+      nickname: value,
+      pinned: _entries[idx].pinned,
+    );
+  }
+
+  @override
+  Future<void> setPinned(String freq, bool pinned) async {
+    final idx = _entries.indexWhere((e) => e.freq == freq);
+    if (idx < 0) return;
+    _entries[idx] = RecentFrequency(
+      freq: _entries[idx].freq,
+      nickname: _entries[idx].nickname,
+      pinned: pinned,
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary

The persistent block list and per-peer mute landed in #159 / #161. This PR closes the third sub-feature of #125: nicknames + pinning for recent frequencies, exposed through a per-row overflow menu in the Discovery list.

## Changes

- **Schema migration (v2 → v3)**: `recent_frequencies` gains `nickname` (TEXT, nullable) and `pinned` (INTEGER, NOT NULL DEFAULT 0). The migration uses ALTER TABLE guarded by a `PRAGMA table_info` check so re-running on a partially-migrated install is a no-op rather than a hard error.

- **`RecentFrequenciesStore` API**:
  - New `RecentFrequency` value type carrying freq + optional nickname + pinned.
  - `getRecentDetailed()` returns the full records (back-compat `getRecent()` projects onto freq strings).
  - `setNickname(freq, String?)` — null/whitespace clears.
  - `setPinned(freq, bool)`.
  - `record()` switches from `INSERT OR REPLACE` to a sqlite UPSERT (`ON CONFLICT(freq) DO UPDATE SET recorded_at = excluded.recorded_at`) so re-hosting a nicknamed/pinned channel preserves its metadata instead of silently wiping it.
  - The cap query excludes pinned rows on both sides — pinned entries are user-curated and exempt from the rolling `maxEntries` cap.

- **`SessionDiscovery.recentHostedFrequencies`** is now `List<RecentFrequency>`. Two new cubit methods (`setRecentNickname`, `setRecentPinned`) persist the change and re-emit Discovery so the list resorts (pinned rows float to the top).

- **Discovery screen**: each Recent row gets a `more_vert` overflow menu (Rename / Pin to top|Unpin), a `PINNED` badge next to the title of pinned rows, the pin glyph in the icon disc when pinned, and a bottom sheet for editing nicknames (with a Remove-nickname affordance when a row already has one). Both the menu and sheet only render when the parent wires up the corresponding callbacks, so back-compat embeddings that don't connect persistence stay rendering.

## Acceptance criterion (from #125)

> Pin a frequency on Discovery → it floats to the top.

Covered by `setPinned floats a pinned row to the top of getRecentDetailed` (store-level) and `setRecentPinned floats the pinned row to the top and re-emits Discovery` (cubit-level).

## Test plan

- [x] \`flutter analyze\` — clean
- [x] \`flutter test\` — 499/499 pass (added 30+ unit/widget tests for the new store API + cubit methods + Discovery UI, plus a v2 → v3 schema migration test that seeds a v2-shaped database on disk and verifies the upgrade path)
- [ ] Manual: nickname a recent → restart app → nickname survives
- [ ] Manual: pin a recent → host more than 5 fresh channels → pinned row still visible at the top

Closes #125 (third sub-feature; the other two landed in #159 and #161).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename recent frequencies with custom nicknames.
  * Pin channels to keep them at the top with a visible “PINNED” badge.
  * Per-row overflow menu with Rename and Pin/Unpin actions.
  * Immediate UI refresh of the Recent list when nickname or pin changes.

* **Localization**
  * New strings for menu labels, pin badge, and nickname entry UI (including sheet title, subtitle, hint, save/clear).

* **Chores**
  * Database migration to persist nicknames and pinned flags while preserving existing recents.

* **Tests**
  * Expanded tests covering naming, pinning, ordering, migration, UI callbacks, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->