### PR TITLE
ops(#131): restore bundle.vcsInfo for Play Console crash deep-links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,31 @@ jobs:
           fi
           flutter build appbundle --release --target-platform=android-arm64,android-arm,android-x64
 
+      - name: Assert vcsInfo metadata is present in AAB
+        # Guards against silent regressions of bundle.vcsInfo.include in
+        # build.gradle.kts (e.g. an autofix tool comments the block out as
+        # collateral during an unrelated cleanup, as happened in 1a763a1).
+        # Without this, only Play Console would notice — by which point a
+        # release is already shipped without source-linked crash traces.
+        # AGP serializes vcsInfo as a protobuf under BUNDLE-METADATA/; matching
+        # the prefix rather than the exact filename keeps the check stable
+        # across AGP versions that may rename the inner path.
+        run: |
+          AAB_PATH=build/app/outputs/bundle/release/app-release.aab
+          if [ ! -f "$AAB_PATH" ]; then
+            echo "Error: $AAB_PATH not found"
+            exit 1
+          fi
+          if ! unzip -l "$AAB_PATH" | grep -qiE 'BUNDLE-METADATA/[^[:space:]]*vcs'; then
+            echo "Error: AAB is missing vcsInfo metadata under BUNDLE-METADATA/."
+            echo "       bundle.vcsInfo.include in android/app/build.gradle.kts"
+            echo "       must be true so Play Console can deep-link crashes to commits."
+            echo "       BUNDLE-METADATA contents in the built AAB:"
+            unzip -l "$AAB_PATH" | grep -E 'BUNDLE-METADATA/' || echo "       (none)"
+            exit 1
+          fi
+          echo "::notice title=vcsInfo::Found vcsInfo metadata in AAB"
+
       - name: Measure AAB size
         # Bundle-on-disk size is a coarse catastrophic-regression alarm — a 50
         # MiB ceiling well above the per-device target catches an accidental

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -205,9 +205,9 @@ android {
         abi {
             enableSplit = true
         }
-        // vcsInfo {
-        //     include = true
-        // }
+        vcsInfo {
+            include = true
+        }
     }
 
     testOptions {


### PR DESCRIPTION
## Summary

- Re-enables `bundle { vcsInfo { include = true } }` so Play Console can deep-link crash stack traces back to the exact source revision.
- Closes the last open acceptance bullet on #131.

## Why

`vcsInfo` embeds the HEAD commit SHA + remote URL into the AAB metadata. Combined with the R8 mapping upload from #110, the Play Console crash dashboard can show fully deobfuscated, source-linked stack traces.

This block was originally added in [#164](https://github.com/ElodinLaarz/walkie-talkie/pull/164) (commit a200f22) but was commented out in 1a763a1 alongside an unrelated Gradle-script cleanup that moved the `java.util.Properties` import to the top of the file. The cleanup was correct; the `vcsInfo` regression appears to have been collateral. Restoring it now that the `Properties` import is fixed at the top.

## #131 status after this PR

- [x] vcsInfo — this PR
- [x] AAB size budget in CI ([#163](https://github.com/ElodinLaarz/walkie-talkie/pull/163))
- [x] R8 fullMode + nonTransitiveRClass ([#164](https://github.com/ElodinLaarz/walkie-talkie/pull/164))
- [x] LicensePage with vendored Oboe + Opus notices ([#175](https://github.com/ElodinLaarz/walkie-talkie/pull/175))
- [x] SLSA build provenance for the release AAB ([#177](https://github.com/ElodinLaarz/walkie-talkie/pull/177))

## Test plan

- [ ] Flutter CI passes (`flutter analyze`, `flutter test`, native C++ tests)
- [ ] On the next tagged release, the `release.yml` AAB build succeeds and `bundletool dump manifest` (or Play Console) shows the embedded VCS info
- [ ] Once a crash is symbolicated in Play Console, the stack trace lines link to the exact commit on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build output now includes version-control metadata in the application bundle.
  * Release workflow now validates generated app bundles and will fail the release if the expected VCS metadata is missing, while reporting diagnostic details when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->