### PR TITLE
ci(#131): add AAB size budget check (< 30 MB)

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -81,3 +81,33 @@ jobs:
               test/cpp/talking_event_queue_test.cpp \
               -o build/cpp_test/talking_event_queue_test
           build/cpp_test/talking_event_queue_test
+
+      # App size budget (issue #131): build a debug AAB and enforce the
+      # < 30 MB download-size target. Uses the debug keystore so no signing
+      # credentials are needed. `continue-on-error` keeps the main test
+      # suite unblocked while the full NDK/Gradle/Opus build path is being
+      # validated; flip to `false` once the native build is stable in CI.
+      - name: Measure AAB size (< 30 MB budget)
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          sudo apt-get install -y -q openjdk-17-jdk-headless
+          export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+          flutter build appbundle --debug
+
+          AAB="build/app/outputs/bundle/debug/app-debug.aab"
+          if [ ! -f "$AAB" ]; then
+            echo "AAB not found at $AAB — skipping size check"; exit 0
+          fi
+
+          SIZE_BYTES=$(stat -c%s "$AAB")
+          SIZE_MB=$(echo "scale=2; $SIZE_BYTES / 1048576" | bc)
+          echo "AAB size: ${SIZE_MB} MB  (${SIZE_BYTES} bytes)"
+
+          LIMIT_BYTES=$((30 * 1048576))
+          if [ "$SIZE_BYTES" -gt "$LIMIT_BYTES" ]; then
+            echo "::error::AAB exceeds 30 MB budget (${SIZE_MB} MB). Reduce dependencies or assets."
+            exit 1
+          fi
+          echo "::notice::AAB size ${SIZE_MB} MB is within the 30 MB budget."


### PR DESCRIPTION
## Summary

Closes #131 — the one remaining item from that issue.

The other items already landed on `main`:
- `vcsInfo { include = true }` in `bundle {}` (crash traces → commit SHA in Play Console)
- `registerNativeLicenses()` + in-app `LicensePage` footer link for Oboe/Opus
- `gradle.properties` hygiene (R8 full mode, `nonTransitiveRClass`)

**This PR adds the CI size budget step** (the only missing piece):

- Builds a `--debug` AAB (debug keystore, no signing credentials required)
- Fails if the raw `.aab` file exceeds **30 MB** with a clear `::error::` annotation
- `continue-on-error: true` keeps the test suite green while the NDK/Gradle/Opus native build is validated in CI; flip to `false` once stable

## Test plan

- [ ] CI passes (Flutter analyze + test + C++ tests)
- [ ] `Measure AAB size` step appears in the workflow run log
- [ ] If the native build succeeds, the AAB size is logged as a `::notice::` annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the continuous integration pipeline with automated Android App Bundle build validation and size monitoring to ensure builds remain within specified constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->