### PR TITLE
feat(#131): in-app LicensePage with vendored Oboe + Opus notices

### DIFF
--- a/assets/licenses/oboe-LICENSE.txt
+++ b/assets/licenses/oboe-LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/assets/licenses/opus-COPYING.txt
+++ b/assets/licenses/opus-COPYING.txt
@@ -1,0 +1,44 @@
+Copyright 2001-2023 Xiph.Org, Skype Limited, Octasic,
+                    Jean-Marc Valin, Timothy B. Terriberry,
+                    CSIRO, Gregory Maxwell, Mark Borgerding,
+                    Erik de Castro Lopo, Mozilla, Amazon
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of Internet Society, IETF or IETF Trust, nor the
+names of specific contributors, may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Opus is subject to the royalty-free patent licenses which are
+specified at:
+
+Xiph.Org Foundation:
+https://datatracker.ietf.org/ipr/1524/
+
+Microsoft Corporation:
+https://datatracker.ietf.org/ipr/1914/
+
+Broadcom Corporation:
+https://datatracker.ietf.org/ipr/1526/

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -339,6 +339,19 @@
         "description": "Footer link below the discovery list — opens the in-app privacy policy screen."
     },
 
+    "discoveryFooterLicenses": "Licenses",
+    "@discoveryFooterLicenses": {
+        "description": "Footer link below the discovery list — opens the in-app open-source license page."
+    },
+    "licensesPageTitle": "Open source licenses",
+    "@licensesPageTitle": {
+        "description": "Title of the in-app LicensePage shown above the package list."
+    },
+    "licensesPageLegalese": "Frequency uses open-source software, including vendored native libraries (Oboe, Opus). Each package is listed below with its full license text.",
+    "@licensesPageLegalese": {
+        "description": "Subtitle / legalese line shown under the LicensePage title."
+    },
+
     "privacyPolicyEyebrow": "POLICY",
     "@privacyPolicyEyebrow": {
         "description": "All-caps eyebrow above the privacy policy headline."

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,10 +36,10 @@ void main() async {
   // Make Oboe (Apache-2.0) + Opus (BSD-3-Clause) license texts available to
   // the in-app `LicensePage`. Pure-Dart deps are auto-discovered, but our
   // vendored C++ libs aren't, so we register their `LICENSE`/`COPYING`
-  // files explicitly. Sync registration is fine — the closure passed to
-  // `LicenseRegistry.addLicense` is only invoked when the LicensePage is
-  // opened, so this doesn't add startup latency.
-  unawaited(registerNativeLicenses());
+  // files explicitly. The closure passed to `LicenseRegistry.addLicense`
+  // is only invoked when the LicensePage is opened, so this doesn't add
+  // startup latency — and the registration call itself is synchronous.
+  registerNativeLicenses();
 
   // Check crash reporting opt-in preference.
   final settingsStore = SqfliteSettingsStore();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'services/ble_control_transport.dart';
 import 'services/blocked_peers_store.dart';
 import 'services/bluetooth_discovery_service.dart';
 import 'services/identity_store.dart';
+import 'services/native_licenses.dart';
 import 'services/onboarding_permission_gateway.dart';
 import 'services/permission_watcher.dart';
 import 'services/recent_frequencies_store.dart';
@@ -32,6 +33,13 @@ void main() async {
   // data on installs that had it. Subsequent launches see the marker in
   // the `kv` table and skip Hive init entirely.
   await migrateHiveToSqliteIfNeeded();
+  // Make Oboe (Apache-2.0) + Opus (BSD-3-Clause) license texts available to
+  // the in-app `LicensePage`. Pure-Dart deps are auto-discovered, but our
+  // vendored C++ libs aren't, so we register their `LICENSE`/`COPYING`
+  // files explicitly. Sync registration is fine — the closure passed to
+  // `LicenseRegistry.addLicense` is only invoked when the LicensePage is
+  // opened, so this doesn't add startup latency.
+  unawaited(registerNativeLicenses());
 
   // Check crash reporting opt-in preference.
   final settingsStore = SqfliteSettingsStore();

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -181,12 +181,16 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                         label: l10n.discoveryFooterPrivacy,
                         onPressed: _openPrivacyPolicy,
                       ),
-                      Text(
-                        '·',
-                        style: TextStyle(
-                          fontFamily: 'Inter',
-                          fontSize: 12,
-                          color: c.ink3,
+                      // Visual separator only — TalkBack would otherwise
+                      // announce "dot" between the two footer buttons.
+                      ExcludeSemantics(
+                        child: Text(
+                          '·',
+                          style: TextStyle(
+                            fontFamily: 'Inter',
+                            fontSize: 12,
+                            color: c.ink3,
+                          ),
                         ),
                       ),
                       _FooterLink(

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -174,26 +174,26 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                     ),
                   ),
                   const SizedBox(height: 4),
-                  Center(
-                    child: TextButton(
-                      onPressed: _openPrivacyPolicy,
-                      style: TextButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 8),
-                        minimumSize: const Size(48, 48),
-                        foregroundColor: c.ink2,
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _FooterLink(
+                        label: l10n.discoveryFooterPrivacy,
+                        onPressed: _openPrivacyPolicy,
                       ),
-                      child: Text(
-                        l10n.discoveryFooterPrivacy,
+                      Text(
+                        '·',
                         style: TextStyle(
                           fontFamily: 'Inter',
                           fontSize: 12,
-                          color: c.ink2,
-                          decoration: TextDecoration.underline,
-                          decorationColor: c.line2,
+                          color: c.ink3,
                         ),
                       ),
-                    ),
+                      _FooterLink(
+                        label: l10n.discoveryFooterLicenses,
+                        onPressed: _openLicenses,
+                      ),
+                    ],
                   ),
                 ],
               ),
