### PR TITLE
test(#128): C++ unit tests for RingBuffer SPSC and OpusCodec round-trip

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -22,6 +22,9 @@ jobs:
           flutter --version
           dart --version
 
+      - name: Install native dependencies
+        run: sudo apt-get install -y libopus-dev
+
       - name: Install dependencies
         run: flutter pub get
 
@@ -39,8 +42,13 @@ jobs:
               test/cpp/jitter_buffer_test.cpp \
               test/cpp/resampler_test.cpp \
               test/cpp/talking_event_queue_test.cpp \
+              test/cpp/ring_buffer_test.cpp \
+              test/cpp/opus_codec_test.cpp \
               android/app/src/main/cpp/audio_mixer.cpp \
-              android/app/src/main/cpp/talking_event_queue.h; do
+              android/app/src/main/cpp/talking_event_queue.h \
+              android/app/src/main/cpp/ring_buffer.h \
+              android/app/src/main/cpp/opus_codec.h \
+              android/app/src/main/cpp/opus_codec.cpp; do
             if [ ! -f "$required" ]; then
               echo "$required missing — failing fast"; exit 1
             fi
@@ -81,6 +89,26 @@ jobs:
               test/cpp/talking_event_queue_test.cpp \
               -o build/cpp_test/talking_event_queue_test
           build/cpp_test/talking_event_queue_test
+
+          # ring_buffer_test exercises header-only ring_buffer.h (#128).
+          ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+              -I test/cpp \
+              -I android/app/src/main/cpp \
+              test/cpp/ring_buffer_test.cpp \
+              -o build/cpp_test/ring_buffer_test
+          build/cpp_test/ring_buffer_test
+
+          # opus_codec_test exercises OpusEncoder/OpusDecoder (#128).
+          # libopus installed above via apt-get; pkg-config supplies include path.
+          ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+              -I test/cpp \
+              -I android/app/src/main/cpp \
+              $(pkg-config --cflags opus) \
+              test/cpp/opus_codec_test.cpp \
+              android/app/src/main/cpp/opus_codec.cpp \
+              $(pkg-config --libs opus) \
+              -o build/cpp_test/opus_codec_test
+          build/cpp_test/opus_codec_test
 
       # App size budget (issue #131): build a debug AAB and enforce the
       # < 30 MB download-size target. Uses the debug keystore so no signing

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -17,8 +17,13 @@ for required in \
     test/cpp/jitter_buffer_test.cpp \
     test/cpp/resampler_test.cpp \
     test/cpp/talking_event_queue_test.cpp \
+    test/cpp/ring_buffer_test.cpp \
+    test/cpp/opus_codec_test.cpp \
     android/app/src/main/cpp/audio_mixer.cpp \
-    android/app/src/main/cpp/talking_event_queue.h; do
+    android/app/src/main/cpp/talking_event_queue.h \
+    android/app/src/main/cpp/ring_buffer.h \
+    android/app/src/main/cpp/opus_codec.h \
+    android/app/src/main/cpp/opus_codec.cpp; do
   if [ ! -f "$required" ]; then
     echo "$required missing — failing fast"
     exit 1
@@ -60,3 +65,25 @@ ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
     test/cpp/talking_event_queue_test.cpp \
     -o build/cpp_test/talking_event_queue_test
 build/cpp_test/talking_event_queue_test
+
+# ring_buffer_test exercises header-only ring_buffer.h — SPSC lock-free audio
+# ring buffer (#128: previously had zero unit tests).
+${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+    -I test/cpp \
+    -I android/app/src/main/cpp \
+    test/cpp/ring_buffer_test.cpp \
+    -o build/cpp_test/ring_buffer_test
+build/cpp_test/ring_buffer_test
+
+# opus_codec_test exercises OpusEncoder/OpusDecoder from opus_codec.cpp.
+# Requires libopus (install via: apt install libopus-dev).
+# pkg-config supplies the opus include path (-I/usr/include/opus on Debian/Ubuntu).
+${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+    -I test/cpp \
+    -I android/app/src/main/cpp \
+    $(pkg-config --cflags opus) \
+    test/cpp/opus_codec_test.cpp \
+    android/app/src/main/cpp/opus_codec.cpp \
+    $(pkg-config --libs opus) \
+    -o build/cpp_test/opus_codec_test
+build/cpp_test/opus_codec_test

--- a/test/cpp/opus_codec_test.cpp
+++ b/test/cpp/opus_codec_test.cpp
@@ -1,0 +1,206 @@
+// Host-buildable test for OpusEncoder / OpusDecoder in opus_codec.cpp.
+// Requires libopus (apt install libopus-dev on Ubuntu).
+//
+// Compile (see scripts/presubmit.sh and .github/workflows/flutter.yml).
+
+#include "opus_codec.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+// Generate one Opus frame (kCodecFrameSize samples) of a sine tone at
+// `freqHz` sampled at kCodecSampleRate. Amplitude is at half-scale (16384)
+// to match the convention in resampler_test and leave codec headroom.
+std::vector<int16_t> makeSineFrame(double freqHz,
+                                   int16_t amplitude = 16384) {
+    const int n = audio_config::kCodecFrameSize;
+    std::vector<int16_t> v(n);
+    for (int i = 0; i < n; ++i) {
+        double s = std::sin(2.0 * kPi * freqHz * i /
+                            audio_config::kCodecSampleRate);
+        v[i] = static_cast<int16_t>(amplitude * s);
+    }
+    return v;
+}
+
+double rms(const int16_t* x, int n) {
+    double sum = 0.0;
+    for (int i = 0; i < n; ++i) {
+        double v = x[i] / 32768.0;
+        sum += v * v;
+    }
+    return std::sqrt(sum / n);
+}
+
+}  // namespace
+
+// ── Construction / teardown ───────────────────────────────────────────────────
+
+void testEncoderDecoderConstruct() {
+    OpusEncoder enc;
+    OpusDecoder dec;
+    // If the ctor fails it stores nullptr; encode/decode would return -1.
+    // We exercise that indirectly by encoding a frame below.
+    std::cout << "Test Encoder/Decoder Construct: PASSED" << std::endl;
+}
+
+// ── Round-trip fidelity with 1 kHz tone ──────────────────────────────────────
+//
+// Encode several frames then decode. After encoder warm-up the decoded RMS
+// must be within 6 dB of the input RMS — a loose bound to accommodate lossy
+// compression at 16 kbps while still detecting a silent or grossly distorted
+// output.
+//
+// Note: DTX is enabled by default; a pure tone at nonzero amplitude is
+// considered active speech, so Opus will always emit a real packet.
+void testRoundTripFidelity1kHz() {
+    OpusEncoder enc;
+    OpusDecoder dec;
+
+    const int frameSize = audio_config::kCodecFrameSize;
+    std::vector<int16_t> pcmIn = makeSineFrame(1000.0);
+    uint8_t encoded[audio_config::kMaxOpusPacketSize];
+    std::vector<int16_t> pcmOut(frameSize, 0);
+
+    double inputRms = rms(pcmIn.data(), frameSize);
+    assert(inputRms > 0.0);
+
+    // Warm up: encode/decode several frames to let the encoder settle.
+    int encodedSize = 0;
+    for (int i = 0; i < 5; ++i) {
+        encodedSize = enc.encode(pcmIn.data(), frameSize, encoded,
+                                 audio_config::kMaxOpusPacketSize);
+        assert(encodedSize > 0);
+        int decoded = dec.decode(encoded, encodedSize, pcmOut.data(), frameSize);
+        assert(decoded == frameSize);
+    }
+
+    double outputRms = rms(pcmOut.data(), frameSize);
+    // Output must be non-silent and within 6 dB of input (~factor of 2).
+    assert(outputRms > inputRms / 2.0);
+    assert(outputRms < inputRms * 2.0);
+    std::cout << "Test Round-Trip Fidelity 1kHz (input RMS=" << inputRms
+              << ", output RMS=" << outputRms << "): PASSED" << std::endl;
+}
+
+// ── encode() must return negative for wrong frame size ───────────────────────
+void testEncodeRejectsWrongFrameSize() {
+    OpusEncoder enc;
+    uint8_t out[audio_config::kMaxOpusPacketSize];
+    std::vector<int16_t> short_frame(audio_config::kCodecFrameSize - 1, 0);
+    int ret = enc.encode(short_frame.data(),
+                         audio_config::kCodecFrameSize - 1, out,
+                         audio_config::kMaxOpusPacketSize);
+    assert(ret < 0);
+    std::cout << "Test Encode Rejects Wrong Frame Size: PASSED" << std::endl;
+}
+
+// ── setBitrate clamping ───────────────────────────────────────────────────────
+void testSetBitrateClampsToRange() {
+    OpusEncoder enc;
+    // Below the floor — must be clamped to kBitrateLow.
+    int result = enc.setBitrate(100);
+    assert(result == audio_config::kBitrateLow);
+    // Above the ceiling — must be clamped to kBitrateHigh.
+    result = enc.setBitrate(1000000);
+    assert(result == audio_config::kBitrateHigh);
+    // Within range — must be accepted exactly.
+    result = enc.setBitrate(audio_config::kBitrateMid);
+    assert(result == audio_config::kBitrateMid);
+    std::cout << "Test SetBitrate Clamps To Range: PASSED" << std::endl;
+}
+
+// ── PLC (decodeMissing) produces non-silent output after a real packet ────────
+//
+// After decoding one real frame, decodeMissing() should synthesise concealment
+// audio. We only assert that it returns the correct frame count and that the
+// concealment is not pure silence (Opus PLC extrapolates the prior signal).
+void testDecodeMissingReturnsConcealedAudio() {
+    OpusEncoder enc;
+    OpusDecoder dec;
+
+    const int frameSize = audio_config::kCodecFrameSize;
+    std::vector<int16_t> pcmIn = makeSineFrame(1000.0);
+    uint8_t encoded[audio_config::kMaxOpusPacketSize];
+
+    // Prime the decoder with one real frame so PLC has state to extrapolate.
+    int encodedSize = enc.encode(pcmIn.data(), frameSize, encoded,
+                                 audio_config::kMaxOpusPacketSize);
+    assert(encodedSize > 0);
+    std::vector<int16_t> realOut(frameSize, 0);
+    int decodedReal = dec.decode(encoded, encodedSize, realOut.data(), frameSize);
+    assert(decodedReal == frameSize);
+
+    // Now synthesise PLC for the next missing frame.
+    std::vector<int16_t> plcOut(frameSize, 0);
+    int plcSamples = dec.decodeMissing(plcOut.data(), frameSize);
+    assert(plcSamples == frameSize);
+    // PLC output must not be all-zero — Opus extrapolates from decoder state.
+    double plcRms = rms(plcOut.data(), frameSize);
+    assert(plcRms > 0.0);
+    std::cout << "Test DecodeMissing Returns Concealed Audio (PLC RMS="
+              << plcRms << "): PASSED" << std::endl;
+}
+
+// ── FEC: decodeFec simulates a lost-packet recovery scenario ─────────────────
+//
+// Standard usage: pkt1 is "lost" (never decoded), pkt2 arrives. We call
+// decodeFec(pkt2) to get a recovered version of frame 1 from pkt2's FEC
+// side-channel, then decode(pkt2) normally to get frame 2.
+//
+// With FEC enabled and loss > 0 the encoder embeds an LBRR copy of the
+// previous frame; we verify decodeFec returns frameSize samples without
+// crashing. Whether the result is FEC audio or PLC audio (when the encoder
+// chose not to embed FEC at this bitrate) is not observable from the API —
+// both paths are exercised by calling decodeFec without a prior decode call.
+void testDecodeFecDoesNotCrash() {
+    const int frameSize = audio_config::kCodecFrameSize;
+
+    OpusEncoder enc;
+    enc.setInbandFec(true);
+    enc.setExpectedLossPct(30);
+
+    // Encode two consecutive frames. pkt2 may carry an FEC copy of pkt1.
+    std::vector<int16_t> pcmIn = makeSineFrame(1000.0);
+    uint8_t pkt1[audio_config::kMaxOpusPacketSize];
+    uint8_t pkt2[audio_config::kMaxOpusPacketSize];
+    int sz1 = enc.encode(pcmIn.data(), frameSize, pkt1,
+                         audio_config::kMaxOpusPacketSize);
+    assert(sz1 > 0);
+    int sz2 = enc.encode(pcmIn.data(), frameSize, pkt2,
+                         audio_config::kMaxOpusPacketSize);
+    assert(sz2 > 0);
+
+    // Simulate a lost pkt1: skip decode(pkt1) and call decodeFec(pkt2)
+    // directly. Opus uses either its FEC side-channel or PLC internally.
+    OpusDecoder dec;
+    std::vector<int16_t> fecOut(frameSize, 0);
+    int fecSamples = dec.decodeFec(pkt2, sz2, fecOut.data(), frameSize);
+    // Must return exactly frameSize samples — no crash, no truncation.
+    assert(fecSamples == frameSize);
+
+    // Then decode pkt2 normally to advance the decoder state.
+    std::vector<int16_t> realOut(frameSize, 0);
+    int decoded = dec.decode(pkt2, sz2, realOut.data(), frameSize);
+    assert(decoded == frameSize);
+
+    std::cout << "Test DecodeFec Does Not Crash: PASSED" << std::endl;
+}
+
+int main() {
+    testEncoderDecoderConstruct();
+    testRoundTripFidelity1kHz();
+    testEncodeRejectsWrongFrameSize();
+    testSetBitrateClampsToRange();
+    testDecodeMissingReturnsConcealedAudio();
+    testDecodeFecDoesNotCrash();
+    std::cout << "\nAll OpusCodec tests passed." << std::endl;
+    return 0;
+}

--- a/test/cpp/ring_buffer_test.cpp
+++ b/test/cpp/ring_buffer_test.cpp
@@ -1,0 +1,234 @@
+// Host-buildable test for the lock-free SPSC RingBuffer in ring_buffer.h.
+// ring_buffer.h is header-only and depends only on <atomic>/<cstdint>/<cstring>,
+// so it compiles cleanly under host g++ without the Android NDK.
+//
+// Compile (see scripts/presubmit.sh and .github/workflows/flutter.yml):
+//   g++ -std=c++17 -Wall -Wextra -pthread -I android/app/src/main/cpp
+//       test/cpp/ring_buffer_test.cpp -o build/cpp_test/ring_buffer_test
+
+#include "ring_buffer.h"
+
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+// ── Basic single-threaded correctness ────────────────────────────────────────
+
+void testEmptyReadReturnsZero() {
+    RingBuffer<int16_t, 32> rb;
+    int16_t out[8];
+    size_t n = rb.read(out, 8);
+    assert(n == 0);
+    assert(rb.availableToRead() == 0);
+    std::cout << "Test Empty Read Returns Zero: PASSED" << std::endl;
+}
+
+void testWriteReadRoundTrip() {
+    RingBuffer<int16_t, 64> rb;
+    int16_t in[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    int16_t out[8] = {};
+    size_t written = rb.write(in, 8);
+    assert(written == 8);
+    assert(rb.availableToRead() == 8);
+    size_t read = rb.read(out, 8);
+    assert(read == 8);
+    assert(rb.availableToRead() == 0);
+    for (int i = 0; i < 8; ++i) {
+        assert(out[i] == in[i]);
+    }
+    std::cout << "Test Write/Read Round Trip: PASSED" << std::endl;
+}
+
+void testPartialWriteOnFull() {
+    // Capacity is N-1 for a ring of size N (one slot reserved as sentinel).
+    RingBuffer<int16_t, 8> rb;  // holds 7 samples
+    int16_t data[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    size_t written = rb.write(data, 8);
+    assert(written == 7);
+    assert(rb.availableToWrite() == 0);
+    // A further write must be rejected entirely.
+    int16_t extra[1] = {99};
+    assert(rb.write(extra, 1) == 0);
+    std::cout << "Test Partial Write On Full: PASSED" << std::endl;
+}
+
+void testPartialReadOnUnderrun() {
+    RingBuffer<int16_t, 32> rb;
+    int16_t in[4] = {10, 20, 30, 40};
+    rb.write(in, 4);
+    int16_t out[8] = {};
+    size_t read = rb.read(out, 8);  // ask for more than available
+    assert(read == 4);
+    for (int i = 0; i < 4; ++i) {
+        assert(out[i] == in[i]);
+    }
+    std::cout << "Test Partial Read On Underrun: PASSED" << std::endl;
+}
+
+// Wrap-around: write past the end of the underlying array, read back correctly.
+void testWraparoundCorrectness() {
+    // Capacity = 7 (ring size 8). Write 5, read 5, write 5 again — the
+    // second write wraps around the internal buffer array boundary.
+    RingBuffer<int16_t, 8> rb;
+    int16_t in[5] = {1, 2, 3, 4, 5};
+    int16_t out[5] = {};
+
+    // First write-read cycle — advance the write index to 5.
+    assert(rb.write(in, 5) == 5);
+    assert(rb.read(out, 5) == 5);
+    for (int i = 0; i < 5; ++i) {
+        assert(out[i] == in[i]);
+    }
+
+    // Second write wraps around (writeIndex = 5, will reach 2 after mod 8).
+    int16_t in2[5] = {10, 20, 30, 40, 50};
+    assert(rb.write(in2, 5) == 5);
+
+    int16_t out2[5] = {};
+    assert(rb.read(out2, 5) == 5);
+    for (int i = 0; i < 5; ++i) {
+        assert(out2[i] == in2[i]);
+    }
+    assert(rb.availableToRead() == 0);
+    std::cout << "Test Wraparound Correctness: PASSED" << std::endl;
+}
+
+// peek() must not advance the read pointer.
+void testPeekDoesNotConsume() {
+    RingBuffer<int16_t, 32> rb;
+    int16_t in[4] = {7, 8, 9, 10};
+    rb.write(in, 4);
+
+    int16_t peeked[4] = {};
+    size_t n = rb.peek(peeked, 4);
+    assert(n == 4);
+    for (int i = 0; i < 4; ++i) {
+        assert(peeked[i] == in[i]);
+    }
+    assert(rb.availableToRead() == 4);  // still 4
+
+    // A subsequent read must return the same data.
+    int16_t out[4] = {};
+    assert(rb.read(out, 4) == 4);
+    for (int i = 0; i < 4; ++i) {
+        assert(out[i] == in[i]);
+    }
+    std::cout << "Test Peek Does Not Consume: PASSED" << std::endl;
+}
+
+void testClearResetsState() {
+    RingBuffer<int16_t, 32> rb;
+    int16_t in[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    rb.write(in, 8);
+    assert(rb.availableToRead() == 8);
+    rb.clear();
+    assert(rb.availableToRead() == 0);
+    constexpr size_t kCap32 = RingBuffer<int16_t, 32>::capacity();
+    assert(rb.availableToWrite() == kCap32);
+    // Write and read again after clear to confirm state is consistent.
+    rb.write(in, 8);
+    int16_t out[8] = {};
+    assert(rb.read(out, 8) == 8);
+    for (int i = 0; i < 8; ++i) {
+        assert(out[i] == in[i]);
+    }
+    std::cout << "Test Clear Resets State: PASSED" << std::endl;
+}
+
+void testAvailableToWriteAccountsForData() {
+    RingBuffer<int16_t, 16> rb;  // capacity = 15
+    constexpr size_t kCap = RingBuffer<int16_t, 16>::capacity();
+    assert(rb.availableToWrite() == kCap);
+
+    int16_t data[5] = {};
+    rb.write(data, 5);
+    assert(rb.availableToWrite() == kCap - 5);
+    assert(rb.availableToRead() == 5);
+    rb.read(data, 5);
+    assert(rb.availableToWrite() == kCap);
+    std::cout << "Test AvailableToWrite Accounts For Data: PASSED" << std::endl;
+}
+
+// ── SPSC stress: producer/consumer threads running concurrently ───────────────
+//
+// The producer writes 1-sample frames and the consumer reads them. After the
+// producer finishes, we drain remaining samples and verify that every value
+// written was eventually read in order (no corruption, no reordering).
+//
+// This exercises the release/acquire ordering on writeIndex/readIndex under
+// genuine concurrent access — a sanitizer run (TSAN) would catch races here.
+void testSpscStress() {
+    // Use a small ring so wrap-around happens frequently.
+    constexpr size_t kRingSize = 64;
+    RingBuffer<int16_t, kRingSize> rb;
+
+    constexpr int kFrames = 200000;
+    // We use values 1..32767 cycling; 0 is reserved as "unwritten".
+    constexpr int16_t kMod = 32767;
+
+    std::atomic<bool> producerDone{false};
+    std::atomic<long long> totalWritten{0};
+    std::atomic<long long> totalRead{0};
+    std::atomic<bool> orderViolation{false};
+
+    std::atomic<int16_t> nextExpected{1};
+
+    std::thread producer([&] {
+        for (int i = 0; i < kFrames; ++i) {
+            int16_t v = static_cast<int16_t>((i % kMod) + 1);
+            // Spin until the ring has room.
+            while (rb.write(&v, 1) == 0) {
+                std::this_thread::yield();
+            }
+            totalWritten.fetch_add(1, std::memory_order_relaxed);
+        }
+        producerDone.store(true, std::memory_order_release);
+    });
+
+    std::thread consumer([&] {
+        while (!producerDone.load(std::memory_order_acquire) ||
+               rb.availableToRead() > 0) {
+            int16_t v;
+            if (rb.read(&v, 1) == 1) {
+                // Check FIFO ordering.
+                int16_t expected = nextExpected.load(std::memory_order_relaxed);
+                if (v != expected) {
+                    orderViolation.store(true, std::memory_order_relaxed);
+                }
+                int16_t next = static_cast<int16_t>((expected % kMod) + 1);
+                nextExpected.store(next, std::memory_order_relaxed);
+                totalRead.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                std::this_thread::yield();
+            }
+        }
+    });
+
+    producer.join();
+    consumer.join();
+
+    assert(!orderViolation.load());
+    assert(totalWritten.load() == kFrames);
+    assert(totalRead.load() == kFrames);
+    std::cout << "Test SPSC Stress (" << kFrames << " frames): PASSED"
+              << std::endl;
+}
+
+int main() {
+    testEmptyReadReturnsZero();
+    testWriteReadRoundTrip();
+    testPartialWriteOnFull();
+    testPartialReadOnUnderrun();
+    testWraparoundCorrectness();
+    testPeekDoesNotConsume();
+    testClearResetsState();
+    testAvailableToWriteAccountsForData();
+    testSpscStress();
+    std::cout << "\nAll RingBuffer tests passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary

Closes part of #128 (C++ test gaps — item 1: RingBuffer SPSC stress; item 8: Opus round-trip).

- **`test/cpp/ring_buffer_test.cpp`** — 9 tests for the lock-free SPSC `RingBuffer<T, N>` in `ring_buffer.h`:
  - empty read returns 0
  - write/read round-trip
  - partial write when full (overflow clamping)
  - partial read on underrun
  - wraparound correctness (write index crosses array boundary)
  - peek does not advance read pointer
  - `clear()` resets both indices
  - `availableToWrite()` accounts for buffered data
  - SPSC stress: 200 k frames, two threads, FIFO-order verified end-to-end

- **`test/cpp/opus_codec_test.cpp`** — 6 tests for `OpusEncoder` / `OpusDecoder` in `opus_codec.cpp`:
  - encoder and decoder construct without error
  - 1 kHz round-trip fidelity (decoded RMS within 6 dB of input)
  - `encode()` rejects wrong frame size
  - `setBitrate()` clamps to `[kBitrateLow, kBitrateHigh]`
  - `decodeMissing()` synthesises non-silent PLC after a real packet
  - `decodeFec()` lost-packet scenario: does not crash and returns `frameSize` samples

- **`scripts/presubmit.sh`** and **`.github/workflows/flutter.yml`** — wire both new tests into the build; add `apt install libopus-dev` step to CI (required for host Opus linking via `pkg-config`).

## Test plan

- [ ] CI passes (Flutter analyze + test + all C++ tests including the two new ones)
- [ ] `ring_buffer_test` SPSC stress completes without assertion failures
- [ ] `opus_codec_test` round-trip RMS values logged in CI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added native tests for the audio codec (encode/decode, PLC, FEC recovery, bitrate clamping, error handling).
  * Added native tests for the ring buffer (single-thread correctness, wrap-around, peek/clear behavior, and concurrent producer/consumer verification).

* **Chores**
  * CI and presubmit now install necessary system audio library support and run the new native tests, failing early if required test artifacts are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->