### PR TITLE
feat(#133): in-app Privacy & Security FAQ screen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -563,6 +563,11 @@
 
     "securityFaqClose": "Got it",
     "@securityFaqClose": {
-        "description": "Close button on the security FAQ screen."
+        "description": "Bottom 'Got it' CTA button on the security FAQ screen."
+    },
+
+    "securityFaqCloseIcon": "Close Privacy & Security FAQ",
+    "@securityFaqCloseIcon": {
+        "description": "Accessibility label for the top-right close icon on the security FAQ screen. Distinct from the bottom 'Got it' CTA so screen readers announce different labels for the two controls."
     }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -500,5 +500,69 @@
     "settingsLicenses": "Open source licenses",
     "@settingsLicenses": {
         "description": "Tappable row that opens the in-app LicensePage."
+    },
+
+    "settingsSecurityFaq": "Privacy & Security FAQ",
+    "@settingsSecurityFaq": {
+        "description": "Tappable row in the Settings Privacy section that opens the in-app security FAQ."
+    },
+
+    "securityFaqTitle": "Privacy & Security",
+    "@securityFaqTitle": {
+        "description": "Title of the in-app security FAQ screen."
+    },
+    "securityFaqIntro": "Frequency connects phones over Bluetooth without any internet. Here's what that means for your privacy.",
+    "@securityFaqIntro": {
+        "description": "Introductory paragraph on the security FAQ screen."
+    },
+
+    "securityFaqQ1": "Is my voice encrypted?",
+    "@securityFaqQ1": {
+        "description": "Security FAQ question 1."
+    },
+    "securityFaqA1": "Frequency v1 does not enforce Bluetooth pairing or encrypted connections. Your voice travels as Opus-encoded audio over L2CAP CoC between phones, but the radio channel itself is not encrypted at the app layer.\n\nBluetooth LE pairing (link-layer encryption) is the planned foundation but is not yet required by the GATT service characteristics. A nearby phone that knows your session code can join without pairing.\n\nApp-level end-to-end encryption (E2EE) is planned for v2.",
+    "@securityFaqA1": {
+        "description": "Security FAQ answer 1. Accurately reflects that pairing is not enforced in v1."
+    },
+
+    "securityFaqQ2": "Can someone eavesdrop on my conversation?",
+    "@securityFaqQ2": {
+        "description": "Security FAQ question 2."
+    },
+    "securityFaqA2": "In v1, an attacker within Bluetooth range (roughly 10–30 metres) who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
+    "@securityFaqA2": {
+        "description": "Security FAQ answer 2."
+    },
+
+    "securityFaqQ3": "Does the app record or store my voice?",
+    "@securityFaqQ3": {
+        "description": "Security FAQ question 3."
+    },
+    "securityFaqA3": "No. Frequency does not record, upload, or persist audio. There is no server and no internet connection for voice; audio exists only in device memory while the session is live and is discarded the moment a peer disconnects.",
+    "@securityFaqA3": {
+        "description": "Security FAQ answer 3."
+    },
+
+    "securityFaqQ4": "What data leaves my device?",
+    "@securityFaqQ4": {
+        "description": "Security FAQ question 4."
+    },
+    "securityFaqA4": "Voice and control traffic travel only over Bluetooth to nearby phones — nothing goes to the internet.\n\nOver BLE advertisements, Frequency broadcasts the session UUID and the host's display name so nearby devices can discover your session. The session UUID is freshly generated each time you start a frequency; it is not linked to your account (there is none) or your persistent identity.",
+    "@securityFaqA4": {
+        "description": "Security FAQ answer 4. Corrected: session UUID (not per-install peerId) is in BLE advertisements."
+    },
+
+    "securityFaqQ5": "What about future versions?",
+    "@securityFaqQ5": {
+        "description": "Security FAQ question 5."
+    },
+    "securityFaqA5": "App-level E2EE, enforced Bluetooth pairing, and host-handover are planned for v2. Until then, use Frequency only in groups where you trust every participant's device and the space around you.",
+    "@securityFaqA5": {
+        "description": "Security FAQ answer 5."
+    },
+
+    "securityFaqClose": "Got it",
+    "@securityFaqClose": {
+        "description": "Close button on the security FAQ screen."
     }
 }

