### PR TITLE
feat(#126): Fastfile + CI workflow for fastlane supply metadata upload

### DIFF
--- a/.github/workflows/play-store-metadata.yml
+++ b/.github/workflows/play-store-metadata.yml
@@ -1,0 +1,46 @@
+name: Play Store — Upload Metadata
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'fastlane/metadata/android/**'
+
+  # Allow manual trigger (e.g. after adding screenshots).
+  workflow_dispatch:
+
+jobs:
+  upload-metadata:
+    name: Upload listing text to Play Console
+    runs-on: ubuntu-latest
+    # Minimum permissions: read checkout only.
+    # The Play Store credential is a service-account key, not a GitHub token.
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Decode Play Store service-account key
+        env:
+          PLAY_STORE_JSON_KEY_BASE64: ${{ secrets.PLAY_STORE_JSON_KEY_BASE64 }}
+        run: |
+          if [ -z "$PLAY_STORE_JSON_KEY_BASE64" ]; then
+            echo "PLAY_STORE_JSON_KEY_BASE64 secret not set — skipping upload"
+            exit 0
+          fi
+          echo "$PLAY_STORE_JSON_KEY_BASE64" | base64 -d > "${{ runner.temp }}/play-store-key.json"
+          echo "PLAY_STORE_JSON_KEY_PATH=${{ runner.temp }}/play-store-key.json" >> "$GITHUB_ENV"
+
+      - name: Upload metadata via fastlane supply
+        if: env.PLAY_STORE_JSON_KEY_PATH != ''
+        run: bundle exec fastlane android upload_metadata
+
+      - name: Clean up key
+        if: always()
+        run: rm -f "${{ runner.temp }}/play-store-key.json"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file(ENV["PLAY_STORE_JSON_KEY_PATH"] || "play-store-credentials.json")
+package_name("com.elodin.walkie_talkie")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,43 @@
+default_platform(:android)
+
+platform :android do
+  # Upload store listing text + changelogs to Play Console without touching
+  # the AAB. Requires a service-account JSON key pointed to by
+  # PLAY_STORE_JSON_KEY_PATH (or play-store-credentials.json at repo root).
+  #
+  # Run locally:
+  #   bundle exec fastlane android upload_metadata
+  #
+  # Secrets needed (Play Console → Setup → API access):
+  #   PLAY_STORE_JSON_KEY_PATH — path to the service-account JSON key file
+  desc "Upload store listing metadata (no binary) to the Play Store internal track"
+  lane :upload_metadata do
+    supply(
+      track:                   "internal",
+      skip_upload_apk:         true,
+      skip_upload_aab:         true,
+      skip_upload_metadata:    false,
+      skip_upload_changelogs:  false,
+      skip_upload_images:      true,
+      skip_upload_screenshots: true,
+      metadata_path:           "fastlane/metadata/android",
+    )
+  end
+
+  # Upload screenshots + feature graphic captured under
+  # fastlane/metadata/android/en-US/images/.
+  # Run after `upload_metadata` once the visual assets exist.
+  desc "Upload screenshots and feature graphic (images only, no metadata or binary)"
+  lane :upload_images do
+    supply(
+      track:                   "internal",
+      skip_upload_apk:         true,
+      skip_upload_aab:         true,
+      skip_upload_metadata:    true,
+      skip_upload_changelogs:  true,
+      skip_upload_images:      false,
+      skip_upload_screenshots: false,
+      metadata_path:           "fastlane/metadata/android",
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Gemfile` (fastlane gem) so the toolchain works out of the box with `bundle install`
- Adds `fastlane/Appfile` wiring `com.elodin.walkie_talkie` to the Play Store service-account key via `PLAY_STORE_JSON_KEY_PATH`
- Adds `fastlane/Fastfile` with two lanes:
  - `upload_metadata` — pushes title / short description / full description / changelog to the Play Console internal track (no binary upload)
  - `upload_images` — pushes screenshots + feature graphic once the visual assets exist under `fastlane/metadata/android/en-US/images/`
- Adds `.github/workflows/play-store-metadata.yml` — runs `upload_metadata` on every push to `main` that touches `fastlane/metadata/**`; exits gracefully when `PLAY_STORE_JSON_KEY_BASE64` is not yet configured so the workflow never blocks other CI

## How to set up the Play Store secret

1. In Play Console → Setup → API access, create a service account with the **Release manager** role.
2. Download the JSON key, base64-encode it: `base64 -w0 key.json`
3. Add the result as a repository secret named `PLAY_STORE_JSON_KEY_BASE64`.

## Remaining manual steps from #126

- Capture phone screenshots (Discovery, Room, Settings) per `fastlane/metadata/android/en-US/images/IMAGES.md`
- Design the 1024×500 feature graphic
- Fill the IARC content-rating questionnaire in Play Console
- Complete the Data Safety form in Play Console (reference: `docs/play-store-data-safety.md`)
- Set up the 12-tester × 14-day closed testing track

Closes part of #126.

## Test plan

- [ ] `bundle install` succeeds locally
- [ ] `bundle exec fastlane android upload_metadata` dry-runs without error (no key needed to validate lane syntax)
- [ ] CI workflow runs on next push that touches `fastlane/metadata/**`
- [ ] CI step exits 0 gracefully when secret is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured continuous integration workflow to automatically publish app metadata and promotional images to Google Play Store
  * Enables faster iteration cycles and more reliable app release management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->