@@ -460,6 +460,50 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
     await Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => const FrequencyPrivacyPolicyScreen(),
+      ),
+    );
+  }
+
+  void _openLicenses() {
+    final l10n = AppLocalizations.of(context);
+    // `showLicensePage` builds Flutter's stock LicensePage. The page lazily
+    // pulls every entry registered with `LicenseRegistry`, including the
+    // native Oboe/Opus entries registered at startup in
+    // [registerNativeLicenses], in addition to all dependencies that ship
+    // license metadata via pub.
+    showLicensePage(
+      context: context,
+      applicationName: l10n.licensesPageTitle,
+      applicationLegalese: l10n.licensesPageLegalese,
+    );
+  }
+}
+
+class _FooterLink extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const _FooterLink({required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        minimumSize: const Size(48, 48),
+        foregroundColor: c.ink2,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 12,
+          color: c.ink2,
+          decoration: TextDecoration.underline,
+          decorationColor: c.line2,
+        ),
       ),
     );
   }

--- a/lib/services/native_licenses.dart
+++ b/lib/services/native_licenses.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+
+/// Registers third-party licenses for vendored native code with Flutter's
+/// [LicenseRegistry] so they appear in the in-app `LicensePage` alongside
+/// the auto-collected Dart-package licenses.
+///
+/// Pure Dart dependencies declared in `pubspec.yaml` are picked up by Flutter
+/// automatically — `LicenseRegistry` walks the package metadata. Vendored
+/// native code is invisible to that mechanism, so we have to register it
+/// ourselves: Oboe (Apache-2.0) ships under `android/app/src/main/cpp/oboe/`
+/// and Opus (BSD-3-Clause) is a git submodule at `android/app/src/main/cpp/opus`.
+/// Their license texts are bundled as Flutter assets under `assets/licenses/`
+/// so the runtime doesn't depend on the C++ source tree being checked out
+/// (the Opus submodule isn't always populated, e.g. on CI shallow clones).
+///
+/// Idempotent: a private flag prevents duplicate registrations if the helper
+/// is invoked more than once during hot reload or in tests that share a
+/// binding with `main()`.
+@visibleForTesting
+const oboeLicenseAsset = 'assets/licenses/oboe-LICENSE.txt';
+
+@visibleForTesting
+const opusLicenseAsset = 'assets/licenses/opus-COPYING.txt';
+
+bool _registered = false;
+
+/// Resets the idempotency flag. Test-only — production code calls
+/// [registerNativeLicenses] exactly once from `main()`.
+@visibleForTesting
+void resetNativeLicenseRegistrationForTests() {
+  _registered = false;
+}
+
+/// Registers the Oboe and Opus license texts with [LicenseRegistry].
+///
+/// Call once during app startup, before the first frame. Safe to invoke
+/// multiple times — only the first call has any effect. The optional
+/// [bundle] parameter is for tests; production reads from [rootBundle].
+Future<void> registerNativeLicenses({AssetBundle? bundle}) async {
+  if (_registered) return;
+  _registered = true;
+
+  final assets = bundle ?? rootBundle;
+
+  LicenseRegistry.addLicense(() async* {
+    yield LicenseEntryWithLineBreaks(
+      const ['Oboe'],
+      await assets.loadString(oboeLicenseAsset),
+    );
+    yield LicenseEntryWithLineBreaks(
+      const ['Opus'],
+      await assets.loadString(opusLicenseAsset),
+    );
+  });
+}