--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -8,6 +8,7 @@ import '../services/settings_store.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
 import 'frequency_privacy_policy_screen.dart';
+import 'security_faq_screen.dart';
 
 /// App settings screen — voice mode, display, privacy, and about.
 ///
@@ -144,6 +145,15 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
               ),
             );
           },
+        ),
+        _SettingsLink(
+          title: l10n.settingsSecurityFaq,
+          c: c,
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (_) => const SecurityFaqScreen(),
+            ),
+          ),
         ),
         // About
         _SectionHeader(label: l10n.settingsAboutSection, c: c),

--- a/lib/screens/security_faq_screen.dart
+++ b/lib/screens/security_faq_screen.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/generated/app_localizations.dart';
+import '../theme/app_theme.dart';
+import '../widgets/frequency_atoms.dart';
+
+/// In-app Privacy & Security FAQ.
+///
+/// Sets honest expectations about Bluetooth LE security, the absence of
+/// app-level E2EE in v1, and what data (if any) leaves the device.
+/// Addresses the security-FAQ sub-item of issue #133.
+class SecurityFaqScreen extends StatelessWidget {
+  const SecurityFaqScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    return Scaffold(
+      backgroundColor: c.bg,
+      body: SafeArea(
+        child: Column(
+          children: [
+            FreqChrome(
+              left: Text(
+                l10n.securityFaqTitle,
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: c.ink,
+                ),
+              ),
+              right: [
+                _CloseButton(
+                  semanticLabel: l10n.securityFaqClose,
+                  onTap: () => Navigator.of(context).maybePop(),
+                ),
+              ],
+            ),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Container(
+                        width: 40,
+                        height: 40,
+                        decoration: BoxDecoration(
+                          color: c.accentSoft,
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        alignment: Alignment.center,
+                        child: Icon(
+                          Icons.lock_outline,
+                          size: 20,
+                          color: c.accentInk,
+                        ),
+                      ),
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: Text(
+                          l10n.securityFaqIntro,
+                          style: TextStyle(
+                            fontFamily: 'Inter',
+                            fontSize: 13,
+                            color: c.ink2,
+                            height: 1.5,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  _FaqItem(
+                    question: l10n.securityFaqQ1,
+                    answer: l10n.securityFaqA1,
+                  ),
+                  _FaqItem(
+                    question: l10n.securityFaqQ2,
+                    answer: l10n.securityFaqA2,
+                  ),
+                  _FaqItem(
+                    question: l10n.securityFaqQ3,
+                    answer: l10n.securityFaqA3,
+                  ),
+                  _FaqItem(
+                    question: l10n.securityFaqQ4,
+                    answer: l10n.securityFaqA4,
+                  ),
+                  _FaqItem(
+                    question: l10n.securityFaqQ5,
+                    answer: l10n.securityFaqA5,
+                  ),
+                  const SizedBox(height: 8),
+                  PrimaryButton(
+                    label: l10n.securityFaqClose,
+                    block: true,
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    fontSize: 15,
+                    onPressed: () => Navigator.of(context).maybePop(),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FaqItem extends StatefulWidget {
+  final String question;
+  final String answer;
+
+  const _FaqItem({required this.question, required this.answer});
+
+  @override
+  State<_FaqItem> createState() => _FaqItemState();
+}
+
+class _FaqItemState extends State<_FaqItem> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: FreqCard(
+        padding: EdgeInsets.zero,
+        clipBehavior: Clip.antiAlias,
+        child: Semantics(
+          expanded: _expanded,
+          child: InkWell(
+            onTap: () => setState(() => _expanded = !_expanded),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          widget.question,
+                          style: TextStyle(
+                            fontFamily: 'Inter',
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: c.ink,
+                          ),
+                        ),
+                      ),
+                      Icon(
+                        _expanded
+                            ? Icons.keyboard_arrow_up
+                            : Icons.keyboard_arrow_down,
+                        size: 18,
+                        color: c.ink2,
+                      ),
+                    ],
+                  ),
+                  if (_expanded) ...[
+                    const SizedBox(height: 10),
+                    Text(
+                      widget.answer,
+                      style: TextStyle(
+                        fontFamily: 'Inter',
+                        fontSize: 13,
+                        color: c.ink2,
+                        height: 1.55,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CloseButton extends StatelessWidget {
+  final VoidCallback onTap;
+  final String semanticLabel;
+  const _CloseButton({required this.onTap, required this.semanticLabel});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Material(
+      color: Colors.transparent,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: 48,
+          height: 48,
+          child: Center(
+            child: Semantics(
+              button: true,
+              label: semanticLabel,
+              child: Icon(Icons.close, size: 20, color: c.ink2),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/security_faq_screen.dart
+++ b/lib/screens/security_faq_screen.dart
@@ -33,7 +33,7 @@ class SecurityFaqScreen extends StatelessWidget {
               ),
               right: [
                 _CloseButton(
-                  semanticLabel: l10n.securityFaqClose,
+                  semanticLabel: l10n.securityFaqCloseIcon,
                   onTap: () => Navigator.of(context).maybePop(),
                 ),
               ],

--- a/lib/screens/security_faq_screen.dart
+++ b/lib/screens/security_faq_screen.dart
@@ -133,10 +133,12 @@ class _FaqItemState extends State<_FaqItem> {
       child: FreqCard(
         padding: EdgeInsets.zero,
         clipBehavior: Clip.antiAlias,
-        child: Semantics(
-          expanded: _expanded,
-          child: InkWell(
-            onTap: () => setState(() => _expanded = !_expanded),
+        child: Material(
+          color: Colors.transparent,
+          child: Semantics(
+            expanded: _expanded,
+            child: InkWell(
+              onTap: () => setState(() => _expanded = !_expanded),
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: Column(
@@ -182,7 +184,8 @@ class _FaqItemState extends State<_FaqItem> {
           ),
         ),
       ),
-    );
+    ),
+  );
   }
 }
 

--- a/test/screens/security_faq_screen_test.dart
+++ b/test/screens/security_faq_screen_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:walkie_talkie/l10n/generated/app_localizations.dart';
+import 'package:walkie_talkie/screens/frequency_settings_screen.dart';
+import 'package:walkie_talkie/screens/security_faq_screen.dart';
+import 'package:walkie_talkie/services/settings_store.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: AppTheme.light(),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: child,
+  );
+}
+
+class _FakeSettingsStore implements SettingsStore {
+  @override
+  Future<bool> getCrashReportingEnabled() async => false;
+  @override
+  Future<void> setCrashReportingEnabled(bool v) async {}
+  @override
+  Future<bool> getPttModeEnabled() async => false;
+  @override
+  Future<void> setPttModeEnabled(bool v) async {}
+  @override
+  Future<bool> getKeepScreenOn() async => false;
+  @override
+  Future<void> setKeepScreenOn(bool v) async {}
+}
+
+void main() {
+  group('SecurityFaqScreen', () {
+    testWidgets('renders title and intro', (tester) async {
+      await tester.pumpWidget(_wrap(const SecurityFaqScreen()));
+
+      expect(find.text('Privacy & Security'), findsOneWidget);
+      expect(
+        find.textContaining('Bluetooth without any internet'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders all five questions', (tester) async {
+      await tester.pumpWidget(_wrap(const SecurityFaqScreen()));
+
+      expect(find.text('Is my voice encrypted?'), findsOneWidget);
+      expect(
+          find.text('Can someone eavesdrop on my conversation?'), findsOneWidget);
+      expect(find.text('Does the app record or store my voice?'), findsOneWidget);
+      expect(find.text('What data leaves my device?'), findsOneWidget);
+      expect(find.text('What about future versions?'), findsOneWidget);
+    });
+
+    testWidgets('answers are hidden by default', (tester) async {
+      await tester.pumpWidget(_wrap(const SecurityFaqScreen()));
+
+      expect(find.textContaining('not enforce Bluetooth pairing'), findsNothing);
+    });
+
+    testWidgets('tapping a question expands its answer', (tester) async {
+      await tester.pumpWidget(_wrap(const SecurityFaqScreen()));
+
+      await tester.tap(find.text('Is my voice encrypted?'));
+      await tester.pump();
+
+      expect(find.textContaining('not enforce Bluetooth pairing'), findsOneWidget);
+    });
+
+    testWidgets('tapping expanded question collapses it', (tester) async {
+      await tester.pumpWidget(_wrap(const SecurityFaqScreen()));
+
+      await tester.tap(find.text('Is my voice encrypted?'));
+      await tester.pump();
+      expect(find.textContaining('not enforce Bluetooth pairing'), findsOneWidget);
+
+      await tester.tap(find.text('Is my voice encrypted?'));
+      await tester.pump();
+      expect(find.textContaining('not enforce Bluetooth pairing'), findsNothing);
+    });
+
+    testWidgets('close button pops the screen', (tester) async {
+      await tester.pumpWidget(_wrap(Builder(builder: (context) {
+        return Scaffold(
+          body: Builder(builder: (innerContext) {
+            return ElevatedButton(
+              onPressed: () => Navigator.of(innerContext).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const SecurityFaqScreen(),
+                ),
+              ),
+              child: const Text('open'),
+            );
+          }),
+        );
+      })));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      expect(find.byType(SecurityFaqScreen), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+      expect(find.byType(SecurityFaqScreen), findsNothing);
+    });
+
+    testWidgets('"Got it" button pops the screen', (tester) async {
+      await tester.pumpWidget(_wrap(Builder(builder: (context) {
+        return Scaffold(
+          body: Builder(builder: (innerContext) {
+            return ElevatedButton(
+              onPressed: () => Navigator.of(innerContext).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const SecurityFaqScreen(),
+                ),
+              ),
+              child: const Text('open'),
+            );
+          }),
+        );
+      })));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView), const Offset(0, -800));
+      await tester.pump();
+
+      await tester.tap(find.text('Got it'));
+      await tester.pumpAndSettle();
+      expect(find.byType(SecurityFaqScreen), findsNothing);
+    });
+  });
+
+  group('FrequencySettingsScreen security FAQ link', () {
+    setUp(() {
+      // The settings screen calls PackageInfo.fromPlatform() in its async
+      // initState. Without mock values the platform channel throws, but the
+      // screen's try-catch handles that and still sets _loaded=true.
+      // Providing mock values makes the version row render with real data
+      // and avoids test-environment exception noise.
+      PackageInfo.setMockInitialValues(
+        appName: 'Frequency',
+        packageName: 'com.elodin.walkie_talkie',
+        version: '1.0.0',
+        buildNumber: '1',
+        buildSignature: '',
+        installerStore: null,
+      );
+    });
+
+    // The settings screen body is gated on `_loaded`, which flips only after
+    // the async initState chain (Future.wait + PackageInfo) resolves.
+    // pumpAndSettle drains all pending futures and frames so the body renders.
+    testWidgets('Privacy section shows Security FAQ link', (tester) async {
+      await tester.pumpWidget(_wrap(
+        FrequencySettingsScreen(settingsStore: _FakeSettingsStore()),
+      ));
+      await tester.pumpAndSettle();
+
+      // The Privacy section may be below the fold — scroll down to find it.
+      await tester.dragUntilVisible(
+        find.text('Privacy & Security FAQ'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      expect(find.text('Privacy & Security FAQ'), findsOneWidget);
+    });
+
+    testWidgets('tapping Security FAQ link opens SecurityFaqScreen',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        FrequencySettingsScreen(settingsStore: _FakeSettingsStore()),
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.dragUntilVisible(
+        find.text('Privacy & Security FAQ'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+
+      await tester.tap(find.text('Privacy & Security FAQ'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SecurityFaqScreen), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/security_faq_screen_test.dart
+++ b/test/screens/security_faq_screen_test.dart
@@ -101,9 +101,9 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(SecurityFaqScreen), findsOneWidget);
 
-      // The icon uses semanticLabel "Close Privacy & Security FAQ" (distinct
-      // from the bottom "Got it" CTA) — find it by the close icon.
-      await tester.tap(find.byIcon(Icons.close));
+      // Find by semantics label to verify the accessibility contract, not
+      // just the icon glyph — guards against label regressions.
+      await tester.tap(find.bySemanticsLabel('Close Privacy & Security FAQ'));
       await tester.pumpAndSettle();
       expect(find.byType(SecurityFaqScreen), findsNothing);
     });
@@ -127,8 +127,13 @@ void main() {
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
 
-      await tester.drag(find.byType(ListView), const Offset(0, -800));
-      await tester.pump();
+      // Use dragUntilVisible instead of a fixed-pixel drag so the test is
+      // stable across different viewport sizes.
+      await tester.dragUntilVisible(
+        find.text('Got it'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
 
       await tester.tap(find.text('Got it'));
       await tester.pumpAndSettle();
@@ -138,6 +143,9 @@ void main() {
 
   group('FrequencySettingsScreen security FAQ link', () {
     setUp(() {
+      // Ensure the test binding is initialized before calling
+      // setMockInitialValues — matches the pattern used elsewhere in the suite.
+      TestWidgetsFlutterBinding.ensureInitialized();
       // The settings screen calls PackageInfo.fromPlatform() in its async
       // initState. Without mock values the platform channel throws, but the
       // screen's try-catch handles that and still sets _loaded=true.

--- a/test/screens/security_faq_screen_test.dart
+++ b/test/screens/security_faq_screen_test.dart
@@ -101,6 +101,8 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(SecurityFaqScreen), findsOneWidget);
 
+      // The icon uses semanticLabel "Close Privacy & Security FAQ" (distinct
+      // from the bottom "Got it" CTA) — find it by the close icon.
       await tester.tap(find.byIcon(Icons.close));
       await tester.pumpAndSettle();
       expect(find.byType(SecurityFaqScreen), findsNothing);


### PR DESCRIPTION
## Summary

Implements the **security FAQ** sub-item from issue #133. Adds a collapsible Q&A screen reachable from **Settings → Privacy** that sets honest expectations about v1 encryption for privacy-conscious users.

- **`SecurityFaqScreen`** — 5 expandable Q&A pairs with accurate content:
  - v1 does *not* enforce Bluetooth pairing / encrypted connections (L2CAP CoC is unencrypted at the app layer)
  - A nearby attacker with the session code can join; the host device sees all audio
  - No audio recording, no server, nothing leaves the device over the internet
  - BLE advertisements carry the session UUID (freshly generated per session, not the per-install peerId) + host display name
  - App-level E2EE and enforced pairing are planned for v2
- **`FrequencySettingsScreen`** — "Privacy & Security FAQ" link added to the existing Privacy section
- **`app_en.arb`** — 12 new strings
- **9 new widget tests** covering expand/collapse, Semantics, navigation from settings, and both close affordances

### Addresses reviewer feedback from PR #193
- Copilot: corrected the FAQ copy to accurately reflect that pairing is not enforced in v1, and that session UUID (not per-install peerId) is in BLE advertisements
- Gemini + Copilot: close button uses `Material`+`InkWell`+`Semantics(button: true, label: ...)` matching the pattern in `FrequencyPrivacyPolicyScreen`
- Gemini: FAQ items wrap tap target in `Semantics(expanded: _expanded)` for screen-reader support
- Copilot: settings integration tests exercise the real `FrequencySettingsScreen` to catch chrome-wiring regressions

The other two #133 sub-items (host handover, app-level E2EE) remain deferred.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 539 tests passing (9 new)
- [ ] Manual: Settings → Privacy → "Privacy & Security FAQ" → FAQ opens → tap questions to expand/collapse → close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Privacy & Security FAQ" entry under Settings → Privacy with an in-app FAQ screen; five expandable Q&A items and two dismissal methods (top-right close icon and "Got it" action).

* **Localization**
  * Added localized strings and accessibility labels for the FAQ screen content and controls.

* **Tests**
  * Added widget tests covering the FAQ screen content, expand/collapse behavior, dismissal, and navigation from Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->