### PR TITLE
test(#123): complete notification/headset event path coverage

### DIFF
--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -771,6 +771,108 @@ void main() {
         expect(find.text('Caleb · muted'), findsOneWidget);
       },
     );
+
+    // --- Additional notification-path coverage (issue #123) ---
+
+    testWidgets(
+      'leaveRoom event from notification or MediaSession.onStop fires onLeave',
+      (tester) async {
+        // The MediaSession onStop callback and the service's Leave
+        // PendingIntent both route through `dispatchEventFromService`,
+        // which emits a leaveRoom event on the audio EventChannel. This
+        // test exercises that path end-to-end from the EventChannel into
+        // the screen's leave handler.
+        final eventEmitter =
+            _EventChannelEmitter('com.elodin.walkie_talkie/audio_events');
+        addTearDown(eventEmitter.dispose);
+
+        var leaveCount = 0;
+        await tester.pumpWidget(_wrap(_room(onLeave: () => leaveCount++)));
+        await tester.pump();
+
+        eventEmitter.emit({'type': 'leaveRoom'});
+        await tester.pump();
+
+        expect(leaveCount, 1);
+      },
+    );
+
+    testWidgets(
+      'pttToggle in open-mic mode mutes (notification PTT button in open-mic)',
+      (tester) async {
+        // In open-mic mode pttToggle and muteToggle are symmetrical —
+        // both toggle the persistent mute. A notification labeled "PTT"
+        // that fires pttToggle should still mute the open-mic stream.
+        final eventEmitter =
+            _EventChannelEmitter('com.elodin.walkie_talkie/audio_events');
+        addTearDown(eventEmitter.dispose);
+
+        await tester.pumpWidget(_wrap(_room()));
+        await tester.pump();
+
+        // Initial: open-mic, not muted.
+        expect(find.text('Mute'), findsOneWidget);
+        expect(find.text('Caleb · muted'), findsNothing);
+
+        // First toggle → muted.
+        eventEmitter.emit({'type': 'pttToggle'});
+        await tester.pump();
+        expect(find.text('Caleb · muted'), findsOneWidget);
+        expect(find.text('Unmute'), findsOneWidget);
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': true}),
+        );
+
+        // Second toggle → back to unmuted.
+        eventEmitter.emit({'type': 'pttToggle'});
+        await tester.pump();
+        expect(find.text('Mute'), findsOneWidget);
+        expect(find.text('Caleb · muted'), findsNothing);
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': false}),
+        );
+      },
+    );
+
+    testWidgets(
+      'muteToggle in PTT mode toggles PTT holding (notification Mute button in PTT mode)',
+      (tester) async {
+        // In PTT mode muteToggle and pttToggle are symmetrical — both
+        // flip the PTT-held state. A notification "Mute" button emitting
+        // muteToggle should unmute the stream when held state is false,
+        // and re-mute it on a second press.
+        final eventEmitter =
+            _EventChannelEmitter('com.elodin.walkie_talkie/audio_events');
+        addTearDown(eventEmitter.dispose);
+
+        await tester.pumpWidget(_wrap(_room(pttMode: true)));
+        await tester.pump();
+
+        // PTT mode starts muted-until-held.
+        expect(find.text('Caleb · muted'), findsOneWidget);
+
+        // First toggle → held → unmuted.
+        eventEmitter.emit({'type': 'muteToggle'});
+        await tester.pump();
+        expect(find.text('Caleb · muted'), findsNothing);
+        expect(find.text('Caleb'), findsOneWidget);
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': false}),
+        );
+
+        // Second toggle → released → muted again.
+        eventEmitter.emit({'type': 'muteToggle'});
+        await tester.pump();
+        expect(find.text('Caleb · muted'), findsOneWidget);
+        expect(
+          audioCalls.last,
+          isMethodCall('setMuted', arguments: {'muted': true}),
+        );
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #123.

The notification-controls feature (MediaStyle notification with PTT / Mute / Leave action buttons, MediaSession headset routing) was fully implemented in PR #161 as part of #97. Issue #123 remained open because the two tests added at the time (#97's batch) covered only two of the six combinations of `{pttToggle, muteToggle, leaveRoom} × {open-mic, PTT mode}`.

This PR adds the three missing widget tests, completing the coverage:

- **`leaveRoom` via EventChannel** — verifies that a `leaveRoom` event emitted on the audio EventChannel (the path taken by `MediaSession.onStop` and by `WalkieTalkieService.handleNotificationAction` when the Leave button is pressed while the activity is alive) fires `widget.onLeave()`.
- **`pttToggle` in open-mic mode** — verifies that the PTT notification button (which emits `pttToggle`) mutes the open-mic stream, confirming the symmetry documented in the screen's event handler comment.
- **`muteToggle` in PTT mode** — verifies that the Mute notification button (which emits `muteToggle`) flips the PTT-held state in PTT mode, confirming the other symmetry.

No production code changes — all three behaviors were already implemented; these tests lock them in.

## Test plan

- [x] `flutter test test/screens/frequency_room_screen_test.dart` — 28/28 passing (was 25/25 before this PR)
- [x] `flutter analyze` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for audio event handling in the frequency room screen, including validation of room leave events, open-mic toggle state management, and PTT mode operations to ensure reliable and consistent audio feature behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->