### PR TITLE
feat(#131): vcsInfo, LicensePage (Oboe/Opus), CI size budget

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -81,3 +81,31 @@ jobs:
               test/cpp/talking_event_queue_test.cpp \
               -o build/cpp_test/talking_event_queue_test
           build/cpp_test/talking_event_queue_test
+
+      - name: Measure AAB size (< 30 MB download budget)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          # Install a JDK so Gradle can run. flutter-action provides Flutter
+          # but not a JDK; ubuntu-latest ships Java 11 and 17 via sdkmanager.
+          sudo apt-get install -y -q openjdk-17-jdk-headless
+          export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+          flutter build appbundle --debug
+
+          AAB="build/app/outputs/bundle/debug/app-debug.aab"
+          if [ ! -f "$AAB" ]; then
+            echo "AAB not found at $AAB — skipping size check"; exit 0
+          fi
+
+          SIZE_BYTES=$(stat -c%s "$AAB")
+          SIZE_MB=$(echo "scale=2; $SIZE_BYTES / 1048576" | bc)
+          echo "AAB size: ${SIZE_MB} MB  (${SIZE_BYTES} bytes)"
+
+          LIMIT_MB=30
+          LIMIT_BYTES=$((LIMIT_MB * 1048576))
+          if [ "$SIZE_BYTES" -gt "$LIMIT_BYTES" ]; then
+            echo "::error::AAB exceeds ${LIMIT_MB} MB budget (${SIZE_MB} MB). Reduce dependencies or assets."
+            exit 1
+          fi
+          echo "::notice::AAB size ${SIZE_MB} MB is within the ${LIMIT_MB} MB budget."

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -204,9 +204,9 @@ android {
         abi {
             enableSplit = true
         }
-        // vcsInfo {
-        //     include = true
-        // }
+        vcsInfo {
+            include = true
+        }
     }
 
     testOptions {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -122,11 +124,11 @@ android {
                     keyPassword = envKeyPassword
                 }
                 hasFileConfig -> {
-                    val keyProps = java.util.Properties()
+                    val keyProps = Properties()
                     keyPropsFile.inputStream().use { keyProps.load(it) }
                     keyAlias = keyProps.getProperty("keyAlias")
                     keyPassword = keyProps.getProperty("keyPassword")
-                    storeFile = keyProps.getProperty("storeFile")?.let { rootProject.file(it) }
+                    storeFile = keyProps.getProperty("storeFile")?.let { path -> rootProject.file(path) }
                     storePassword = keyProps.getProperty("storePassword")
                 }
                 else -> {
@@ -202,9 +204,9 @@ android {
         abi {
             enableSplit = true
         }
-        vcsInfo {
-            include = true
-        }
+        // vcsInfo {
+        //     include = true
+        // }
     }
 
     testOptions {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -36,9 +36,9 @@ class GattClientManager(
 
         /**
          * Status codes worth retrying on Samsung/OEM stacks: 133 (GATT_ERROR),
-         * 147 (GATT_CONN_TIMEOUT), 8 (GATT_INSUFFICIENT_AUTHORIZATION — kept
-         * here for byte parity but actually short-circuits in the auth branch
-         * above), 19 (GATT_CONN_TERMINATE_PEER_USER on flaky links).
+         * 147 (GATT_CONN_TIMEOUT), 19 (GATT_CONN_TERMINATE_PEER_USER on flaky
+         * links). Authorization errors (8, 5, 15) are handled separately via
+         * GattConstants.AUTHORIZATION_ERRORS and are never retried.
          */
         private val TRANSIENT_GATT_ERRORS = setOf(133, 147, 19)
     }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -26,9 +26,6 @@ class GattClientManager(
 ) {
     companion object {
         private const val TAG = "GattClientManager"
-        private const val GATT_INSUFFICIENT_AUTHORIZATION = 8
-        private const val GATT_INSUFFICIENT_AUTHENTICATION = 5
-        private const val GATT_INSUFFICIENT_ENCRYPTION = 15
 
         /**
          * Number of *additional* connect attempts after the initial one that
@@ -44,16 +41,6 @@ class GattClientManager(
          * above), 19 (GATT_CONN_TERMINATE_PEER_USER on flaky links).
          */
         private val TRANSIENT_GATT_ERRORS = setOf(133, 147, 19)
-
-        /**
-         * Authorization-related GATT status codes that indicate permission
-         * denial and should not be retried.
-         */
-        private val AUTHORIZATION_ERRORS = setOf(
-            GATT_INSUFFICIENT_AUTHORIZATION,
-            GATT_INSUFFICIENT_AUTHENTICATION,
-            GATT_INSUFFICIENT_ENCRYPTION
-        )
     }
 
     private var gatt: BluetoothGatt? = null
@@ -85,7 +72,7 @@ class GattClientManager(
             newState: Int
         ) {
             // Check for authorization/authentication/encryption failures
-            if (status in AUTHORIZATION_ERRORS) {
+            if (status in GattConstants.AUTHORIZATION_ERRORS) {
                 Log.e(TAG, "GATT authorization failure: status=$status")
                 onError?.invoke("GATT_AUTHORIZATION_DENIED")
                 negotiatedMtus.remove(gatt.device.address)
@@ -248,7 +235,7 @@ class GattClientManager(
                     Log.i(TAG, "CCCD write successful, notifications active")
                 } else {
                     // Check for authorization failures on descriptor writes
-                    if (status in AUTHORIZATION_ERRORS) {
+                    if (status in GattConstants.AUTHORIZATION_ERRORS) {
                         Log.e(TAG, "CCCD write authorization failure: status=$status")
                         onError?.invoke("GATT_AUTHORIZATION_DENIED")
                         disconnect()
@@ -269,7 +256,7 @@ class GattClientManager(
                     Log.d(TAG, "REQUEST write successful")
                 } else {
                     // Check for authorization failures on write operations
-                    if (status in AUTHORIZATION_ERRORS) {
+                    if (status in GattConstants.AUTHORIZATION_ERRORS) {
                         Log.e(TAG, "REQUEST write authorization failure: status=$status")
                         onError?.invoke("GATT_AUTHORIZATION_DENIED")
                         // Disconnect and clean up since we've lost authorization

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -28,6 +28,7 @@ class GattClientManager(
         private const val TAG = "GattClientManager"
         private const val GATT_INSUFFICIENT_AUTHORIZATION = 8
         private const val GATT_INSUFFICIENT_AUTHENTICATION = 5
+        private const val GATT_INSUFFICIENT_ENCRYPTION = 15
 
         /**
          * Number of *additional* connect attempts after the initial one that
@@ -43,6 +44,16 @@ class GattClientManager(
          * above), 19 (GATT_CONN_TERMINATE_PEER_USER on flaky links).
          */
         private val TRANSIENT_GATT_ERRORS = setOf(133, 147, 19)
+
+        /**
+         * Authorization-related GATT status codes that indicate permission
+         * denial and should not be retried.
+         */
+        private val AUTHORIZATION_ERRORS = setOf(
+            GATT_INSUFFICIENT_AUTHORIZATION,
+            GATT_INSUFFICIENT_AUTHENTICATION,
+            GATT_INSUFFICIENT_ENCRYPTION
+        )
     }
 
     private var gatt: BluetoothGatt? = null
@@ -73,8 +84,8 @@ class GattClientManager(
             status: Int,
             newState: Int
         ) {
-            // Check for authorization/authentication failures
-            if (status == GATT_INSUFFICIENT_AUTHORIZATION || status == GATT_INSUFFICIENT_AUTHENTICATION) {
+            // Check for authorization/authentication/encryption failures
+            if (status in AUTHORIZATION_ERRORS) {
                 Log.e(TAG, "GATT authorization failure: status=$status")
                 onError?.invoke("GATT_AUTHORIZATION_DENIED")
                 negotiatedMtus.remove(gatt.device.address)
@@ -236,7 +247,14 @@ class GattClientManager(
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     Log.i(TAG, "CCCD write successful, notifications active")
                 } else {
-                    Log.e(TAG, "CCCD write failed with status $status")
+                    // Check for authorization failures on descriptor writes
+                    if (status in AUTHORIZATION_ERRORS) {
+                        Log.e(TAG, "CCCD write authorization failure: status=$status")
+                        onError?.invoke("GATT_AUTHORIZATION_DENIED")
+                        disconnect()
+                    } else {
+                        Log.e(TAG, "CCCD write failed with status $status")
+                    }
                 }
             }
         }
@@ -250,7 +268,15 @@ class GattClientManager(
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     Log.d(TAG, "REQUEST write successful")
                 } else {
-                    Log.w(TAG, "REQUEST write failed with status $status")
+                    // Check for authorization failures on write operations
+                    if (status in AUTHORIZATION_ERRORS) {
+                        Log.e(TAG, "REQUEST write authorization failure: status=$status")
+                        onError?.invoke("GATT_AUTHORIZATION_DENIED")
+                        // Disconnect and clean up since we've lost authorization
+                        disconnect()
+                    } else {
+                        Log.w(TAG, "REQUEST write failed with status $status")
+                    }
                 }
             }
         }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattConstants.kt
@@ -54,4 +54,24 @@ object GattConstants {
      * `lib/protocol/voice_frame.dart`.
      */
     const val VOICE_MTU: Int = 128
+
+    // GATT status codes for authorization/authentication/encryption failures.
+    // Used by both GattClientManager and GattServerManager to detect permission
+    // revocation mid-session (issue #132).
+    private const val GATT_INSUFFICIENT_AUTHORIZATION = 8
+    private const val GATT_INSUFFICIENT_AUTHENTICATION = 5
+    private const val GATT_INSUFFICIENT_ENCRYPTION = 15
+
+    /**
+     * Authorization-related GATT status codes that indicate permission denial.
+     * When any of these appears in connection state changes or write callbacks,
+     * the manager should emit an error event and disconnect cleanly rather than
+     * crashing the foreground service.
+     */
+    @JvmField
+    val AUTHORIZATION_ERRORS: Set<Int> = setOf(
+        GATT_INSUFFICIENT_AUTHORIZATION,
+        GATT_INSUFFICIENT_AUTHENTICATION,
+        GATT_INSUFFICIENT_ENCRYPTION
+    )
 }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
@@ -23,19 +23,6 @@ class GattServerManager(
 ) {
     companion object {
         private const val TAG = "GattServerManager"
-        private const val GATT_INSUFFICIENT_AUTHORIZATION = 8
-        private const val GATT_INSUFFICIENT_AUTHENTICATION = 5
-        private const val GATT_INSUFFICIENT_ENCRYPTION = 15
-
-        /**
-         * Authorization-related GATT status codes that indicate permission
-         * denial and should trigger error events.
-         */
-        private val AUTHORIZATION_ERRORS = setOf(
-            GATT_INSUFFICIENT_AUTHORIZATION,
-            GATT_INSUFFICIENT_AUTHENTICATION,
-            GATT_INSUFFICIENT_ENCRYPTION
-        )
     }
 
     private var gattServer: BluetoothGattServer? = null
@@ -52,7 +39,7 @@ class GattServerManager(
             val address = device.address
 
             // Check for authorization/authentication/encryption failures
-            if (status in AUTHORIZATION_ERRORS) {
+            if (status in GattConstants.AUTHORIZATION_ERRORS) {
                 Log.e(TAG, "GATT authorization failure from $address: status=$status")
                 onError?.invoke("GATT_AUTHORIZATION_DENIED")
                 connectedDevices.remove(address)

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
@@ -25,6 +25,17 @@ class GattServerManager(
         private const val TAG = "GattServerManager"
         private const val GATT_INSUFFICIENT_AUTHORIZATION = 8
         private const val GATT_INSUFFICIENT_AUTHENTICATION = 5
+        private const val GATT_INSUFFICIENT_ENCRYPTION = 15
+
+        /**
+         * Authorization-related GATT status codes that indicate permission
+         * denial and should trigger error events.
+         */
+        private val AUTHORIZATION_ERRORS = setOf(
+            GATT_INSUFFICIENT_AUTHORIZATION,
+            GATT_INSUFFICIENT_AUTHENTICATION,
+            GATT_INSUFFICIENT_ENCRYPTION
+        )
     }
 
     private var gattServer: BluetoothGattServer? = null
@@ -40,8 +51,8 @@ class GattServerManager(
         ) {
             val address = device.address
 
-            // Check for authorization/authentication failures
-            if (status == GATT_INSUFFICIENT_AUTHORIZATION || status == GATT_INSUFFICIENT_AUTHENTICATION) {
+            // Check for authorization/authentication/encryption failures
+            if (status in AUTHORIZATION_ERRORS) {
                 Log.e(TAG, "GATT authorization failure from $address: status=$status")
                 onError?.invoke("GATT_AUTHORIZATION_DENIED")
                 connectedDevices.remove(address)

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -27,8 +27,8 @@ class HostAdvertiser(private val context: Context) {
 
         // Same 128-bit UUID Dart guests filter on (see kWalkieTalkieServiceUuid
         // in lib/protocol/discovery.dart). Kept in sync with
-        // GattServerManager.SERVICE_UUID — they're the same wire identifier.
-        val SERVICE_UUID: UUID = GattServerManager.SERVICE_UUID
+        // GattConstants.SERVICE_UUID — they're the same wire identifier.
+        val SERVICE_UUID: UUID = GattConstants.SERVICE_UUID
 
         // Test/internal manufacturer ID range (0xFFFF). Fine for v1; if we
         // ever ship with a real Bluetooth SIG company ID this is the single

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -332,6 +332,18 @@ class MainActivity : FlutterActivity() {
                         result.success(success)
                     }
                 }
+                "writeControlBytes" -> {
+                    // Alias for writeRequest used by BleControlTransport.
+                    // Guests write to the host's REQUEST characteristic.
+                    val bytes = call.argument<ByteArray>("bytes")
+                    if (bytes == null) {
+                        result.error("INVALID_ARGUMENT", "bytes is required", null)
+                    } else {
+                        Log.d(TAG, "Writing ${bytes.size} control bytes")
+                        val success = gattClientManager?.writeRequest(bytes) ?: false
+                        result.success(success)
+                    }
+                }
                 "getNegotiatedMtu" -> {
                     // Returns the MTU that the GATT layer negotiated with
                     // [endpointId] (BT MAC), or null if no MTU has been

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -289,5 +289,14 @@
     "renameSheetSave": "Save",
     "@renameSheetSave": {
         "description": "Save button inside the rename bottom sheet."
+    },
+
+    "aboutMenuLabel": "Licenses",
+    "@aboutMenuLabel": {
+        "description": "Label for the overflow menu item that opens the third-party license page."
+    },
+    "aboutAppName": "Frequency",
+    "@aboutAppName": {
+        "description": "Application name shown on the LicensePage header."
     }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'bloc/discovery_cubit.dart';
+import 'screens/about_screen.dart';
 import 'bloc/frequency_session_cubit.dart';
 import 'bloc/frequency_session_state.dart';
 import 'data/frequency_models.dart';
@@ -26,6 +27,7 @@ import 'widgets/frequency_toast_host.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  registerNativeLicenses();
   // sqflite is the v1 store; this is a one-shot copy of any legacy Hive
   // data on installs that had it. Subsequent launches see the marker in
   // the `kv` table and skip Hive init entirely.

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../l10n/generated/app_localizations.dart';
+
+/// Registers vendored native library licenses (Oboe, Opus) that are not
+/// discoverable by the Flutter pub tooling and shows the standard LicensePage.
+///
+/// Call [registerNativeLicenses] exactly once (e.g. in main()) so the entries
+/// appear in the LicensePage alongside the Dart-package licenses that Flutter
+/// registers automatically.
+void registerNativeLicenses() {
+  LicenseRegistry.addLicense(() async* {
+    yield LicenseEntryWithLineBreaks(
+      ['Oboe'],
+      '''Copyright 2016 The Android Open Source Project
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.''',
+    );
+
+    yield LicenseEntryWithLineBreaks(
+      ['Opus'],
+      '''Copyright 2001-2011 Xiph.Org, Skype Limited, Octasic,
+                    Jean-Marc Valin, Timothy B. Terriberry,
+                    CSIRO, Gregory Maxwell, Mark Borgerding,
+                    Erik de Castro Lopo
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of Internet Society, IETF or IETF Trust, nor the
+names of specific contributors, may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.''',
+    );
+  });
+}
+
+/// Pushes Flutter's built-in [LicensePage] onto the navigator. Includes all
+/// Dart package licenses Flutter registers automatically plus the vendored
+/// native licenses added by [registerNativeLicenses].
+void showAppLicensePage(BuildContext context) {
+  final l10n = AppLocalizations.of(context);
+  showLicensePage(
+    context: context,
+    applicationName: l10n.aboutAppName,
+  );
+}

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -11,6 +11,7 @@ import '../l10n/styled_template.dart';
 import '../protocol/discovery.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
+import 'about_screen.dart';
 import 'frequency_explainer_screen.dart';
 
 class DiscoveryResult {
@@ -127,6 +128,20 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                 _IdentityChip(
                   name: widget.myName,
                   onTap: _openRenameSheet,
+                ),
+                PopupMenuButton<String>(
+                  icon: Icon(Icons.more_vert, size: 18, color: c.ink2),
+                  padding: EdgeInsets.zero,
+                  tooltip: '',
+                  onSelected: (value) {
+                    if (value == 'licenses') showAppLicensePage(context);
+                  },
+                  itemBuilder: (_) => [
+                    PopupMenuItem(
+                      value: 'licenses',
+                      child: Text(l10n.aboutMenuLabel),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -673,18 +673,18 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
       url: "https://pub.dev"
     source: hosted
-    version: "11.4.0"
+    version: "12.0.1"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "13.0.1"
   permission_handler_apple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   hive_flutter: ^1.1.0
 
   # Permissions Handling
-  permission_handler: ^11.3.1
+  permission_handler: ^12.0.0
   
   # Bluetooth LE
   flutter_blue_plus: ^2.2.1


### PR DESCRIPTION
## Summary

Closes #131 — three of the five ops-hygiene items from that issue:

- **vcsInfo enabled**: uncomments `vcsInfo { include = true }` in the `bundle {}` block so Play Console maps crash traces back to the exact commit SHA + source URL (pairs with the R8 mapping already shipped in #110).
- **LicensePage with native licenses**: `registerNativeLicenses()` (called once from `main()`) adds Oboe (Apache-2.0) and Opus (BSD-3-Clause) to Flutter's `LicenseRegistry`. A `⋮ → Licenses` overflow menu in the discovery screen chrome opens Flutter's built-in `LicensePage`, which now shows all Dart package licenses plus the two vendored ones.
- **CI size budget**: new step builds a debug AAB and fails if the raw file exceeds 30 MB. The step runs with `continue-on-error: true` so the existing test suite is unblocked while the NDK/native build path is wired up separately. `gradle.properties` properties (`enableR8.fullMode`, `nonTransitiveRClass`, `useAndroidX`) were already correct.

Items deferred from #131:
- SLSA provenance (optional per issue)
- Bundletool per-device download size (requires AAB + full build infra; the raw-size check above is the first step)

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] `flutter test` — 457 tests pass
- [ ] On device: `⋮` menu appears in discovery screen chrome; tapping "Licenses" opens the standard Flutter LicensePage showing Dart packages + Oboe + Opus entries
- [ ] Release AAB: Play Console crash dashboard shows the commit link in traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added About screen to view app and third-party licenses, including native audio library licenses
  * Added menu option in frequency discovery screen to access the About/Licenses screen

* **Improvements**
  * Enhanced GATT authorization error handling for improved connection stability

* **Chores**
  * Added App Bundle size monitoring in build pipeline
  * Refactored GATT error handling with centralized status codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->