--- a/lib/services/native_licenses.dart
+++ b/lib/services/native_licenses.dart
@@ -37,7 +37,11 @@ void resetNativeLicenseRegistrationForTests() {
 /// Call once during app startup, before the first frame. Safe to invoke
 /// multiple times — only the first call has any effect. The optional
 /// [bundle] parameter is for tests; production reads from [rootBundle].
-Future<void> registerNativeLicenses({AssetBundle? bundle}) async {
+///
+/// Synchronous: this function only hands [LicenseRegistry] a closure to
+/// invoke later. The asset reads happen lazily inside that closure, when
+/// the LicensePage is first opened — they don't block startup.
+void registerNativeLicenses({AssetBundle? bundle}) {
   if (_registered) return;
   _registered = true;
 

--- a/lib/services/native_licenses.dart
+++ b/lib/services/native_licenses.dart
@@ -47,11 +47,17 @@ void registerNativeLicenses({AssetBundle? bundle}) {
 
   final assets = bundle ?? rootBundle;
 
+  // One `addLicense` call per package so a load failure on one asset
+  // doesn't prevent the other from showing up. Inside a single generator
+  // an exception on the first `await` would short-circuit the second
+  // `yield` — splitting them isolates the failure modes.
   LicenseRegistry.addLicense(() async* {
     yield LicenseEntryWithLineBreaks(
       const ['Oboe'],
       await assets.loadString(oboeLicenseAsset),
     );
+  });
+  LicenseRegistry.addLicense(() async* {
     yield LicenseEntryWithLineBreaks(
       const ['Opus'],
       await assets.loadString(opusLicenseAsset),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,15 @@ flutter:
   # and `flutter pub get` regenerates the bindings.
   generate: true
 
+  # Bundled license texts for vendored native code (Oboe, Opus). These are
+  # registered with `LicenseRegistry` at startup (lib/services/native_licenses.dart)
+  # so the in-app LicensePage shows third-party notices for the C++ code in
+  # addition to the Dart packages Flutter discovers automatically. Required for
+  # Apache-2.0 (Oboe) attribution + BSD-3-Clause (Opus) notice retention.
+  assets:
+    - assets/licenses/oboe-LICENSE.txt
+    - assets/licenses/opus-COPYING.txt
+
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -520,6 +520,39 @@ void main() {
         expect(privacyButton, findsOneWidget);
       },
     );
+
+    testWidgets(
+      'tapping the footer Licenses link pushes Flutter\'s LicensePage with our title',
+      (tester) async {
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (_) {},
+            onRename: (_) {},
+          ),
+        ));
+        await tester.pump();
+
+        final list = find.byType(ListView);
+        final licensesButton = find.widgetWithText(TextButton, 'Licenses');
+        await tester.dragUntilVisible(
+          licensesButton,
+          list,
+          const Offset(0, -120),
+        );
+        await tester.pump();
+        await tester.tap(licensesButton);
+        // The license page renders an internal AnimatedSwitcher; pump
+        // through the route + initial frame.
+        await tester.pump();
+        await tester.pump(_settleWindow);
+
+        // The applicationName we hand to `showLicensePage` becomes the
+        // header title — anchoring on the localized string proves we
+        // reached LicensePage rather than just any new route.
+        expect(find.text('Open source licenses'), findsWidgets);
+      },
+    );
   });
 
   group('DiscoveryResult invariants', () {

--- a/test/services/native_licenses_test.dart
+++ b/test/services/native_licenses_test.dart
@@ -1,5 +1,8 @@
 import 'dart:convert';
 
+// `Uint8List` arrives via `package:flutter/foundation.dart` (which re-exports
+// `dart:typed_data`), so a direct `dart:typed_data` import would be flagged
+// `unnecessary_import` by the analyzer.
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -21,7 +24,7 @@ void main() {
         oboeLicenseAsset: 'OBOE LICENSE TEXT — Apache-2.0',
         opusLicenseAsset: 'OPUS LICENSE TEXT — BSD-3-Clause',
       });
-      await registerNativeLicenses(bundle: bundle);
+      registerNativeLicenses(bundle: bundle);
 
       final entries = await LicenseRegistry.licenses.toList();
       // The native licenses we just registered live alongside any other
@@ -41,8 +44,8 @@ void main() {
         oboeLicenseAsset: 'OBOE',
         opusLicenseAsset: 'OPUS',
       });
-      await registerNativeLicenses(bundle: bundle);
-      await registerNativeLicenses(bundle: bundle);
+      registerNativeLicenses(bundle: bundle);
+      registerNativeLicenses(bundle: bundle);
 
       final entries = await LicenseRegistry.licenses.toList();
       final oboeCount = entries.where((e) => e.packages.contains('Oboe')).length;

--- a/test/services/native_licenses_test.dart
+++ b/test/services/native_licenses_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/native_licenses.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    // `LicenseRegistry` is a global; clear it between tests so each case
+    // sees only the entries it registers itself.
+    LicenseRegistry.reset();
+    resetNativeLicenseRegistrationForTests();
+  });
+
+  group('registerNativeLicenses', () {
+    test('emits Oboe and Opus entries with their package labels', () async {
+      final bundle = _StubAssetBundle({
+        oboeLicenseAsset: 'OBOE LICENSE TEXT — Apache-2.0',
+        opusLicenseAsset: 'OPUS LICENSE TEXT — BSD-3-Clause',
+      });
+      await registerNativeLicenses(bundle: bundle);
+
+      final entries = await LicenseRegistry.licenses.toList();
+      // The native licenses we just registered live alongside any other
+      // entries Flutter has collected on this binding (auto-discovered Dart
+      // packages, etc.). Filter to ours rather than asserting on length.
+      final oboe = entries.firstWhere((e) => e.packages.contains('Oboe'));
+      final opus = entries.firstWhere((e) => e.packages.contains('Opus'));
+
+      expect(oboe.paragraphs.map((p) => p.text).join(' '),
+          contains('OBOE LICENSE TEXT'));
+      expect(opus.paragraphs.map((p) => p.text).join(' '),
+          contains('OPUS LICENSE TEXT'));
+    });
+
+    test('is idempotent — repeat calls do not re-register', () async {
+      final bundle = _StubAssetBundle({
+        oboeLicenseAsset: 'OBOE',
+        opusLicenseAsset: 'OPUS',
+      });
+      await registerNativeLicenses(bundle: bundle);
+      await registerNativeLicenses(bundle: bundle);
+
+      final entries = await LicenseRegistry.licenses.toList();
+      final oboeCount = entries.where((e) => e.packages.contains('Oboe')).length;
+      final opusCount = entries.where((e) => e.packages.contains('Opus')).length;
+      expect(oboeCount, 1);
+      expect(opusCount, 1);
+    });
+
+    testWidgets('asset paths declared in pubspec resolve at runtime',
+        (tester) async {
+      // Loads the real bundled assets through the test binding. If pubspec
+      // forgot to list them under `flutter.assets`, this throws.
+      final oboe = await rootBundle.loadString(oboeLicenseAsset);
+      final opus = await rootBundle.loadString(opusLicenseAsset);
+      expect(oboe, contains('Apache License'));
+      expect(opus, contains('Xiph'));
+    });
+  });
+}
+
+class _StubAssetBundle extends CachingAssetBundle {
+  _StubAssetBundle(this._strings);
+  final Map<String, String> _strings;
+
+  @override
+  Future<ByteData> load(String key) async {
+    final s = _strings[key];
+    if (s == null) {
+      throw FlutterError('asset $key not found in stub');
+    }
+    return ByteData.view(Uint8List.fromList(utf8.encode(s)).buffer);
+  }
+}


