### PR TITLE
ops(#131): SLSA build provenance for release AAB

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,15 +9,8 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
-    # SLSA provenance signing (#131): id-token for the OIDC token used to sign
-    # the attestation via Sigstore, attestations for storing the SLSA Provenance
-    # v1 statement against the repo. contents:read is the default we'd otherwise
-    # inherit but is spelled out here so the full permission surface is visible
-    # in one place.
     permissions:
       contents: read
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -108,25 +101,6 @@ jobs:
             exit 1
           fi
 
-      - name: Generate SLSA build provenance
-        # Emits a SLSA Provenance v1 statement bound to the AAB's SHA-256 digest,
-        # signed with this workflow's OIDC identity via Sigstore's public-good
-        # infrastructure (GitHub-hosted runners + reusable workflow detection
-        # qualify this for SLSA Build Level 3 per the action docs). The
-        # attestation is stored on the repo and is verifiable with:
-        #   gh attestation verify <aab> --repo ElodinLaarz/walkie-talkie
-        # which lets a downloader confirm the AAB was produced by THIS workflow
-        # at this commit, before sideloading or shipping it through Play.
-        #
-        # Pinned to a full commit SHA (not the @v2 tag) because this is the only
-        # step in the workflow that holds id-token:write + attestations:write —
-        # a tag retarget on a privileged action could mint provenance for
-        # arbitrary subjects under our identity. Other actions in the repo use
-        # major-version tags because they don't carry that privilege.
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
-        with:
-          subject-path: build/app/outputs/bundle/release/app-release.aab
-
       - name: Upload release AAB
         uses: actions/upload-artifact@v4
         with:
@@ -137,3 +111,41 @@ jobs:
       - name: Clean up keystore
         if: always()
         run: rm -f ${{ runner.temp }}/walkie-talkie.jks
+
+  attest-release:
+    # Isolated job so id-token:write + attestations:write don't bleed onto the
+    # build steps that touch the keystore, run third-party Dart/Gradle code, or
+    # could otherwise be coerced into minting a provenance statement under our
+    # OIDC identity. The attestation is bound to the AAB's SHA-256 digest, so
+    # generating it after a re-download from the workflow artifact store is
+    # equivalent to generating it in-place — same bytes, same subject.
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download release AAB
+        uses: actions/download-artifact@v4
+        with:
+          name: release-aab
+          path: aab
+
+      - name: Generate SLSA build provenance
+        # Emits a SLSA Provenance v1 statement bound to the AAB's SHA-256 digest,
+        # signed with this workflow's OIDC identity via Sigstore's public-good
+        # infrastructure (GitHub-hosted runners + reusable workflow detection
+        # qualify this for SLSA Build Level 3 per the action docs). Verifiable
+        # post-download with:
+        #   gh attestation verify <aab> --repo ElodinLaarz/walkie-talkie
+        # which lets a downloader confirm the AAB was produced by THIS workflow
+        # at this commit, before sideloading or shipping it through Play.
+        #
+        # Pinned to a full commit SHA (not the @v2 tag) because this job holds
+        # id-token:write + attestations:write — a tag retarget on a privileged
+        # action could mint provenance for arbitrary subjects under our
+        # identity. Other (non-privileged) actions stay on major-version tags.
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: aab/app-release.aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,13 @@ jobs:
         #   gh attestation verify <aab> --repo ElodinLaarz/walkie-talkie
         # which lets a downloader confirm the AAB was produced by THIS workflow
         # at this commit, before sideloading or shipping it through Play.
-        uses: actions/attest-build-provenance@v2
+        #
+        # Pinned to a full commit SHA (not the @v2 tag) because this is the only
+        # step in the workflow that holds id-token:write + attestations:write —
+        # a tag retarget on a privileged action could mint provenance for
+        # arbitrary subjects under our identity. Other actions in the repo use
+        # major-version tags because they don't carry that privilege.
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: build/app/outputs/bundle/release/app-release.aab
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
+    # Minimal permissions: only contents:read for actions/checkout. The cache
+    # half of subosito/flutter-action and actions/upload-artifact@v4 both rely
+    # on ACTIONS_RUNTIME_TOKEN (runner-scoped, not GITHUB_TOKEN) so they need
+    # no actions:* scope on the GITHUB_TOKEN — confirmed in their respective
+    # action docs.
     permissions:
       contents: read
     steps:
@@ -127,7 +132,12 @@ jobs:
       attestations: write
     steps:
       - name: Download release AAB
-        uses: actions/download-artifact@v4
+        # Pinned to a commit SHA (not @v4) for the same reason
+        # attest-build-provenance is pinned: this step runs alongside the
+        # privileged attestation step in a job that holds id-token:write +
+        # attestations:write. A retargeted tag could compromise the runner
+        # before the attestation step signs anything.
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-aab
           path: aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,22 +10,28 @@ jobs:
   build-release:
     runs-on: ubuntu-latest
     # Minimal permissions: only contents:read for actions/checkout. The cache
-    # half of subosito/flutter-action and actions/upload-artifact@v4 both rely
-    # on ACTIONS_RUNTIME_TOKEN (runner-scoped, not GITHUB_TOKEN) so they need
-    # no actions:* scope on the GITHUB_TOKEN — confirmed in their respective
+    # half of subosito/flutter-action and actions/upload-artifact both rely on
+    # ACTIONS_RUNTIME_TOKEN (runner-scoped, not GITHUB_TOKEN) so they need no
+    # actions:* scope on the GITHUB_TOKEN — confirmed in their respective
     # action docs.
     permissions:
       contents: read
+    # Every action in this job is SHA-pinned. The release AAB this job produces
+    # is what attest-release signs a provenance statement for — if any of these
+    # actions could be retargeted (`@v4` resolving to a malicious commit), the
+    # AAB itself could be tampered with before signing, and the attestation
+    # would faithfully prove the wrong artifact's authenticity. The pin is
+    # what makes the whole supply-chain claim meaningful.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           channel: stable
           cache: true
@@ -107,7 +113,7 @@ jobs:
           fi
 
       - name: Upload release AAB
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-aab
           path: build/app/outputs/bundle/release/app-release.aab
@@ -132,11 +138,6 @@ jobs:
       attestations: write
     steps:
       - name: Download release AAB
-        # Pinned to a commit SHA (not @v4) for the same reason
-        # attest-build-provenance is pinned: this step runs alongside the
-        # privileged attestation step in a job that holds id-token:write +
-        # attestations:write. A retargeted tag could compromise the runner
-        # before the attestation step signs anything.
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-aab
@@ -152,10 +153,11 @@ jobs:
         # which lets a downloader confirm the AAB was produced by THIS workflow
         # at this commit, before sideloading or shipping it through Play.
         #
-        # Pinned to a full commit SHA (not the @v2 tag) because this job holds
-        # id-token:write + attestations:write — a tag retarget on a privileged
-        # action could mint provenance for arbitrary subjects under our
-        # identity. Other (non-privileged) actions stay on major-version tags.
+        # Pinned to a full commit SHA — every action in this workflow is, on
+        # purpose: build-release produces the AAB this step signs, so a tag
+        # retarget on any of them would let an attacker tamper with the AAB
+        # while we still emit a "valid" provenance statement for it. The pin
+        # is what makes the supply-chain claim meaningful end-to-end.
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-path: aab/app-release.aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
+    # SLSA provenance signing (#131): id-token for the OIDC token used to sign
+    # the attestation via Sigstore, attestations for storing the SLSA Provenance
+    # v1 statement against the repo. contents:read is the default we'd otherwise
+    # inherit but is spelled out here so the full permission surface is visible
+    # in one place.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -98,6 +107,19 @@ jobs:
             echo "Error: AAB size ${AAB_BYTES} bytes exceeds budget ${AAB_MAX_BYTES} bytes"
             exit 1
           fi
+
+      - name: Generate SLSA build provenance
+        # Emits a SLSA Provenance v1 statement bound to the AAB's SHA-256 digest,
+        # signed with this workflow's OIDC identity via Sigstore's public-good
+        # infrastructure (GitHub-hosted runners + reusable workflow detection
+        # qualify this for SLSA Build Level 3 per the action docs). The
+        # attestation is stored on the repo and is verifiable with:
+        #   gh attestation verify <aab> --repo ElodinLaarz/walkie-talkie
+        # which lets a downloader confirm the AAB was produced by THIS workflow
+        # at this commit, before sideloading or shipping it through Play.
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: build/app/outputs/bundle/release/app-release.aab
 
       - name: Upload release AAB
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Closes the last open item in #131. The other items (`vcsInfo`, R8 + mapping upload, AAB size budget in CI, in-app `LicensePage` with vendored Oboe + Opus notices) already landed in prior PRs. This adds a **SLSA Provenance v1** attestation bound to the release AAB's SHA-256 digest, signed with the workflow's OIDC identity via Sigstore's public-good infrastructure (qualifies for SLSA Build Level 3 per the [`attest-build-provenance` docs](https://github.com/actions/attest-build-provenance)).

## Why

> SLSA provenance for the AAB (optional but worth it for a security-first app). — #131

A walkie-talkie app sideloaded from a GitHub release artifact has no Play Store integrity check standing between the runner output and the user's device. With this attestation in place, anyone who downloads the AAB can verify it was produced by **this** workflow at **this** commit before installing it:

```
gh attestation verify app-release.aab --repo ElodinLaarz/walkie-talkie
```

Same primitive Play Console will eventually use as it rolls out attested artifact ingestion.

## Changes

- `.github/workflows/release.yml`
  - Add `permissions:` block scoping the workflow to `contents:read`, `id-token:write` (for the OIDC token used to sign the attestation), `attestations:write` (for storing the signed statement against the repo).
  - Add `Generate SLSA build provenance` step using `actions/attest-build-provenance@v2`, pointed at the AAB the previous step just built.

No new secrets, no new dependencies, no changes to Flutter/Kotlin/native code.

## Test plan

- [ ] Cut a tag (or run `workflow_dispatch`) on a branch that includes this change and confirm the `Generate SLSA build provenance` step succeeds and produces an attestation visible under the repo's *Attestations* tab.
- [ ] After the run, download `release-aab` and verify locally: `gh attestation verify app-release.aab --repo ElodinLaarz/walkie-talkie` should succeed and print the source repo + workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI permissions for the release pipeline to minimize token access during publication.
  * Added an automated attestation step that generates and attaches SLSA Provenance v1 attestations for published release artifacts using OIDC-based signing for verifiable integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->