### PR TITLE
test(#128): Functional tests for BluetoothDiscoveryService

### DIFF
--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:permission_handler/permission_handler.dart';

--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
 import '../protocol/discovery.dart';
@@ -46,7 +47,7 @@ class DiscoveryService {
     await _scanSubscription?.cancel();
     _scanSubscription = FlutterBluePlus.scanResults.listen((results) {
       for (ScanResult r in results) {
-        final session = _parseResult(r);
+        final session = parseResult(r);
         if (session != null) {
           _discovered[session.sessionUuidLow8] =
               (session: session, lastSeen: DateTime.now());
@@ -82,7 +83,8 @@ class DiscoveryService {
     );
   }
 
-  DiscoveredSession? _parseResult(ScanResult r) {
+  @visibleForTesting
+  DiscoveredSession? parseResult(ScanResult r) {
     // Manufacturer data is a Map<int, List<int>>.
     for (final entry in r.advertisementData.manufacturerData.entries) {
       final data = Uint8List.fromList(entry.value);

--- a/test/services/bluetooth_discovery_service_test.dart
+++ b/test/services/bluetooth_discovery_service_test.dart
@@ -8,7 +8,7 @@ import 'package:walkie_talkie/services/bluetooth_discovery_service.dart';
 
 import 'bluetooth_discovery_service_test.mocks.dart';
 
-/// Tests for BluetoothDiscoveryService.parseResult, covering:
+/// Tests for DiscoveryService.parseResult, covering:
 /// - Manufacturer data filtering (valid v1 payloads accepted, invalid rejected)
 /// - RSSI propagation from scan results to DiscoveredSession
 /// - Advertisement name (advName) passthrough to DiscoveredSession.hostName
@@ -22,7 +22,7 @@ void main() {
   // Ensure Flutter bindings are initialized for any widget-dependent code
   WidgetsFlutterBinding.ensureInitialized();
 
-  group('BluetoothDiscoveryService parseResult', () {
+  group('DiscoveryService parseResult', () {
     late DiscoveryService service;
 
     setUp(() {
@@ -133,7 +133,7 @@ void main() {
 
       final scanResult = makeScanResult(
         manufacturerData: {
-          0x0001: junkPayload.toList(), // Invalid company ID
+          0x0001: junkPayload.toList(), // Truncated payload; too short to parse
           0x05A0: validPayload.toList(), // Valid Frequency payload
         },
         advName: 'MultiMfg',
@@ -256,15 +256,12 @@ void main() {
 
       // Should return the first valid session found during iteration
       expect(session, isNotNull);
-      // The session UUID should be from one of the payloads
-      expect(
-        [uuid1.toLowerCase(), uuid2.toLowerCase()].contains(session!.sessionUuidLow8),
-        true,
-      );
+      // Dart maps iterate in insertion order, so should return uuid1
+      expect(session!.sessionUuidLow8, uuid1.toLowerCase());
     });
   });
 
-  group('BluetoothDiscoveryService freshness window', () {
+  group('DiscoveryService freshness window', () {
     test('freshnessWindow constant is 10 seconds', () {
       expect(DiscoveryService.freshnessWindow, const Duration(seconds: 10));
     });

--- a/test/services/bluetooth_discovery_service_test.dart
+++ b/test/services/bluetooth_discovery_service_test.dart
@@ -8,11 +8,12 @@ import 'package:walkie_talkie/services/bluetooth_discovery_service.dart';
 
 import 'bluetooth_discovery_service_test.mocks.dart';
 
-/// Tests for BluetoothDiscoveryService, covering:
-/// - `_parseResult` manufacturer data filtering
+/// Tests for BluetoothDiscoveryService.parseResult, covering:
+/// - Manufacturer data filtering (valid v1 payloads accepted, invalid rejected)
 /// - RSSI propagation from scan results to DiscoveredSession
-/// - Freshness window pruning
-/// - Advertisement name passthrough
+/// - Advertisement name (advName) passthrough to DiscoveredSession.hostName
+/// - MAC address propagation from device.remoteId to DiscoveredSession.macAddress
+/// - Multiple manufacturer data entries (iteration until valid found)
 @GenerateMocks([
   BluetoothDevice,
   AdvertisementData,
@@ -21,7 +22,7 @@ void main() {
   // Ensure Flutter bindings are initialized for any widget-dependent code
   WidgetsFlutterBinding.ensureInitialized();
 
-  group('BluetoothDiscoveryService _parseResult logic', () {
+  group('BluetoothDiscoveryService parseResult', () {
     late DiscoveryService service;
 
     setUp(() {
@@ -55,6 +56,7 @@ void main() {
     }
 
     /// Valid v1 host advertisement payload.
+    /// Protocol: [version(1)][role(1)][sessionUuidLow8(8)][flags(2)][reserved(4)]
     Uint8List validV1Payload({String sessionUuidLow8 = '0011223344556677'}) {
       final uuidBytes = <int>[];
       for (var i = 0; i < sessionUuidLow8.length; i += 2) {
@@ -70,7 +72,8 @@ void main() {
       ]);
     }
 
-    test('parseResult extracts valid manufacturer data and propagates RSSI', () {
+    test('parseResult extracts valid manufacturer data and propagates all fields',
+        () {
       final scanResult = makeScanResult(
         manufacturerData: {0x05A0: validV1Payload().toList()},
         advName: 'TestHost',
@@ -78,49 +81,19 @@ void main() {
         macAddress: '11:22:33:44:55:66',
       );
 
-      // _parseResult is private, so we test it through the public startScan flow.
-      // We'll manually call the internal method by reflection, OR we test the
-      // integrated behavior by emitting scan results.
-      //
-      // Since _parseResult is private, we verify the behavior by checking that
-      // sessions with the expected RSSI and hostName appear in the results stream.
-      //
-      // For direct unit testing of _parseResult, we verify the logic through
-      // the protocol parser (which is already tested) and ensure the service
-      // correctly propagates the RSSI, hostName, and macAddress fields.
+      final session = service.parseResult(scanResult);
 
-      // Direct verification: the method should produce a DiscoveredSession with
-      // rssi=-72, hostName='TestHost', macAddress='11:22:33:44:55:66'.
-      // Since we can't call _parseResult directly, we verify the contract:
-      // DiscoveredSession.fromManufacturerData is tested in protocol/discovery_test.dart,
-      // and this service test verifies that RSSI/hostName/MAC from ScanResult flow through.
-
-      // We'll use a different approach: test that when scan results arrive,
-      // the service emits sessions with correct RSSI/hostName/MAC.
-      // This requires integration with flutter_blue_plus scanning, which we mock.
-
-      // For this unit test focused on _parseResult logic, we verify the expected
-      // behavior: given a ScanResult with specific manufacturer data, RSSI, advName,
-      // and MAC, the resulting DiscoveredSession should have those exact values.
-
-      // Since _parseResult is private, we document the expected behavior:
-      // - Manufacturer data is iterated
-      // - Each entry is passed to DiscoveredSession.fromManufacturerData
-      // - RSSI from scanResult.rssi is propagated
-      // - advName from scanResult.advertisementData.advName is propagated
-      // - MAC from scanResult.device.remoteId.str is propagated
-
-      // The actual test coverage comes from integration tests where we emit
-      // scan results and verify the results stream. For focused unit testing
-      // of _parseResult, we verify the contract is met.
-
-      expect(scanResult.rssi, -72);
-      expect(scanResult.advertisementData.advName, 'TestHost');
-      expect(scanResult.device.remoteId.str, '11:22:33:44:55:66');
+      expect(session, isNotNull);
+      expect(session!.hostName, 'TestHost');
+      expect(session.rssi, -72);
+      expect(session.macAddress, '11:22:33:44:55:66');
+      expect(session.protocolVersion, 1);
+      expect(session.isHost, true);
+      expect(session.sessionUuidLow8, '0011223344556677');
     });
 
-    test('parseResult filters out non-Frequency manufacturer data', () {
-      // Invalid manufacturer data (wrong version)
+    test('parseResult returns null for invalid protocol version', () {
+      // Version 2 is unsupported
       final invalidPayload = Uint8List.fromList([
         0x02, // Version 2 (unsupported)
         0x01, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
@@ -133,40 +106,45 @@ void main() {
         rssi: -50,
       );
 
-      // _parseResult should return null for invalid payloads.
-      // We verify this by ensuring no sessions appear in the results stream
-      // when only invalid advertisements are received.
+      final session = service.parseResult(scanResult);
+      expect(session, isNull);
+    });
 
-      // The expected behavior: _parseResult returns null when
-      // DiscoveredSession.fromManufacturerData returns null.
-      // This is verified by the protocol tests; here we document that
-      // the service correctly filters out such results.
+    test('parseResult returns null for truncated payload', () {
+      // Missing required fields
+      final truncatedPayload = Uint8List.fromList([
+        0x01, 0x01, 0x00, 0x11, 0x22, // Only 5 bytes instead of 16
+      ]);
 
-      expect(invalidPayload[0], 0x02); // Version mismatch
-      expect(scanResult.advertisementData.manufacturerData, isNotEmpty);
+      final scanResult = makeScanResult(
+        manufacturerData: {0x05A0: truncatedPayload.toList()},
+        advName: 'BadHost',
+        rssi: -45,
+      );
+
+      final session = service.parseResult(scanResult);
+      expect(session, isNull);
     });
 
     test('parseResult handles multiple manufacturer data entries', () {
-      // A scan result can have multiple manufacturer data entries.
-      // _parseResult iterates them and returns the first valid session.
+      // First entry is junk, second is valid
       final validPayload = validV1Payload();
-      final invalidPayload = Uint8List.fromList([0x99, 0x99]); // Junk
+      final junkPayload = Uint8List.fromList([0x99, 0x99]);
 
       final scanResult = makeScanResult(
         manufacturerData: {
-          0x0001: invalidPayload.toList(), // Invalid entry first
-          0x05A0: validPayload.toList(), // Valid Frequency payload second
+          0x0001: junkPayload.toList(), // Invalid company ID
+          0x05A0: validPayload.toList(), // Valid Frequency payload
         },
         advName: 'MultiMfg',
         rssi: -65,
       );
 
-      // _parseResult should skip the invalid entry and return the valid one.
-      // The iteration order of Map.entries is insertion order in Dart, so
-      // the service should find the valid entry even if junk appears first.
+      final session = service.parseResult(scanResult);
 
-      expect(scanResult.advertisementData.manufacturerData.length, 2);
-      expect(scanResult.advertisementData.manufacturerData.containsKey(0x05A0), true);
+      expect(session, isNotNull);
+      expect(session!.hostName, 'MultiMfg');
+      expect(session.rssi, -65);
     });
 
     test('parseResult returns null when manufacturer data is empty', () {
@@ -176,8 +154,8 @@ void main() {
         rssi: -40,
       );
 
-      // _parseResult should return null when there's no manufacturer data.
-      expect(scanResult.advertisementData.manufacturerData.isEmpty, true);
+      final session = service.parseResult(scanResult);
+      expect(session, isNull);
     });
 
     test('parseResult propagates advName to DiscoveredSession.hostName', () {
@@ -187,9 +165,10 @@ void main() {
         rssi: -55,
       );
 
-      // The hostName field of DiscoveredSession should be the advName from
-      // the advertisement data.
-      expect(scanResult.advertisementData.advName, 'Pixel 7 Pro');
+      final session = service.parseResult(scanResult);
+
+      expect(session, isNotNull);
+      expect(session!.hostName, 'Pixel 7 Pro');
     });
 
     test('parseResult propagates macAddress from device.remoteId', () {
@@ -201,12 +180,14 @@ void main() {
         macAddress: testMac,
       );
 
-      // The macAddress field should come from scanResult.device.remoteId.str
-      expect(scanResult.device.remoteId.str, testMac);
+      final session = service.parseResult(scanResult);
+
+      expect(session, isNotNull);
+      expect(session!.macAddress, testMac);
     });
 
-    test('RSSI values propagate correctly from negative to positive range', () {
-      // Test RSSI boundary values: very weak, moderate, very strong
+    test('RSSI propagates correctly across negative range', () {
+      // Test boundary values: very weak and very strong signals
       final weakSignal = makeScanResult(
         manufacturerData: {0x05A0: validV1Payload().toList()},
         advName: 'WeakHost',
@@ -219,26 +200,85 @@ void main() {
         rssi: -30, // Very strong
       );
 
-      expect(weakSignal.rssi, -95);
-      expect(strongSignal.rssi, -30);
-      // RSSI is always negative in practice for BLE scan results, but the
-      // protocol and types support any int value.
+      final weakSession = service.parseResult(weakSignal);
+      final strongSession = service.parseResult(strongSignal);
+
+      expect(weakSession, isNotNull);
+      expect(weakSession!.rssi, -95);
+
+      expect(strongSession, isNotNull);
+      expect(strongSession!.rssi, -30);
+    });
+
+    test('parseResult extracts different session UUIDs correctly', () {
+      final uuid1 = 'AABBCCDD11223344';
+      final uuid2 = 'FFEEDDCC99887766';
+
+      final result1 = makeScanResult(
+        manufacturerData: {0x05A0: validV1Payload(sessionUuidLow8: uuid1).toList()},
+        advName: 'Host1',
+        rssi: -50,
+      );
+
+      final result2 = makeScanResult(
+        manufacturerData: {0x05A0: validV1Payload(sessionUuidLow8: uuid2).toList()},
+        advName: 'Host2',
+        rssi: -60,
+      );
+
+      final session1 = service.parseResult(result1);
+      final session2 = service.parseResult(result2);
+
+      expect(session1, isNotNull);
+      expect(session1!.sessionUuidLow8, uuid1.toLowerCase());
+
+      expect(session2, isNotNull);
+      expect(session2!.sessionUuidLow8, uuid2.toLowerCase());
+    });
+
+    test('parseResult returns first valid session from multiple mfg entries', () {
+      // Both entries are valid with different UUIDs
+      final uuid1 = '1111111111111111';
+      final uuid2 = '2222222222222222';
+      final payload1 = validV1Payload(sessionUuidLow8: uuid1);
+      final payload2 = validV1Payload(sessionUuidLow8: uuid2);
+
+      final scanResult = makeScanResult(
+        manufacturerData: {
+          0x05A0: payload1.toList(), // First valid
+          0x05A1: payload2.toList(), // Second valid (different company ID)
+        },
+        advName: 'MultiValid',
+        rssi: -70,
+      );
+
+      final session = service.parseResult(scanResult);
+
+      // Should return the first valid session found during iteration
+      expect(session, isNotNull);
+      // The session UUID should be from one of the payloads
+      expect(
+        [uuid1.toLowerCase(), uuid2.toLowerCase()].contains(session!.sessionUuidLow8),
+        true,
+      );
     });
   });
 
   group('BluetoothDiscoveryService freshness window', () {
-    test('sessions older than freshnessWindow are pruned', () async {
-      // This would require mocking DateTime or using a time-controllable service.
-      // The freshness window is 10 seconds, defined as a constant.
+    test('freshnessWindow constant is 10 seconds', () {
       expect(DiscoveryService.freshnessWindow, const Duration(seconds: 10));
-
-      // Full integration test of pruning would involve:
-      // 1. Emit a session
-      // 2. Advance time by >10 seconds
-      // 3. Emit a new scan result (which triggers _emit())
-      // 4. Verify the old session is no longer in the results
-      //
-      // This is better suited for an integration test with a clock abstraction.
     });
+
+    // Full integration test of freshness pruning would require:
+    // 1. Mock DateTime or use a time-controllable service
+    // 2. Emit a session
+    // 3. Advance time by >10 seconds
+    // 4. Emit a new scan (triggers _emit and pruning)
+    // 5. Verify the old session is removed
+    //
+    // This is better suited for an integration test with clock injection,
+    // which is beyond the scope of unit testing parseResult logic.
+    // The pruning logic itself is simple (_emit removes entries older than
+    // freshnessWindow) and is covered by code inspection.
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/main.dart';
 import 'package:walkie_talkie/protocol/discovery.dart';
@@ -154,6 +155,9 @@ class _FakeDiscoveryService implements DiscoveryService {
 
   @override
   Future<void> dispose() async {}
+
+  @override
+  DiscoveredSession? parseResult(ScanResult r) => null;
 }
 
 /// No-op watcher for widget tests. The production [DefaultPermissionWatcher]


### PR DESCRIPTION
## Summary
Addresses part of #128 by adding proper functional tests for `BluetoothDiscoveryService.parseResult`.

The existing test file had only placeholder tests that documented expected behavior without actually verifying it. This PR:

- Makes `_parseResult` testable via `@visibleForTesting` annotation
- Renames `_parseResult` → `parseResult` to allow direct unit testing
- Replaces placeholder tests with functional tests that actually call the method and verify behavior

## Coverage Added
✅ Valid manufacturer data extraction with all fields (RSSI, hostName, macAddress, protocolVersion, isHost, sessionUuidLow8)
✅ RSSI propagation across signal strength range (-95 to -30 dBm)
✅ advName passthrough to DiscoveredSession.hostName
✅ MAC address propagation from device.remoteId
✅ Invalid protocol version rejection (v2 unsupported)
✅ Truncated payload rejection
✅ Multiple manufacturer data entry iteration
✅ Empty manufacturer data handling
✅ Different session UUID extraction

## Test Results
All 203 service tests pass:
```
00:03 +203: All tests passed!
```

flutter analyze: No issues found

## Related
Addresses issue #128 item #4: "BluetoothDiscoveryService — zero unit tests for `_parseResult`, manufacturer-data filtering, RSSI propagation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Bluetooth discovery tests with direct unit coverage of scan-result parsing, RSSI propagation, multi-manufacturer handling, and negative cases for unsupported/truncated payloads; simplified freshness-window assertion.
  * Updated widget tests to align with the new parser interface (fake discovery returns inert results).

* **Refactor**
  * Made the scan-result parser test-accessible to enable focused unit testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->