### PR TITLE
deps(#118): package_info_plus 9.x → 10.x + Dependabot for pub & GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -277,10 +277,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -657,18 +665,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.1.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1150,10 +1158,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba7d5750e3441caa1bbe31d9e516348fcf8dfcb32aa29ef87a844a59f4d1f1d0
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.1.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1180,4 +1188,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.38.0"
+  flutter: ">=3.38.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   
   # UI/UX
   google_fonts: ^8.1.0
-  package_info_plus: ^9.0.0
+  package_info_plus: ^10.1.0
 
   # Crash Reporting (opt-in, privacy-first)
   sentry_flutter: ^9.0.0


### PR DESCRIPTION
## Summary

Partial close of #118 — advances the dependency-upgrade tracker by:

- **`package_info_plus` 9.x → 10.x** (`^9.0.0` → `^10.1.0`). No API changes; the only breaking requirement is Dart ≥ 3.10 / Flutter ≥ 3.38, which this project already satisfies (`sdk: ^3.11.0`). Transitive bumps: `package_info_plus_platform_interface` 3.2.1 → 4.1.0, `win32` 5.15.0 → 6.1.0, `ffi` 2.1.4 → 2.2.0.
- **`.github/dependabot.yml`** — weekly Dependabot scanning for both `pub` and `github-actions`. This means future bumps (including `flutter_blue_plus` 3.x when it ships, which unblocks the remaining item in #118) will surface as automated PRs rather than requiring a manual audit.

The remaining open item in #118 (`flutter_blue_plus` 2.x → 3.x) is blocked upstream — pub.dev's latest stable is still 2.2.1. Dependabot will open a PR automatically once 3.x lands.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 530/530 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `package_info_plus` dependency to the latest compatible version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->