### PR TITLE
feat(#126): Play Store listing text, data safety + permissions docs

### DIFF
--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -1,0 +1,71 @@
+# Play Store — Data Safety Form
+
+Reference answers for the Play Console Data Safety section.
+Fill these in at: **Play Console → App content → Data safety**.
+
+---
+
+## Does your app collect or share any of the required user data types?
+
+**Yes** — the app processes two narrow categories:
+
+| Data type | Collected? | Shared? | Notes |
+|---|---|---|---|
+| Voice or sound recordings (Audio) | Transient / processed | No | Mic audio is captured, Opus-encoded, and transmitted over BLE to nearby phones only. Never stored, never sent to a server. |
+| Device or other IDs (Bluetooth MAC / peerId) | Transient / on-device | No | A stable `peerId` UUID is generated on first launch and stored locally. It is shared with peers inside an active room for roster display but never sent off-device to any server. Bluetooth hardware addresses are used only by the OS for BLE connection management. |
+
+All other data type rows should be answered **No**.
+
+---
+
+## Does your app collect data?
+
+**Yes** — but only the two transient categories above.
+
+### Audio
+
+- **Why collected:** To transmit the user's voice to nearby peers in the same Frequency room.
+- **Is it encrypted in transit?** Yes — BLE link-layer encryption (LE pairing).
+- **Can the user request deletion?** Not applicable — audio is never stored. It is processed in real time and discarded.
+- **Is collection required or optional?** Required to use the core walkie-talkie feature.
+
+### Device or other IDs (peerId)
+
+- **Why collected:** To identify the local peer in the room roster displayed to others.
+- **Is it encrypted in transit?** Yes — BLE link-layer encryption.
+- **Can the user request deletion?** Yes — uninstalling the app deletes all local data including the `peerId`. There is no server-side record to delete. See the Data Deletion section below.
+- **Is collection required or optional?** Required.
+
+---
+
+## Does your app share data with third parties?
+
+**No.**
+
+The app has no `INTERNET` permission. It cannot make network connections. No data is shared with any third party or any server operated by the developer.
+
+Exception: if the user explicitly opts in to crash reporting (off by default), anonymised crash stack traces are sent to Sentry. These traces contain no audio, no display names, no peer IDs, and no location data.
+
+---
+
+## Security practices
+
+- **Data is encrypted in transit:** Yes (BLE link-layer encryption for all peer-to-peer traffic; TLS for optional crash reporting).
+- **You follow the Families Policy:** N/A — the app is rated 13+ (audio capture).
+- **Independent security review:** No formal third-party review at v1 launch.
+
+---
+
+## Data deletion
+
+The app stores no user data on any server. To delete all local data:
+
+1. Open **Settings → Apps → Walkie Talkie → Storage**.
+2. Tap **Clear Data**.
+
+Or simply uninstall the app.
+
+For the **"Account and data deletion" URL** Play Console requires: link to the
+in-app Settings screen → "Clear local data" action, or point to this document
+with the instructions above. Suggested URL: your GitHub Pages privacy-policy
+page (already filed under [docs/privacy-policy.md](privacy-policy.md)).

--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -40,17 +40,17 @@ All other data type rows should be answered **No**.
 
 ## Does your app share data with third parties?
 
-**No.**
+**No** — with one narrow, opt-in exception.
 
-The app has no `INTERNET` permission. It cannot make network connections. No data is shared with any third party or any server operated by the developer.
+All peer-to-peer voice and control traffic stays within local Bluetooth range and is never sent to any server. No data is shared with any third party by default.
 
-Exception: if the user explicitly opts in to crash reporting (off by default), anonymised crash stack traces are sent to Sentry. These traces contain no audio, no display names, no peer IDs, and no location data.
+Exception: if the user explicitly opts in to crash reporting (Settings → Crash reporting, off by default), anonymised crash stack traces are sent to Sentry. These traces contain no audio, no display names, no peer IDs, and no location data. Users who keep crash reporting disabled have zero outbound network traffic.
 
 ---
 
 ## Security practices
 
-- **Data is encrypted in transit:** Yes (BLE link-layer encryption for all peer-to-peer traffic; TLS for optional crash reporting).
+- **Data is encrypted in transit:** Yes (BLE link-layer encryption for all peer-to-peer traffic; TLS for the optional opt-in crash reporting channel).
 - **You follow the Families Policy:** N/A — the app is rated 13+ (audio capture).
 - **Independent security review:** No formal third-party review at v1 launch.
 

--- a/docs/play-store-permissions-rationale.md
+++ b/docs/play-store-permissions-rationale.md
@@ -7,6 +7,7 @@ them when responding to a policy review query.
 ---
 
 ## BLUETOOTH_SCAN
+
 > *"To discover other Walkie Talkie rooms broadcasting nearby over Bluetooth LE.
 > The `neverForLocation` flag is set — this scan cannot be used to derive the
 > user's location."*
@@ -21,6 +22,7 @@ the OS enforces that scan results cannot be used to derive location.
 ---
 
 ## BLUETOOTH_CONNECT
+
 > *"To connect to a nearby Walkie Talkie host and exchange voice and control
 > messages over GATT and L2CAP CoC (Bluetooth LE connection-oriented channels)."*
 
@@ -31,6 +33,7 @@ the voice plane (Opus-encoded audio).
 ---
 
 ## BLUETOOTH_ADVERTISE
+
 > *"To broadcast the local frequency so nearby devices can discover and join
 > your room when you are acting as host."*
 
@@ -40,6 +43,7 @@ find the room. Without this permission, a user cannot create their own channel.
 ---
 
 ## RECORD_AUDIO
+
 > *"To capture microphone input for real-time voice transmission to nearby peers
 > in the same room. Audio is Opus-encoded and sent directly over Bluetooth LE —
 > it is never stored, uploaded, or sent to any server."*
@@ -50,6 +54,7 @@ without microphone access.
 ---
 
 ## MODIFY_AUDIO_SETTINGS
+
 > *"To configure Android's audio routing so that voice output is directed to
 > the active audio device — phone speaker, wired headset, or paired Bluetooth
 > headset — according to the user's preference."*
@@ -60,6 +65,7 @@ to the correct output device when a Bluetooth headset is connected.
 ---
 
 ## FOREGROUND_SERVICE / FOREGROUND_SERVICE_MICROPHONE / FOREGROUND_SERVICE_CONNECTED_DEVICE
+
 > *"To keep the microphone and Bluetooth connection alive when the screen is off
 > or the app is in the background. A foreground service is required by Android
 > to sustain microphone capture and BLE connections outside the foreground;
@@ -74,6 +80,7 @@ maintain the BLE connection while backgrounded.
 ---
 
 ## POST_NOTIFICATIONS
+
 > *"To display the persistent 'Walkie Talkie Active' foreground notification.
 > Android 13+ requires notification permission before a foreground service
 > notification can appear; this notification is the mandatory indicator that
@@ -81,7 +88,7 @@ maintain the BLE connection while backgrounded.
 
 **Why needed:** Android 13+ (API 33) requires `POST_NOTIFICATIONS` to show any
 notification, including the mandatory foreground service notification. Denying
-this permission on API 33+ would prevent the foreground service from starting,
+this permission on API 33+ prevents the foreground service from starting,
 effectively making the app non-functional while backgrounded.
 
 ---
@@ -96,4 +103,4 @@ effectively making the app non-functional while backgrounded.
 | RECORD_AUDIO | Yes | Yes | Cannot transmit voice |
 | MODIFY_AUDIO_SETTINGS | No (normal) | N/A | No headset routing |
 | FOREGROUND_SERVICE (+ _MICROPHONE, + _CONNECTED_DEVICE) | No (normal) | N/A | OS does not allow mic/BLE BG |
-| POST_NOTIFICATIONS | Yes (Android 13+) | Yes | FGS notification hidden; BG operation degraded |
+| POST_NOTIFICATIONS | Yes (Android 13+) | Yes | On API 33+: prevents FGS from starting, app non-functional while backgrounded |

--- a/docs/play-store-permissions-rationale.md
+++ b/docs/play-store-permissions-rationale.md
@@ -1,0 +1,99 @@
+# Play Store — Permissions Rationale
+
+Justification text for each permission declared in `AndroidManifest.xml`.
+Copy these into the Play Console **App content → Permissions** section, or use
+them when responding to a policy review query.
+
+---
+
+## BLUETOOTH_SCAN
+> *"To discover other Walkie Talkie rooms broadcasting nearby over Bluetooth LE.
+> The `neverForLocation` flag is set — this scan cannot be used to derive the
+> user's location."*
+
+**Why needed:** The discovery screen lists nearby hosts that are advertising the
+Walkie Talkie service UUID. Without scan permission the list stays empty.
+
+**Privacy note:** `android:usesPermissionFlags="neverForLocation"` is set in the
+manifest, so Android does not require the user to grant location permission and
+the OS enforces that scan results cannot be used to derive location.
+
+---
+
+## BLUETOOTH_CONNECT
+> *"To connect to a nearby Walkie Talkie host and exchange voice and control
+> messages over GATT and L2CAP CoC (Bluetooth LE connection-oriented channels)."*
+
+**Why needed:** Joining a room requires a GATT connection to the host for the
+control plane (join/leave/roster/mute messages) and an L2CAP CoC channel for
+the voice plane (Opus-encoded audio).
+
+---
+
+## BLUETOOTH_ADVERTISE
+> *"To broadcast the local frequency so nearby devices can discover and join
+> your room when you are acting as host."*
+
+**Why needed:** The host role requires advertising a BLE service so guests can
+find the room. Without this permission, a user cannot create their own channel.
+
+---
+
+## RECORD_AUDIO
+> *"To capture microphone input for real-time voice transmission to nearby peers
+> in the same room. Audio is Opus-encoded and sent directly over Bluetooth LE —
+> it is never stored, uploaded, or sent to any server."*
+
+**Why needed:** Core walkie-talkie functionality. The app cannot transmit voice
+without microphone access.
+
+---
+
+## MODIFY_AUDIO_SETTINGS
+> *"To configure Android's audio routing so that voice output is directed to
+> the active audio device — phone speaker, wired headset, or paired Bluetooth
+> headset — according to the user's preference."*
+
+**Why needed:** Allows the app to call `AudioManager.setMode()` and route audio
+to the correct output device when a Bluetooth headset is connected.
+
+---
+
+## FOREGROUND_SERVICE / FOREGROUND_SERVICE_MICROPHONE / FOREGROUND_SERVICE_CONNECTED_DEVICE
+> *"To keep the microphone and Bluetooth connection alive when the screen is off
+> or the app is in the background. A foreground service is required by Android
+> to sustain microphone capture and BLE connections outside the foreground;
+> without it the OS would silence the mic and drop the connection when the user
+> pockets their phone mid-conversation."*
+
+**Why needed:** Android 9+ enforces that apps capturing the microphone from the
+background must declare and maintain a `foregroundServiceType=microphone`
+foreground service. The `connectedDevice` type is additionally required to
+maintain the BLE connection while backgrounded.
+
+---
+
+## POST_NOTIFICATIONS
+> *"To display the persistent 'Walkie Talkie Active' foreground notification.
+> Android 13+ requires notification permission before a foreground service
+> notification can appear; this notification is the mandatory indicator that
+> the microphone foreground service is running."*
+
+**Why needed:** Android 13+ (API 33) requires `POST_NOTIFICATIONS` to show any
+notification, including the mandatory foreground service notification. Denying
+this permission on API 33+ would prevent the foreground service from starting,
+effectively making the app non-functional while backgrounded.
+
+---
+
+## Summary table
+
+| Permission | Runtime prompt? | User can deny? | Impact if denied |
+|---|---|---|---|
+| BLUETOOTH_SCAN | Yes (Android 12+) | Yes | Cannot discover nearby rooms |
+| BLUETOOTH_CONNECT | Yes (Android 12+) | Yes | Cannot join or host rooms |
+| BLUETOOTH_ADVERTISE | Yes (Android 12+) | Yes | Cannot host a room |
+| RECORD_AUDIO | Yes | Yes | Cannot transmit voice |
+| MODIFY_AUDIO_SETTINGS | No (normal) | N/A | No headset routing |
+| FOREGROUND_SERVICE* | No (normal) | N/A | OS does not allow mic BG |
+| POST_NOTIFICATIONS | Yes (Android 13+) | Yes | FGS notification hidden; BG operation degraded |

--- a/docs/play-store-permissions-rationale.md
+++ b/docs/play-store-permissions-rationale.md
@@ -95,5 +95,5 @@ effectively making the app non-functional while backgrounded.
 | BLUETOOTH_ADVERTISE | Yes (Android 12+) | Yes | Cannot host a room |
 | RECORD_AUDIO | Yes | Yes | Cannot transmit voice |
 | MODIFY_AUDIO_SETTINGS | No (normal) | N/A | No headset routing |
-| FOREGROUND_SERVICE* | No (normal) | N/A | OS does not allow mic BG |
+| FOREGROUND_SERVICE (+ _MICROPHONE, + _CONNECTED_DEVICE) | No (normal) | N/A | OS does not allow mic/BLE BG |
 | POST_NOTIFICATIONS | Yes (Android 13+) | Yes | FGS notification hidden; BG operation degraded |

--- a/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,0 +1,1 @@
+Initial release. Offline peer-to-peer voice rooms over Bluetooth LE — no internet required.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -15,7 +15,7 @@ Open the app and either host your own frequency or join one a friend is broadcas
 • No accounts. Your display name is stored only on your device and shared only inside an active room.
 • No audio stored or uploaded. Voice is captured, transmitted over Bluetooth to nearby phones, and discarded in real time. Nothing leaves local Bluetooth range.
 • Bluetooth identifiers are used only for connection management between phones in the same room and are not stored beyond the active session.
-• Crash reporting is opt-in and off by default. If enabled, only anonymised crash stack traces are sent — no audio, no names, no peer IDs.
+• Crash reporting is opt-in and off by default. If enabled, only anonymised crash stack traces are sent — no audio, no display names.
 
 ── HOW VOICE WORKS ──
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,37 @@
+Walkie Talkie is an offline, privacy-first voice communication app for Android. "Tune in" to a shared frequency and you're instantly on a voice channel with everyone nearby on the same one — no Wi-Fi, no internet, no account required.
+
+── HOW IT WORKS ──
+
+Open the app and either host your own frequency or join one a friend is broadcasting nearby. Voice travels over Bluetooth LE directly between phones — there is no server in the path.
+
+• Host a channel: Your phone becomes the room host. Others can scan for your frequency and tune in.
+• Join a channel: Tap any visible frequency in the discovery list to send a join request.
+• Talk: Push-to-talk or hands-free mode. A talking ring lights up around any peer who is speaking.
+• Mute: Silence yourself without leaving the room.
+• Leave: Walk away at any time; the room stays open for others.
+
+── PRIVACY FIRST ──
+
+• No internet. The app has no INTERNET permission — confirmed offline by design.
+• No accounts. Your display name is stored only on your device and shared only inside an active room.
+• No data transmitted to any server. Ever.
+• Audio is captured, transmitted over Bluetooth to nearby phones, and discarded. Nothing leaves local Bluetooth range.
+• Bluetooth identifiers are used only for connection management between phones in the same room and are not stored beyond the active session.
+• Crash reporting is opt-in and off by default. If enabled, only anonymised crash stack traces are sent — no audio, no names, no peer IDs.
+
+── HOW VOICE WORKS ──
+
+Voice is carried over L2CAP CoC (Bluetooth LE connection-oriented channels) using the Opus codec at 24 kbps — the same codec used by Discord, WebRTC, and WhatsApp calls. A mix-minus algorithm on the host phone prevents echo: each listener hears everyone except themselves.
+
+── PERMISSIONS ──
+
+Walkie Talkie requests the minimum set of permissions needed to function:
+• Bluetooth: to discover, connect, and broadcast nearby frequencies.
+• Microphone: to capture your voice while you are in a room.
+• Notifications: to show the persistent room notification required by Android for microphone-enabled background services.
+
+No location, no contacts, no storage, no internet.
+
+── OPEN SOURCE ──
+
+Walkie Talkie is open source (MIT licence). Source code and the full wire-protocol specification are available on GitHub.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -12,10 +12,8 @@ Open the app and either host your own frequency or join one a friend is broadcas
 
 ── PRIVACY FIRST ──
 
-• No internet. The app has no INTERNET permission — confirmed offline by design.
 • No accounts. Your display name is stored only on your device and shared only inside an active room.
-• No data transmitted to any server. Ever.
-• Audio is captured, transmitted over Bluetooth to nearby phones, and discarded. Nothing leaves local Bluetooth range.
+• No audio stored or uploaded. Voice is captured, transmitted over Bluetooth to nearby phones, and discarded in real time. Nothing leaves local Bluetooth range.
 • Bluetooth identifiers are used only for connection management between phones in the same room and are not stored beyond the active session.
 • Crash reporting is opt-in and off by default. If enabled, only anonymised crash stack traces are sent — no audio, no names, no peer IDs.
 
@@ -30,7 +28,7 @@ Walkie Talkie requests the minimum set of permissions needed to function:
 • Microphone: to capture your voice while you are in a room.
 • Notifications: to show the persistent room notification required by Android for microphone-enabled background services.
 
-No location, no contacts, no storage, no internet.
+No location, no contacts, no storage.
 
 ── OPEN SOURCE ──
 

--- a/fastlane/metadata/android/en-US/images/IMAGES.md
+++ b/fastlane/metadata/android/en-US/images/IMAGES.md
@@ -1,0 +1,35 @@
+# Play Store Images
+
+Place the following assets in this directory, then upload them via Play Console
+or `fastlane supply`.
+
+## Feature graphic
+
+File name: `featureGraphic.png`
+Required size: **1024 × 500 px**
+Format: PNG or JPEG (no alpha)
+
+Suggested design:
+- Background: app primary blue (#3498DB from adaptive icon config)
+- App icon centred or offset-left
+- Tagline text: "Voice rooms. No internet. Just Bluetooth."
+- Ensure readability at small sizes (shown as a banner on the store listing)
+
+## Phone screenshots (required — at least 2)
+
+File names: `phoneScreenshots/1.png`, `2.png`, `3.png`
+Required size: Between 320 px and 3840 px on the longest side; aspect ratio 16:9 or 9:16 recommended.
+
+Suggested shots (capture on a Pixel 8 or similar):
+1. **Discovery screen** — showing 2–3 nearby frequency rows with the radar animation.
+2. **Frequency room** — showing the central dial, 2 peer chips with talking rings, and the PTT button.
+3. **Settings screen** — showing the PTT mode toggle and About section.
+
+## 7-inch tablet screenshots (recommended)
+
+File names: `sevenInchScreenshots/1.png`, `2.png`
+Play Console recommends at least 2 even if the app is phone-only.
+
+## 10-inch tablet screenshots (recommended)
+
+File names: `tenInchScreenshots/1.png`, `2.png`

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Peer-to-peer voice rooms over Bluetooth LE. No internet, no accounts, no cloud.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Walkie Talkie


### PR DESCRIPTION
## Summary

Closes part of #126 — the text-content and documentation items from the Play Store submission checklist that can be committed to the repo.

- **`fastlane/metadata/android/en-US/`** — app title, short description, full description, and v1 changelog in standard [Supply / fastlane](https://docs.fastlane.tools/actions/supply/) format; ready to paste into Play Console or upload via `fastlane supply`
- **`docs/play-store-data-safety.md`** — reference answers for the Play Console Data Safety form: covers transient audio over BLE, on-device `peerId`, confirms no server sharing, documents the data-deletion path
- **`docs/play-store-permissions-rationale.md`** — per-permission justification text for all seven permissions in `AndroidManifest.xml`, ready to paste into a policy review response
- **`fastlane/metadata/android/en-US/images/IMAGES.md`** — spec checklist for the feature graphic and screenshots (assets require a real device; not committed here)

### Acceptance criteria covered

- [x] App name ≤ 30 chars (`Walkie Talkie` = 13)
- [x] Short description ≤ 80 chars (79 chars)
- [x] Long description ≤ 4000 chars (2406 chars)
- [x] Data safety form answers documented
- [x] Permissions justification text written
- [x] Data deletion instructions documented (uninstall / Clear Data; links to privacy-policy doc)

### Remaining manual steps (not in this PR)

- [ ] Capture phone screenshots (Discovery, Room, Settings) and commit to `fastlane/metadata/android/en-US/images/phoneScreenshots/`
- [ ] Design 1024×500 feature graphic and commit to `featureGraphic.png`
- [ ] Complete IARC content rating questionnaire in Play Console (declare 13+, audio capture)
- [ ] Fill in Data Safety form in Play Console (answers in `docs/play-store-data-safety.md`)
- [ ] Set target audience to 13+ and declare audio capture
- [ ] Add data-deletion URL pointing to privacy policy page
- [ ] Set up closed testing track (12 testers × 14 days per new personal dev account policy)
- [ ] Upload to internal track and run pre-launch report on Pixel + Galaxy + Xiaomi

## Test plan

- [x] `flutter analyze` — no new issues (no Dart code changed)
- [x] `flutter test` — no tests affected (docs and text assets only)
- [x] Character count check: title 13, short desc 79, full desc 2406 (all within Play Console limits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Play Store Data Safety page: lists transient data types (captured/encoded audio and local peer ID), no server-side storage, optional opt-in anonymized crash reporting, encryption-in-transit, and step-by-step local data removal instructions.
  * Added Permissions Rationale: per-permission justifications, foreground-service and notification rationale, and a table summarizing runtime prompts and functional impacts.
  * Added Play Store metadata: title, short/full descriptions, release changelog, and image/asset guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->