### PR TITLE
deps(#118): bump sqflite, build_runner, mockito, mocktail, sqflite_common_ffi

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   build_daemon:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "110c56ef29b5eb367b4d17fc79375fa8c18a6cd7acd92c05bb3986c17a079057"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.4"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -609,18 +609,18 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: dac24d461418d363778d53198d9ac0510b9d073869f078450f195766ec48d05e
+      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.1"
+    version: "5.6.4"
   mocktail:
     dependency: "direct dev"
     description:
       name: mocktail
-      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   native_toolchain_c:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.10.1
+  sdk: ^3.11.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
   # unmaintained; `hive` + `hive_flutter` are kept transiently to drive a
   # one-shot migration from any pre-existing boxes — can be dropped in a
   # follow-up after the migration has had time to run on installed devices.)
-  sqflite: ^2.3.3+1
+  sqflite: ^2.4.2+1
   path: ^1.9.0
   path_provider: ^2.1.4
   hive: ^2.2.3
@@ -76,10 +76,10 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
-  mockito: ^5.6.1
-  build_runner: ^2.10.4
+  mockito: ^5.6.4
+  build_runner: ^2.15.0
   bloc_test: ^10.0.0
-  mocktail: ^1.0.4
+  mocktail: ^1.0.5
   flutter_launcher_icons: ^0.14.4
   # Generates the Android 12+ SplashScreen API resources (windowSplashScreen*
   # style attributes + drawable). Without these, cold start on Android 12/13/14
@@ -89,7 +89,7 @@ dev_dependencies:
   # In-memory sqflite for unit tests via FFI. Production uses the real
   # `sqflite` plugin on Android; tests inject `databaseFactoryFfi` so
   # they don't depend on the platform channel.
-  sqflite_common_ffi: ^2.3.3
+  sqflite_common_ffi: ^2.4.0+3
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/bloc/discovery_cubit_test.mocks.dart
+++ b/test/bloc/discovery_cubit_test.mocks.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i3;
 
+import 'package:flutter_blue_plus/flutter_blue_plus.dart' as _i5;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:walkie_talkie/protocol/discovery.dart' as _i4;
 import 'package:walkie_talkie/services/bluetooth_discovery_service.dart' as _i2;
@@ -57,6 +58,11 @@ class MockDiscoveryService extends _i1.Mock implements _i2.DiscoveryService {
             returnValueForMissingStub: _i3.Future<void>.value(),
           )
           as _i3.Future<void>);
+
+  @override
+  _i4.DiscoveredSession? parseResult(_i5.ScanResult? r) =>
+      (super.noSuchMethod(Invocation.method(#parseResult, [r]))
+          as _i4.DiscoveredSession?);
 
   @override
   _i3.Future<void> dispose() =>


### PR DESCRIPTION
Partial progress on #118 — bumps the dependencies that have newer compatible versions available.

## Changes

| Package | Old | New | Type |
|---|---|---|---|
| `sqflite` | `^2.3.3+1` | `^2.4.2+1` | prod, minor |
| `build_runner` | `^2.10.4` | `^2.15.0` | dev, minor |
| `mockito` | `^5.6.1` | `^5.6.4` | dev, patch |
| `mocktail` | `^1.0.4` | `^1.0.5` | dev, patch |
| `sqflite_common_ffi` | `^2.3.3` | `^2.4.0+3` | dev, minor |

`mockito` cannot reach 5.6.5: it requires `meta ^1.18.0`, but `flutter_test` from the current Flutter SDK (3.41.7) pins `meta` to `1.17.0`. Pinned at 5.6.4.

## Not addressed

`flutter_blue_plus` 3.x: no such version exists on pub.dev yet — latest stable remains `2.2.1`. The primary goal of #118 must wait until 3.x is released.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 530 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database library and development tooling to latest stable versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->