### PR TITLE
docs(#126): GitHub Pages site — stable URL for privacy policy + data deletion

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment; skip queued runs but do not cancel
+# an in-progress run since that would leave the live site in a partial state.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs/
+          destination: ./_site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      # Skip on PRs: Pages is not configured until the first push to main, and
-      # the action errors with 404 when the Pages site does not yet exist.
-      # The Jekyll build falls back to baseurl/url from docs/_config.yml.
+      # Only on main: Pages returns 404 before it is enabled, and this step is
+      # only needed for production deployments. PRs validate via Jekyll build
+      # alone, using baseurl/url from docs/_config.yml as fallback.
       - name: Configure Pages
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build with Jekyll
@@ -44,12 +44,13 @@ jobs:
           destination: ./_site
 
       - name: Upload Pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   deploy:
-    # Only deploy on pushes/dispatches to main, not on pull request builds.
-    if: github.event_name != 'pull_request'
+    # Only deploy when running on main (push or workflow_dispatch from main).
+    # Excludes PRs and workflow_dispatch triggered from non-main branches.
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,12 +17,6 @@ on:
 permissions:
   contents: read
 
-# Allow only one concurrent deployment; skip queued runs but do not cancel
-# an in-progress run since that would leave the live site in a partial state.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -54,6 +48,12 @@ jobs:
     permissions:
       pages: write
       id-token: write
+    # Serialize deploys only — PR builds run in parallel, but only one
+    # production deploy proceeds at a time. cancel-in-progress=false avoids
+    # leaving the live site in a partial state.
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/pages.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -24,21 +29,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:
           source: ./docs/
           destination: ./_site
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   deploy:
+    # Only deploy on pushes/dispatches to main, not on pull request builds.
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -47,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,10 +13,9 @@ on:
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
+# Global minimum; elevated scopes are scoped to the deploy job only.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment; skip queued runs but do not cancel
 # an in-progress run since that would leave the live site in a partial state.
@@ -31,7 +30,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # Skip on PRs: Pages is not configured until the first push to main, and
+      # the action errors with 404 when the Pages site does not yet exist.
+      # The Jekyll build falls back to baseurl/url from docs/_config.yml.
       - name: Configure Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build with Jekyll
@@ -41,11 +44,15 @@ jobs:
           destination: ./_site
 
       - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   deploy:
     # Only deploy on pushes/dispatches to main, not on pull request builds.
     if: github.event_name != 'pull_request'
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,11 @@ key.properties
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 
+# Jekyll (docs site build output)
+_site/
+.jekyll-cache/
+.jekyll-metadata
+
 # Exceptions to above rules.
 !**/ios/**/default.mode1v3
 !**/ios/**/default.mode2v3

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,7 @@
 title: Frequency
-description: "Offline, privacy-first voice rooms over Bluetooth LE — no internet required."
+description: "Offline, privacy-first voice rooms over Bluetooth LE — no internet required for core functionality."
+baseurl: "/walkie-talkie"
+url: "https://elodinlaarz.github.io"
 theme: minima
 
 minima:
@@ -8,8 +10,8 @@ minima:
     - platform: github
       user_url: "https://github.com/ElodinLaarz/walkie-talkie"
 
+# index.md is omitted: minima's site title already links to the home page.
 header_pages:
-  - index.md
   - privacy-policy.md
   - protocol.md
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,22 @@
+title: Frequency
+description: "Offline, privacy-first voice rooms over Bluetooth LE — no internet required."
+theme: minima
+
+minima:
+  date_format: "%B %-d, %Y"
+  social_links:
+    - { platform: github, user_url: "https://github.com/ElodinLaarz/walkie-talkie" }
+
+header_pages:
+  - index.md
+  - privacy-policy.md
+  - protocol.md
+
+# Keep internal reference docs out of the public site; they live in the repo
+# for contributor reference only.
+exclude:
+  - play-store-data-safety.md
+  - play-store-permissions-rationale.md
+  - sentry-setup.md
+  - smoke-test.md
+  - "*.txt"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,8 @@ theme: minima
 minima:
   date_format: "%B %-d, %Y"
   social_links:
-    - { platform: github, user_url: "https://github.com/ElodinLaarz/walkie-talkie" }
+    - platform: github
+      user_url: "https://github.com/ElodinLaarz/walkie-talkie"
 
 header_pages:
   - index.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,11 @@ title: Frequency
 
 ## Offline peer-to-peer voice rooms over Bluetooth LE
 
-**No internet. No accounts. No server.**  
+**No internet required. No accounts. No server.**  
 Open the app, tune to a frequency, and talk — voice travels directly between
-nearby phones over Bluetooth LE using the Opus codec. Nothing leaves local
-Bluetooth range.
+nearby phones over Bluetooth LE using the Opus codec. No audio is stored or
+sent to any server. Optional crash reporting (off by default) may send
+anonymised diagnostic data if enabled in Settings.
 
 [Source code on GitHub](https://github.com/ElodinLaarz/walkie-talkie) · MIT licence
 
@@ -16,8 +17,8 @@ Bluetooth range.
 
 ### Documentation
 
-- **[Privacy Policy](privacy-policy)** — what data the app processes, what is
+- **[Privacy Policy]({% link privacy-policy.md %})** — what data the app processes, what is
   stored locally, and how to delete it. Required reading for the Play Store
   Data Safety form.
-- **[Wire Protocol](protocol)** — the on-wire format for discovery
+- **[Wire Protocol]({% link protocol.md %})** — the on-wire format for discovery
   advertisements, control messages, and audio framing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+---
+layout: home
+title: Frequency
+---
+
+## Offline peer-to-peer voice rooms over Bluetooth LE
+
+**No internet. No accounts. No server.**  
+Open the app, tune to a frequency, and talk — voice travels directly between
+nearby phones over Bluetooth LE using the Opus codec. Nothing leaves local
+Bluetooth range.
+
+[Source code on GitHub](https://github.com/ElodinLaarz/walkie-talkie) · MIT licence
+
+---
+
+### Documentation
+
+- **[Privacy Policy](privacy-policy)** — what data the app processes, what is
+  stored locally, and how to delete it. Required reading for the Play Store
+  Data Safety form.
+- **[Wire Protocol](protocol)** — the on-wire format for discovery
+  advertisements, control messages, and audio framing.

--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -67,9 +67,7 @@ Or simply uninstall the app.
 
 For the **"Account and data deletion" URL** Play Console requires, use:
 
-```
-https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion
-```
+<https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion>
 
 This anchors directly to the Data Retention and Deletion section of the public
 privacy policy, which explains that uninstalling the app removes all local data

--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -65,7 +65,12 @@ The app stores no user data on any server. To delete all local data:
 
 Or simply uninstall the app.
 
-For the **"Account and data deletion" URL** Play Console requires: link to the
-in-app Settings screen → "Clear local data" action, or point to this document
-with the instructions above. Suggested URL: your GitHub Pages privacy-policy
-page (already filed under [docs/privacy-policy.md](privacy-policy.md)).
+For the **"Account and data deletion" URL** Play Console requires, use:
+
+```
+https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion
+```
+
+This anchors directly to the Data Retention and Deletion section of the public
+privacy policy, which explains that uninstalling the app removes all local data
+and that there is no server-side account to delete.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Privacy Policy
+permalink: /privacy-policy/
+---
+
 # Frequency — Privacy Policy
 
 _Last updated: 2026-04-30_
@@ -100,10 +106,12 @@ peer ID, the recent-frequencies list, and the blocked-peers list.
 ## Changes to this policy
 
 If we change how Frequency processes data we will update this file and
-revise the "Last updated" date at the top. The canonical source of this
-policy is the
+revise the "Last updated" date at the top. The canonical URL for this
+policy is
+[https://elodinlaarz.github.io/walkie-talkie/privacy-policy/](https://elodinlaarz.github.io/walkie-talkie/privacy-policy/).
+The source lives in
 [`docs/privacy-policy.md`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/docs/privacy-policy.md)
-file in the project's GitHub repository.
+in the project's GitHub repository.
 
 ## Contact
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: Wire Protocol
+permalink: /protocol/
+---
+
 # Frequency Wire Protocol — v1
 
 This document defines the wire protocol that Frequency phones use to discover


### PR DESCRIPTION
## Summary

Closes part of #126 (Play Store listing prep) by establishing a stable public URL for the privacy policy and account-deletion instructions — both required by the Play Console Data Safety and Account Deletion URL fields.

- Adds `.github/workflows/pages.yml` — Jekyll build + deploy on every push that touches `docs/` or the workflow file itself
- Adds `docs/_config.yml` — minima theme, navigation, excludes internal reference docs from the public build
- Adds `docs/index.md` — landing page with app summary and doc links
- Updates `docs/privacy-policy.md` — Jekyll front matter + canonical GitHub Pages URL
- Updates `docs/protocol.md` — Jekyll front matter + permalink
- Updates `docs/play-store-data-safety.md` — replaces the vague "Suggested URL" with the concrete anchor URL for the Play Console "Account & data deletion" field
- Updates `.gitignore` — excludes `_site/` and `.jekyll-cache/`

### Post-merge one-time step (owner)

Enable GitHub Pages in **Settings → Pages → Source: GitHub Actions**.
Subsequent pushes will then auto-publish to:

```
https://elodinlaarz.github.io/walkie-talkie/
```

The privacy policy URL that satisfies both Play Console requirements:

| Play Console field | URL |
|---|---|
| Privacy policy | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/` |
| Account & data deletion | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion` |

## Test plan

- [ ] Workflow file passes lint (`actionlint` or manual inspection)
- [ ] After merge + Pages enabled: navigate to `https://elodinlaarz.github.io/walkie-talkie/` and confirm the site renders
- [ ] Confirm privacy policy page renders at `/privacy-policy/`
- [ ] Enter the data deletion URL in Play Console data safety form and verify it is accepted as a valid URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documentation site configured for GitHub Pages publishing
  * Homepage added describing offline peer-to-peer voice rooms over Bluetooth LE
  * Privacy policy and wire protocol pages added/updated and now publicly accessible
  * Play Store data safety guidance clarified with a direct privacy-policy link

* **Chores**
  * Documentation build artifacts ignored to keep the repository clean
  * Automated Pages deployment workflow added to publish docs on changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->