### PR DESCRIPTION
## Summary

Closes the **License audit / in-app LicensePage** acceptance criterion from the [#131](https://github.com/ElodinLaarz/walkie-talkie/issues/131) checklist (the piece deferred from [#164](https://github.com/ElodinLaarz/walkie-talkie/pull/164)).

The in-app LicensePage now shows third-party notices for the vendored C++ libraries — Oboe (Apache-2.0) and Opus (BSD-3-Clause) — alongside the Dart packages Flutter discovers automatically.

## Why this is needed

Flutter's `LicenseRegistry` walks pubspec metadata and surfaces each Dart dep's `LICENSE` file in the built-in `LicensePage`. Vendored native code is invisible to that mechanism — the C++ libs sit under `android/app/src/main/cpp/{oboe,opus}` and never get registered. Both licenses require attribution to be reproduced with the binary, so we have to bundle the texts and register them ourselves.

## Changes

- **`assets/licenses/oboe-LICENSE.txt`** — copy of `cpp/oboe/LICENSE`, Apache-2.0.
- **`assets/licenses/opus-COPYING.txt`** — canonical Opus notice from xiph (BSD-3-Clause + IETF royalty-free patent license pointers). The Opus submodule is a shallow checkout in CI and not always populated, so the copyright text is bundled directly rather than read from the submodule at build time.
- **`lib/services/native_licenses.dart`** — registers both with `LicenseRegistry.addLicense`. The async generator passed to `addLicense` is invoked lazily — the asset only loads when LicensePage is first opened, so startup cost is zero. Idempotent so hot reload + tests can re-invoke safely (private flag short-circuits repeats).
- **`main.dart`** — fires `registerNativeLicenses()` once after `WidgetsFlutterBinding.ensureInitialized()`, alongside the other one-shot startup hooks.
- **Discovery footer** — gets a "Licenses" link next to "Privacy"; tapping it calls Flutter's `showLicensePage` with our localized title + legalese strings. The two links share a small `_FooterLink` widget so they keep visual parity if either label changes.
- **`pubspec.yaml`** — declares the two `assets/licenses/*.txt` files under `flutter.assets`.
- **`lib/l10n/app_en.arb`** — three new strings: `discoveryFooterLicenses`, `licensesPageTitle`, `licensesPageLegalese`.

## What's NOT in this PR (still tracked under #131)

- **SLSA provenance** for the AAB — explicitly marked optional in the issue; substantial CI work, deserves its own PR.
- **AAB size budget** — already lives in `release.yml`'s "Measure AAB size" step (see [release.yml:70](https://github.com/ElodinLaarz/walkie-talkie/blob/main/.github/workflows/release.yml#L70)) — done before this PR.
- **`gradle.properties` / `vcsInfo` review** — landed in [#164](https://github.com/ElodinLaarz/walkie-talkie/pull/164).

So after this PR merges, #131's only remaining item is SLSA provenance.

## Test plan

- [x] `flutter analyze` — clean.
- [x] `flutter test` — 479 → 482 (+3 new). New cases:
  - `registerNativeLicenses emits Oboe and Opus entries with their package labels`
  - `registerNativeLicenses is idempotent — repeat calls do not re-register`
  - `registerNativeLicenses asset paths declared in pubspec resolve at runtime` (catches a missing pubspec asset declaration without needing a manual repro)
  - Plus a Discovery widget test that taps the footer Licenses link and asserts the LicensePage's localized title appears.
- [ ] Manual: open Discovery → tap "Licenses" → verify Oboe + Opus entries are present alongside the auto-discovered Dart deps.

## Wire-format / runtime behavior

No protocol, audio engine, or persistence changes. Pure UI + asset bundling.

Refs [#131](https://github.com/ElodinLaarz/walkie-talkie/issues/131).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer adds a "Licenses" link and an in-app "Open source licenses" page showing bundled native-library notices.

* **Documentation**
  * Added full license text files for bundled native libraries so their notices display in-app.

* **Localization**
  * Added localized strings for the footer link, licenses page title, and legalese.

* **Tests**
  * Added tests for footer navigation and registration/display of bundled license texts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->