### PR TITLE
test(#128): C++ unit tests for RingBuffer SPSC and OpusCodec round-trip

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -23,7 +23,9 @@ jobs:
           dart --version
 
       - name: Install native dependencies
-        run: sudo apt-get install -y libopus-dev
+        run: |
+          sudo apt-get update -y -q
+          sudo apt-get install -y -q libopus-dev pkg-config
 
       - name: Install dependencies
         run: flutter pub get

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -76,8 +76,17 @@ ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
 build/cpp_test/ring_buffer_test
 
 # opus_codec_test exercises OpusEncoder/OpusDecoder from opus_codec.cpp.
-# Requires libopus (install via: apt install libopus-dev).
-# pkg-config supplies the opus include path (-I/usr/include/opus on Debian/Ubuntu).
+# Requires libopus and pkg-config. Without an explicit preflight, a missing
+# libopus surfaces as a confusing "fatal error: opus.h: No such file" from g++
+# instead of a clear install hint.
+if ! command -v pkg-config >/dev/null 2>&1; then
+    echo "pkg-config not found — install it (apt install pkg-config) to run opus_codec_test."
+    exit 1
+fi
+if ! pkg-config --exists opus; then
+    echo "libopus not found via pkg-config — install it (apt install libopus-dev) to run opus_codec_test."
+    exit 1
+fi
 ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
     -I test/cpp \
     -I android/app/src/main/cpp \

--- a/test/cpp/opus_codec_test.cpp
+++ b/test/cpp/opus_codec_test.cpp
@@ -5,11 +5,25 @@
 
 #include "opus_codec.h"
 
-#include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <iostream>
 #include <vector>
+
+// CHECK is preferred over assert(): assert() is a no-op when NDEBUG is
+// defined (release/optimized builds), which would let tests pass silently
+// without any validation. CHECK always fires and aborts the binary with a
+// clear diagnostic.
+#define CHECK(cond)                                                          \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            std::cerr << "CHECK failed: " #cond                              \
+                      << " (" << __FILE__ << ":" << __LINE__ << ")"          \
+                      << std::endl;                                          \
+            std::exit(1);                                                    \
+        }                                                                    \
+    } while (0)
 
 namespace {
 
@@ -42,12 +56,35 @@ double rms(const int16_t* x, int n) {
 }  // namespace
 
 // ── Construction / teardown ───────────────────────────────────────────────────
-
+//
+// Validates that the encoder/decoder constructors actually allocated their
+// underlying libopus state — encode() and setBitrate() return -1 when the
+// internal pointer is null, so a successful encode of a real frame plus a
+// successful setBitrate proves the wrappers initialised libopus correctly.
 void testEncoderDecoderConstruct() {
     OpusEncoder enc;
     OpusDecoder dec;
-    // If the ctor fails it stores nullptr; encode/decode would return -1.
-    // We exercise that indirectly by encoding a frame below.
+
+    // setBitrate() returns the (possibly clamped) configured rate or -1 on
+    // null encoder. A non-negative result confirms the encoder is alive.
+    int rate = enc.setBitrate(audio_config::kBitrateMid);
+    CHECK(rate >= 0);
+
+    // Encoding a single valid frame must succeed (>0 bytes written) — a
+    // failed ctor would surface as encode() returning -1.
+    const int frameSize = audio_config::kCodecFrameSize;
+    std::vector<int16_t> pcmIn = makeSineFrame(1000.0);
+    uint8_t encoded[audio_config::kMaxOpusPacketSize];
+    int encodedSize = enc.encode(pcmIn.data(), frameSize, encoded,
+                                 audio_config::kMaxOpusPacketSize);
+    CHECK(encodedSize > 0);
+
+    // The decoder is exercised more thoroughly elsewhere; here we just
+    // confirm one decode call against a real packet succeeds.
+    std::vector<int16_t> pcmOut(frameSize, 0);
+    int decoded = dec.decode(encoded, encodedSize, pcmOut.data(), frameSize);
+    CHECK(decoded == frameSize);
+
     std::cout << "Test Encoder/Decoder Construct: PASSED" << std::endl;
 }
 
@@ -70,22 +107,22 @@ void testRoundTripFidelity1kHz() {
     std::vector<int16_t> pcmOut(frameSize, 0);
 
     double inputRms = rms(pcmIn.data(), frameSize);
-    assert(inputRms > 0.0);
+    CHECK(inputRms > 0.0);
 
     // Warm up: encode/decode several frames to let the encoder settle.
     int encodedSize = 0;
     for (int i = 0; i < 5; ++i) {
         encodedSize = enc.encode(pcmIn.data(), frameSize, encoded,
                                  audio_config::kMaxOpusPacketSize);
-        assert(encodedSize > 0);
+        CHECK(encodedSize > 0);
         int decoded = dec.decode(encoded, encodedSize, pcmOut.data(), frameSize);
-        assert(decoded == frameSize);
+        CHECK(decoded == frameSize);
     }
 
     double outputRms = rms(pcmOut.data(), frameSize);
     // Output must be non-silent and within 6 dB of input (~factor of 2).
-    assert(outputRms > inputRms / 2.0);
-    assert(outputRms < inputRms * 2.0);
+    CHECK(outputRms > inputRms / 2.0);
+    CHECK(outputRms < inputRms * 2.0);
     std::cout << "Test Round-Trip Fidelity 1kHz (input RMS=" << inputRms
               << ", output RMS=" << outputRms << "): PASSED" << std::endl;
 }
@@ -98,7 +135,7 @@ void testEncodeRejectsWrongFrameSize() {
     int ret = enc.encode(short_frame.data(),
                          audio_config::kCodecFrameSize - 1, out,
                          audio_config::kMaxOpusPacketSize);
-    assert(ret < 0);
+    CHECK(ret < 0);
     std::cout << "Test Encode Rejects Wrong Frame Size: PASSED" << std::endl;
 }
 
@@ -107,13 +144,13 @@ void testSetBitrateClampsToRange() {
     OpusEncoder enc;
     // Below the floor — must be clamped to kBitrateLow.
     int result = enc.setBitrate(100);
-    assert(result == audio_config::kBitrateLow);
+    CHECK(result == audio_config::kBitrateLow);
     // Above the ceiling — must be clamped to kBitrateHigh.
     result = enc.setBitrate(1000000);
-    assert(result == audio_config::kBitrateHigh);
+    CHECK(result == audio_config::kBitrateHigh);
     // Within range — must be accepted exactly.
     result = enc.setBitrate(audio_config::kBitrateMid);
-    assert(result == audio_config::kBitrateMid);
+    CHECK(result == audio_config::kBitrateMid);
     std::cout << "Test SetBitrate Clamps To Range: PASSED" << std::endl;
 }
 
@@ -133,18 +170,18 @@ void testDecodeMissingReturnsConcealedAudio() {
     // Prime the decoder with one real frame so PLC has state to extrapolate.
     int encodedSize = enc.encode(pcmIn.data(), frameSize, encoded,
                                  audio_config::kMaxOpusPacketSize);
-    assert(encodedSize > 0);
+    CHECK(encodedSize > 0);
     std::vector<int16_t> realOut(frameSize, 0);
     int decodedReal = dec.decode(encoded, encodedSize, realOut.data(), frameSize);
-    assert(decodedReal == frameSize);
+    CHECK(decodedReal == frameSize);
 
     // Now synthesise PLC for the next missing frame.
     std::vector<int16_t> plcOut(frameSize, 0);
     int plcSamples = dec.decodeMissing(plcOut.data(), frameSize);
-    assert(plcSamples == frameSize);
+    CHECK(plcSamples == frameSize);
     // PLC output must not be all-zero — Opus extrapolates from decoder state.
     double plcRms = rms(plcOut.data(), frameSize);
-    assert(plcRms > 0.0);
+    CHECK(plcRms > 0.0);
     std::cout << "Test DecodeMissing Returns Concealed Audio (PLC RMS="
               << plcRms << "): PASSED" << std::endl;
 }
@@ -155,11 +192,12 @@ void testDecodeMissingReturnsConcealedAudio() {
 // decodeFec(pkt2) to get a recovered version of frame 1 from pkt2's FEC
 // side-channel, then decode(pkt2) normally to get frame 2.
 //
-// With FEC enabled and loss > 0 the encoder embeds an LBRR copy of the
-// previous frame; we verify decodeFec returns frameSize samples without
-// crashing. Whether the result is FEC audio or PLC audio (when the encoder
-// chose not to embed FEC at this bitrate) is not observable from the API —
-// both paths are exercised by calling decodeFec without a prior decode call.
+// With FEC enabled and loss > 0 the encoder *may* embed an LBRR copy of the
+// previous frame — but Opus is free to omit FEC depending on bitrate and
+// content. A negative return from decodeFec is therefore not a failure; the
+// caller is expected to fall back to decodeMissing(). This test exercises
+// both branches: if decodeFec returns frameSize, FEC was emitted; if it
+// returns negative, we verify the PLC fallback recovers cleanly.
 void testDecodeFecDoesNotCrash() {
     const int frameSize = audio_config::kCodecFrameSize;
 
@@ -173,25 +211,33 @@ void testDecodeFecDoesNotCrash() {
     uint8_t pkt2[audio_config::kMaxOpusPacketSize];
     int sz1 = enc.encode(pcmIn.data(), frameSize, pkt1,
                          audio_config::kMaxOpusPacketSize);
-    assert(sz1 > 0);
+    CHECK(sz1 > 0);
     int sz2 = enc.encode(pcmIn.data(), frameSize, pkt2,
                          audio_config::kMaxOpusPacketSize);
-    assert(sz2 > 0);
+    CHECK(sz2 > 0);
 
     // Simulate a lost pkt1: skip decode(pkt1) and call decodeFec(pkt2)
-    // directly. Opus uses either its FEC side-channel or PLC internally.
+    // directly. If FEC is present this returns frameSize; otherwise the
+    // caller must fall back to decodeMissing() (PLC).
     OpusDecoder dec;
     std::vector<int16_t> fecOut(frameSize, 0);
     int fecSamples = dec.decodeFec(pkt2, sz2, fecOut.data(), frameSize);
-    // Must return exactly frameSize samples — no crash, no truncation.
-    assert(fecSamples == frameSize);
+    bool usedFec = (fecSamples == frameSize);
+    if (!usedFec) {
+        // No FEC side-channel — fall back to PLC.
+        CHECK(fecSamples < 0);
+        int plcSamples = dec.decodeMissing(fecOut.data(), frameSize);
+        CHECK(plcSamples == frameSize);
+    }
 
     // Then decode pkt2 normally to advance the decoder state.
     std::vector<int16_t> realOut(frameSize, 0);
     int decoded = dec.decode(pkt2, sz2, realOut.data(), frameSize);
-    assert(decoded == frameSize);
+    CHECK(decoded == frameSize);
 
-    std::cout << "Test DecodeFec Does Not Crash: PASSED" << std::endl;
+    std::cout << "Test DecodeFec Does Not Crash (FEC "
+              << (usedFec ? "used" : "absent — PLC fallback")
+              << "): PASSED" << std::endl;
 }
 
 int main() {

--- a/test/cpp/ring_buffer_test.cpp
+++ b/test/cpp/ring_buffer_test.cpp
@@ -9,13 +9,28 @@
 #include "ring_buffer.h"
 
 #include <atomic>
-#include <cassert>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <thread>
 #include <vector>
+
+// CHECK is preferred over assert(): assert() is a no-op when NDEBUG is
+// defined (release/optimized builds), which would let tests pass silently
+// without any validation. CHECK always fires and aborts the binary with a
+// clear diagnostic.
+#define CHECK(cond)                                                          \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            std::cerr << "CHECK failed: " #cond                              \
+                      << " (" << __FILE__ << ":" << __LINE__ << ")"          \
+                      << std::endl;                                          \
+            std::exit(1);                                                    \
+        }                                                                    \
+    } while (0)
 
 // ── Basic single-threaded correctness ────────────────────────────────────────
 
@@ -23,8 +38,8 @@ void testEmptyReadReturnsZero() {
     RingBuffer<int16_t, 32> rb;
     int16_t out[8];
     size_t n = rb.read(out, 8);
-    assert(n == 0);
-    assert(rb.availableToRead() == 0);
+    CHECK(n == 0);
+    CHECK(rb.availableToRead() == 0);
     std::cout << "Test Empty Read Returns Zero: PASSED" << std::endl;
 }
 
@@ -33,13 +48,13 @@ void testWriteReadRoundTrip() {
     int16_t in[8] = {1, 2, 3, 4, 5, 6, 7, 8};
     int16_t out[8] = {};
     size_t written = rb.write(in, 8);
-    assert(written == 8);
-    assert(rb.availableToRead() == 8);
+    CHECK(written == 8);
+    CHECK(rb.availableToRead() == 8);
     size_t read = rb.read(out, 8);
-    assert(read == 8);
-    assert(rb.availableToRead() == 0);
+    CHECK(read == 8);
+    CHECK(rb.availableToRead() == 0);
     for (int i = 0; i < 8; ++i) {
-        assert(out[i] == in[i]);
+        CHECK(out[i] == in[i]);
     }
     std::cout << "Test Write/Read Round Trip: PASSED" << std::endl;
 }
@@ -49,11 +64,11 @@ void testPartialWriteOnFull() {
     RingBuffer<int16_t, 8> rb;  // holds 7 samples
     int16_t data[8] = {1, 2, 3, 4, 5, 6, 7, 8};
     size_t written = rb.write(data, 8);
-    assert(written == 7);
-    assert(rb.availableToWrite() == 0);
+    CHECK(written == 7);
+    CHECK(rb.availableToWrite() == 0);
     // A further write must be rejected entirely.
     int16_t extra[1] = {99};
-    assert(rb.write(extra, 1) == 0);
+    CHECK(rb.write(extra, 1) == 0);
     std::cout << "Test Partial Write On Full: PASSED" << std::endl;
 }
 
@@ -63,9 +78,9 @@ void testPartialReadOnUnderrun() {
     rb.write(in, 4);
     int16_t out[8] = {};
     size_t read = rb.read(out, 8);  // ask for more than available
-    assert(read == 4);
+    CHECK(read == 4);
     for (int i = 0; i < 4; ++i) {
-        assert(out[i] == in[i]);
+        CHECK(out[i] == in[i]);
     }
     std::cout << "Test Partial Read On Underrun: PASSED" << std::endl;
 }
@@ -79,22 +94,22 @@ void testWraparoundCorrectness() {
     int16_t out[5] = {};
 
     // First write-read cycle — advance the write index to 5.
-    assert(rb.write(in, 5) == 5);
-    assert(rb.read(out, 5) == 5);
+    CHECK(rb.write(in, 5) == 5);
+    CHECK(rb.read(out, 5) == 5);
     for (int i = 0; i < 5; ++i) {
-        assert(out[i] == in[i]);
+        CHECK(out[i] == in[i]);
     }
 
     // Second write wraps around (writeIndex = 5, will reach 2 after mod 8).
     int16_t in2[5] = {10, 20, 30, 40, 50};
-    assert(rb.write(in2, 5) == 5);
+    CHECK(rb.write(in2, 5) == 5);
 
     int16_t out2[5] = {};
-    assert(rb.read(out2, 5) == 5);
+    CHECK(rb.read(out2, 5) == 5);
     for (int i = 0; i < 5; ++i) {
-        assert(out2[i] == in2[i]);
+        CHECK(out2[i] == in2[i]);
     }
-    assert(rb.availableToRead() == 0);
+    CHECK(rb.availableToRead() == 0);
     std::cout << "Test Wraparound Correctness: PASSED" << std::endl;
 }
 
@@ -106,17 +121,17 @@ void testPeekDoesNotConsume() {
 
     int16_t peeked[4] = {};
     size_t n = rb.peek(peeked, 4);
-    assert(n == 4);
+    CHECK(n == 4);
     for (int i = 0; i < 4; ++i) {
-        assert(peeked[i] == in[i]);
+        CHECK(peeked[i] == in[i]);
     }
-    assert(rb.availableToRead() == 4);  // still 4
+    CHECK(rb.availableToRead() == 4);  // still 4
 
     // A subsequent read must return the same data.
     int16_t out[4] = {};
-    assert(rb.read(out, 4) == 4);
+    CHECK(rb.read(out, 4) == 4);
     for (int i = 0; i < 4; ++i) {
-        assert(out[i] == in[i]);
+        CHECK(out[i] == in[i]);
     }
     std::cout << "Test Peek Does Not Consume: PASSED" << std::endl;
 }
@@ -125,17 +140,17 @@ void testClearResetsState() {
     RingBuffer<int16_t, 32> rb;
     int16_t in[8] = {1, 2, 3, 4, 5, 6, 7, 8};
     rb.write(in, 8);
-    assert(rb.availableToRead() == 8);
+    CHECK(rb.availableToRead() == 8);
     rb.clear();
-    assert(rb.availableToRead() == 0);
+    CHECK(rb.availableToRead() == 0);
     constexpr size_t kCap32 = RingBuffer<int16_t, 32>::capacity();
-    assert(rb.availableToWrite() == kCap32);
+    CHECK(rb.availableToWrite() == kCap32);
     // Write and read again after clear to confirm state is consistent.
     rb.write(in, 8);
     int16_t out[8] = {};
-    assert(rb.read(out, 8) == 8);
+    CHECK(rb.read(out, 8) == 8);
     for (int i = 0; i < 8; ++i) {
-        assert(out[i] == in[i]);
+        CHECK(out[i] == in[i]);
     }
     std::cout << "Test Clear Resets State: PASSED" << std::endl;
 }
@@ -143,14 +158,14 @@ void testClearResetsState() {
 void testAvailableToWriteAccountsForData() {
     RingBuffer<int16_t, 16> rb;  // capacity = 15
     constexpr size_t kCap = RingBuffer<int16_t, 16>::capacity();
-    assert(rb.availableToWrite() == kCap);
+    CHECK(rb.availableToWrite() == kCap);
 
     int16_t data[5] = {};
     rb.write(data, 5);
-    assert(rb.availableToWrite() == kCap - 5);
-    assert(rb.availableToRead() == 5);
+    CHECK(rb.availableToWrite() == kCap - 5);
+    CHECK(rb.availableToRead() == 5);
     rb.read(data, 5);
-    assert(rb.availableToWrite() == kCap);
+    CHECK(rb.availableToWrite() == kCap);
     std::cout << "Test AvailableToWrite Accounts For Data: PASSED" << std::endl;
 }
 
@@ -162,6 +177,11 @@ void testAvailableToWriteAccountsForData() {
 //
 // This exercises the release/acquire ordering on writeIndex/readIndex under
 // genuine concurrent access — a sanitizer run (TSAN) would catch races here.
+//
+// Watchdog: a regression in RingBuffer (or a platform-specific atomic bug)
+// could leave a thread spinning forever inside the unbounded write/yield
+// loop. The kWatchdogTimeout below caps the total wall-clock time so a hung
+// test fails the CI job in seconds rather than minutes.
 void testSpscStress() {
     // Use a small ring so wrap-around happens frequently.
     constexpr size_t kRingSize = 64;
@@ -171,18 +191,26 @@ void testSpscStress() {
     // We use values 1..32767 cycling; 0 is reserved as "unwritten".
     constexpr int16_t kMod = 32767;
 
+    // Generous on a slow CI runner but still well below a "hang" threshold.
+    constexpr auto kWatchdogTimeout = std::chrono::seconds(30);
+
     std::atomic<bool> producerDone{false};
+    std::atomic<bool> abort{false};
     std::atomic<long long> totalWritten{0};
     std::atomic<long long> totalRead{0};
     std::atomic<bool> orderViolation{false};
 
     std::atomic<int16_t> nextExpected{1};
 
+    const auto start = std::chrono::steady_clock::now();
+
     std::thread producer([&] {
         for (int i = 0; i < kFrames; ++i) {
+            if (abort.load(std::memory_order_acquire)) return;
             int16_t v = static_cast<int16_t>((i % kMod) + 1);
-            // Spin until the ring has room.
+            // Spin until the ring has room — but bail if the watchdog fires.
             while (rb.write(&v, 1) == 0) {
+                if (abort.load(std::memory_order_acquire)) return;
                 std::this_thread::yield();
             }
             totalWritten.fetch_add(1, std::memory_order_relaxed);
@@ -193,6 +221,7 @@ void testSpscStress() {
     std::thread consumer([&] {
         while (!producerDone.load(std::memory_order_acquire) ||
                rb.availableToRead() > 0) {
+            if (abort.load(std::memory_order_acquire)) return;
             int16_t v;
             if (rb.read(&v, 1) == 1) {
                 // Check FIFO ordering.
@@ -209,12 +238,51 @@ void testSpscStress() {
         }
     });
 
+    // Watchdog thread: trips the abort flag if either producer or consumer
+    // stalls past the budget. Without this, a regression in RingBuffer could
+    // leave the CI job hanging until the workflow-level timeout (typically
+    // many minutes).
+    std::thread watchdog([&] {
+        while (!producerDone.load(std::memory_order_acquire) ||
+               totalRead.load(std::memory_order_relaxed) < kFrames) {
+            if (std::chrono::steady_clock::now() - start > kWatchdogTimeout) {
+                abort.store(true, std::memory_order_release);
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    });
+
     producer.join();
     consumer.join();
+    // Wake the watchdog so it doesn't sleep out the rest of its budget when
+    // the test completed successfully — its loop exit condition already
+    // covers the success case, but a stale `abort=false` would just mean a
+    // few extra polls before it observes producerDone+totalRead.
+    abort.store(true, std::memory_order_release);
+    watchdog.join();
 
-    assert(!orderViolation.load());
-    assert(totalWritten.load() == kFrames);
-    assert(totalRead.load() == kFrames);
+    // Belt-and-suspenders drain after the producer has joined: the consumer
+    // loop's TOCTOU between `producerDone` and `availableToRead()` is
+    // already covered by the producer's release-store sequencing, but an
+    // explicit drain here makes the contract obvious and catches any
+    // future regression where the ordering invariant slips.
+    while (rb.availableToRead() > 0) {
+        int16_t v;
+        if (rb.read(&v, 1) == 1) {
+            int16_t expected = nextExpected.load(std::memory_order_relaxed);
+            if (v != expected) {
+                orderViolation.store(true, std::memory_order_relaxed);
+            }
+            int16_t next = static_cast<int16_t>((expected % kMod) + 1);
+            nextExpected.store(next, std::memory_order_relaxed);
+            totalRead.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    CHECK(!orderViolation.load());
+    CHECK(totalWritten.load() == kFrames);
+    CHECK(totalRead.load() == kFrames);
     std::cout << "Test SPSC Stress (" << kFrames << " frames): PASSED"
               << std::endl;
 }


### PR DESCRIPTION
Closes the final outstanding sub-item (item 8) of #128.

## Summary

- `test/cpp/ring_buffer_test.cpp` — 8 tests: empty read, write/read round-trip, partial overflow, partial underrun, wraparound, peek-without-consume, clear, `availableToWrite` accounting, plus a 200k-frame SPSC stress test on two threads verifying FIFO order under concurrent access.
- `test/cpp/opus_codec_test.cpp` — 6 tests: encoder/decoder construction, 1 kHz tone round-trip fidelity (RMS within 6 dB), wrong-frame-size rejection, `setBitrate` clamping to `[kBitrateLow, kBitrateHigh]`, PLC via `decodeMissing`, and the `decodeFec` lost-packet scenario.
- Wired into `scripts/presubmit.sh` and `.github/workflows/flutter.yml`; CI gains a `libopus-dev` apt install step for the Opus test.

## Test plan

- [ ] `scripts/presubmit.sh` runs the new C++ tests locally and they pass.
- [ ] CI workflow builds and runs both test binaries on the Linux runner.
- [ ] Once merged, close #128 (items 1–7 already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened native tests to always enforce expectations in all builds, added watchdogs and drain loops to prevent hangs, and improved codec encoding/decoding and FEC/PLC validations and diagnostics.

* **Chores**
  * CI now updates package lists and ensures required native tooling is installed.
  * Presubmit checks now fail early with clear messages if native tooling or codec packages are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->