### PR TITLE
feat(#133): graceful host handover when the host leaves a room

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -200,6 +200,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   @visibleForTesting
   int get debugSeq => _seq;
 
+  /// Full session UUID for the current room. Set on the host path by
+  /// [joinRoom] and on the guest path by [_promoteToHost]. Used by
+  /// [_initiateHostTransfer] to tell the promoted peer what UUID to advertise.
+  String? _sessionUuid;
+
   FrequencySessionCubit({
     required this.identityStore,
     required this.recentFrequenciesStore,
@@ -350,6 +355,25 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         _onLinkQuality(m);
       case BitrateHint m:
         _onBitrateHint(m);
+      case HostTransfer m:
+        // If I'm the designated new host, promote. Otherwise update
+        // hostPeerId so the old host's Leave isn't mistaken for a room-kill
+        // and enter reconnecting so the UI shows progress while the new
+        // host starts up. Non-promoted guests will fall back to Discovery
+        // via the normal heartbeat-timeout → reconnect → lost path if they
+        // can't reach the new host. Hosts should not receive their own
+        // HostTransfer back (we're on the RESPONSE characteristic the
+        // host writes to), so the `roomIsHost` guard is just defensive.
+        final current = state;
+        if (isClosed || current is! SessionRoom || current.roomIsHost) break;
+        if (m.newHostPeerId == _localPeerId) {
+          unawaited(_promoteToHost(m.sessionUuid));
+        } else {
+          emit(current.copyWith(
+            hostPeerId: m.newHostPeerId,
+            connectionPhase: ConnectionPhase.reconnecting,
+          ));
+        }
       // These message types are handled by future issues
       // (voice-activity detection, join request flow). Silently drop.
       case TalkingState():
@@ -831,6 +855,90 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     unawaited(t.send(msg));
   }
 
+  /// Sends [HostTransfer] to the room, nominating [newHostPeerId] as the
+  /// successor. Waits 200 ms after the send to give the message time to
+  /// arrive over the GATT write characteristic before the caller tears down
+  /// the server. No-op when the transport is absent (tests / loopback builds).
+  Future<void> _initiateHostTransfer(
+    SessionRoom current,
+    String newHostPeerId,
+  ) async {
+    final t = _transport;
+    final sessionUuid = _sessionUuid;
+    if (t == null || sessionUuid == null) return;
+    final String peerId;
+    try {
+      peerId = _localPeerId ?? await identityStore.getPeerId();
+    } catch (error, stackTrace) {
+      if (kDebugMode) debugPrint('Failed to resolve peerId for host transfer: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+      return;
+    }
+    if (isClosed) return;
+    final msg = HostTransfer(
+      peerId: peerId,
+      seq: ++_seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+      newHostPeerId: newHostPeerId,
+      sessionUuid: sessionUuid,
+    );
+    await t.send(msg);
+    // Brief hold so the BLE write completes before the GATT server shuts down.
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+  }
+
+  /// Transitions the local peer from guest to host for the current room.
+  /// Called when a [HostTransfer] message names [_localPeerId] as the
+  /// new host.
+  ///
+  /// Stops the guest-only reporters (signal, link-quality), starts the
+  /// host BLE surfaces (advertising + GATT server) with the provided
+  /// [sessionUuid], and updates state to [roomIsHost: true]. The old
+  /// host's peerId is removed from the roster; a self-entry is added if
+  /// not already present (it should be, since the roster includes all
+  /// peers including the local one).
+  Future<void> _promoteToHost(String sessionUuid) async {
+    if (isClosed) return;
+    final current = state;
+    if (current is! SessionRoom || current.roomIsHost) return;
+    // Stop guest-only services before taking the host role.
+    _signalReporter.stop();
+    _linkQualityReporter.stop();
+    _reconnectController?.cancel();
+    _reconnectController = null;
+    _joinAcceptedWatchdog?.cancel();
+    _joinAcceptedWatchdog = null;
+    final localPeerId = _localPeerId ?? await identityStore.getPeerId();
+    if (isClosed) return;
+    // Remove the departing host from the roster and ensure the local
+    // peer (the new host) has an entry.
+    final roster = current.roster
+        .where((p) => p.peerId != current.hostPeerId)
+        .toList();
+    if (!roster.any((p) => p.peerId == localPeerId)) {
+      roster.add(ProtocolPeer(peerId: localPeerId, displayName: current.myName));
+    }
+    _sessionUuid = sessionUuid;
+    _localPeerId = localPeerId;
+    emit(current.copyWith(
+      roomIsHost: true,
+      hostPeerId: localPeerId,
+      roster: roster,
+      macAddress: null,
+      sessionUuidLow8: null,
+      connectionPhase: ConnectionPhase.online,
+    ));
+    // Start host BLE surfaces so remaining guests can reconnect.
+    final audio = _audio;
+    if (audio != null) {
+      unawaited(audio.startAdvertising(
+        sessionUuid: sessionUuid,
+        displayName: current.myName,
+      ));
+      unawaited(audio.startGattServer());
+    }
+  }
+
   /// Called when local voice activity detection triggers. Sends a [TalkingState]
   /// message over the BLE control transport to notify other peers about the
   /// local user's speaking state.
@@ -1014,6 +1122,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // logged on the future and surfaced on next launch as a missing
       // entry; nothing else depends on success here.
       unawaited(_recordRecentFrequency(roomFreq));
+      _sessionUuid = sessionUuid;
       room = SessionRoom(
         myName: myName,
         roomFreq: roomFreq,
@@ -1094,6 +1203,20 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   Future<void> leaveRoom() async {
     final current = state;
     if (current is! SessionRoom) return;
+    // If the host is leaving while guests are present, hand the room off
+    // to the first available guest rather than killing the room for everyone.
+    // We fire-and-forget the transfer message and give it a brief window to
+    // land on the wire before tearing down the GATT server. Guests who receive
+    // it before the connection drops will promote their new host immediately;
+    // any who don't will fall back to the normal reconnect / Discovery path.
+    if (current.roomIsHost) {
+      final guests = current.roster
+          .where((p) => p.peerId != current.hostPeerId)
+          .toList();
+      if (guests.isNotEmpty) {
+        await _initiateHostTransfer(current, guests.first.peerId);
+      }
+    }
     // Symmetric teardown of the host BLE surfaces booted in joinRoom.
     // Without this the device keeps advertising and serving GATT after
     // the host backs out — strangers nearby would still see the room and
@@ -1137,6 +1260,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // would otherwise swallow the next session's first messages.
     _transport?.forgetAllPeers();
     _seq = 0;
+    _sessionUuid = null;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
     emit(SessionDiscovery(

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -882,7 +882,15 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       newHostPeerId: newHostPeerId,
       sessionUuid: sessionUuid,
     );
-    await t.send(msg);
+    // Best-effort: a closing BLE link may throw here. Swallow the error so
+    // leaveRoom() teardown always proceeds — the promoted peer will fall back
+    // to Discovery if it never receives the message.
+    try {
+      await t.send(msg);
+    } catch (error, stackTrace) {
+      if (kDebugMode) debugPrint('HostTransfer send failed: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+    }
     // Brief hold so the BLE write completes before the GATT server shuts down.
     await Future<void>.delayed(const Duration(milliseconds: 200));
   }

--- a/lib/protocol/messages.dart
+++ b/lib/protocol/messages.dart
@@ -160,6 +160,7 @@ sealed class FrequencyMessage {
       'link_quality' => LinkQuality._fromJson(json),
       'bitrate_hint' => BitrateHint._fromJson(json),
       'ping' => Heartbeat._fromJson(json),
+      'host_transfer' => HostTransfer._fromJson(json),
       _ => throw FormatException('Unknown frequency message kind: $kind'),
     };
   }
@@ -734,4 +735,45 @@ final class BitrateHint extends FrequencyMessage {
       bps: bpsRaw,
     );
   }
+}
+
+// ── Host handover ────────────────────────────────────────────────────────────
+
+/// Sent by the current host just before it leaves when guests are present.
+/// The named peer should start advertising + serving GATT with [sessionUuid]
+/// and take over as the new host. All other peers update their [hostPeerId]
+/// so subsequent messages from the old host (e.g. [Leave]) are not
+/// misinterpreted as a room-killing event.
+final class HostTransfer extends FrequencyMessage {
+  final String newHostPeerId;
+
+  /// Full session UUID the new host must use when calling startAdvertising,
+  /// so the room frequency stays stable for guests that need to reconnect.
+  final String sessionUuid;
+
+  const HostTransfer({
+    required super.peerId,
+    required super.seq,
+    required super.atMs,
+    required this.newHostPeerId,
+    required this.sessionUuid,
+  });
+
+  @override
+  String get kind => 'host_transfer';
+
+  @override
+  Map<String, dynamic> toJson() => {
+        ..._envelope(),
+        'newHostPeerId': newHostPeerId,
+        'sessionUuid': sessionUuid,
+      };
+
+  factory HostTransfer._fromJson(Map<String, dynamic> j) => HostTransfer(
+        peerId: j['peerId'] as String,
+        seq: j['seq'] as int,
+        atMs: j['atMs'] as int,
+        newHostPeerId: j['newHostPeerId'] as String,
+        sessionUuid: j['sessionUuid'] as String,
+      );
 }

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -3384,6 +3384,260 @@ void main() {
       },
     );
 
+    // ── Host handover ────────────────────────────────────────────────────────
+
+    group('host handover', () {
+      // Shared transport factory matching the pattern used by the heartbeat /
+      // signal-report groups above.
+      ({
+        BleControlTransport transport,
+        List<Uint8List> outbox,
+        StreamController<({String endpointId, Uint8List bytes})> inbox,
+      }) makeT() {
+        final outbox = <Uint8List>[];
+        final inbox =
+            StreamController<({String endpointId, Uint8List bytes})>.broadcast();
+        final transport = BleControlTransport.forTest(
+          controlBytes: inbox.stream,
+          writeBytes: (bytes) async => outbox.add(bytes),
+        );
+        return (transport: transport, outbox: outbox, inbox: inbox);
+      }
+
+      // Convenience: inject a FrequencyMessage through the inbox.
+      void injectMsg(
+        StreamController<({String endpointId, Uint8List bytes})> inbox,
+        FrequencyMessage msg,
+      ) {
+        for (final frag in encodeFragments(msg.encode())) {
+          inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+      }
+
+      test(
+        'leaveRoom as host with guests sends HostTransfer before teardown',
+        () async {
+          final t = makeT();
+          final cubit = _makeCubit(
+            transport: t.transport,
+            mintSessionUuid: () => _testHostSessionUuid,
+          );
+          await cubit.bootstrap();
+          cubit.emit(const SessionDiscovery(myName: 'Maya'));
+          await cubit.joinRoom(isHost: true);
+          await Future<void>.delayed(Duration.zero);
+
+          // Inject a guest peer into the roster.
+          final roomBeforeLeave = cubit.state as SessionRoom;
+          cubit.emit(roomBeforeLeave.copyWith(
+            roster: [
+              const ProtocolPeer(peerId: 'fake-peer-id', displayName: 'Maya'),
+              const ProtocolPeer(peerId: 'peer-2', displayName: 'Devon'),
+            ],
+          ));
+
+          await cubit.leaveRoom();
+          await Future<void>.delayed(Duration.zero);
+
+          // Reassemble outbound fragments and look for a HostTransfer.
+          final reassembler = FragmentReassembler();
+          final outMsgs = <FrequencyMessage>[];
+          for (final raw in t.outbox) {
+            final json = reassembler.feed(raw);
+            if (json != null) outMsgs.add(FrequencyMessage.decode(json));
+          }
+          final transfers = outMsgs.whereType<HostTransfer>().toList();
+          expect(transfers, hasLength(1));
+          expect(transfers.single.newHostPeerId, 'peer-2');
+          expect(transfers.single.sessionUuid, _testHostSessionUuid);
+
+          await cubit.close();
+          await t.inbox.close();
+          t.transport.dispose();
+        },
+      );
+
+      test(
+        'leaveRoom as host with NO guests does not send HostTransfer',
+        () async {
+          final t = makeT();
+          final cubit = _makeCubit(
+            transport: t.transport,
+            mintSessionUuid: () => _testHostSessionUuid,
+          );
+          await cubit.bootstrap();
+          cubit.emit(const SessionDiscovery(myName: 'Maya'));
+          await cubit.joinRoom(isHost: true);
+          await Future<void>.delayed(Duration.zero);
+          // Roster has only the local host — no guests.
+
+          t.outbox.clear();
+          await cubit.leaveRoom();
+          await Future<void>.delayed(Duration.zero);
+
+          // No HostTransfer among sent messages — just check wire bytes.
+          final wire = t.outbox.map((b) => String.fromCharCodes(b)).join();
+          expect(wire, isNot(contains('host_transfer')));
+
+          await cubit.close();
+          await t.inbox.close();
+          t.transport.dispose();
+        },
+      );
+
+      test(
+        'receiving HostTransfer as the promoted peer transitions to host',
+        () async {
+          // Guest cubit with localPeerId = 'peer-2' receives a HostTransfer
+          // that names it as the new host. Expect roomIsHost→true and the
+          // old host removed from the roster.
+          final t = makeT();
+          final store = _FakeStore(initial: 'Devon');
+          store._peerId = 'peer-2';
+          final cubit = _makeCubit(
+            identityStore: store,
+            transport: t.transport,
+          );
+          await cubit.bootstrap();
+          cubit.emit(const SessionRoom(
+            myName: 'Devon',
+            roomFreq: '104.3',
+            roomIsHost: false,
+            hostPeerId: 'peer-1',
+            macAddress: 'AA:BB:CC:DD:EE:FF',
+            sessionUuidLow8: '0011223344556677',
+            roster: [
+              ProtocolPeer(peerId: 'peer-1', displayName: 'Maya'),
+              ProtocolPeer(peerId: 'peer-2', displayName: 'Devon'),
+            ],
+          ));
+
+          injectMsg(t.inbox, HostTransfer(
+            peerId: 'peer-1',
+            seq: 1,
+            atMs: 0,
+            newHostPeerId: 'peer-2',
+            sessionUuid: _testHostSessionUuid,
+          ));
+          // Two event-loop turns: one for the stream delivery, one for the
+          // async _promoteToHost body.
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+
+          final room = cubit.state as SessionRoom;
+          expect(room.roomIsHost, isTrue);
+          expect(room.hostPeerId, 'peer-2');
+          expect(room.roster.map((p) => p.peerId), isNot(contains('peer-1')));
+          expect(room.macAddress, isNull);
+          expect(room.connectionPhase, ConnectionPhase.online);
+
+          await cubit.close();
+          await t.inbox.close();
+          t.transport.dispose();
+        },
+      );
+
+      test(
+        'receiving HostTransfer as a non-promoted guest updates hostPeerId '
+        'and enters reconnecting',
+        () async {
+          final t = makeT();
+          final store = _FakeStore(initial: 'Charlie');
+          store._peerId = 'peer-3';
+          final cubit = _makeCubit(
+            identityStore: store,
+            transport: t.transport,
+          );
+          await cubit.bootstrap();
+          cubit.emit(const SessionRoom(
+            myName: 'Charlie',
+            roomFreq: '104.3',
+            roomIsHost: false,
+            hostPeerId: 'peer-1',
+            macAddress: 'AA:BB:CC:DD:EE:FF',
+            sessionUuidLow8: '0011223344556677',
+            roster: [
+              ProtocolPeer(peerId: 'peer-1', displayName: 'Maya'),
+              ProtocolPeer(peerId: 'peer-2', displayName: 'Devon'),
+              ProtocolPeer(peerId: 'peer-3', displayName: 'Charlie'),
+            ],
+          ));
+
+          injectMsg(t.inbox, HostTransfer(
+            peerId: 'peer-1',
+            seq: 1,
+            atMs: 0,
+            newHostPeerId: 'peer-2',
+            sessionUuid: _testHostSessionUuid,
+          ));
+          await Future<void>.delayed(Duration.zero);
+
+          final room = cubit.state as SessionRoom;
+          expect(room.roomIsHost, isFalse);
+          expect(room.hostPeerId, 'peer-2');
+          expect(room.connectionPhase, ConnectionPhase.reconnecting);
+
+          await cubit.close();
+          await t.inbox.close();
+          t.transport.dispose();
+        },
+      );
+
+      test(
+        'Leave from old host is not a room-kill after HostTransfer '
+        'updates hostPeerId',
+        () async {
+          // After HostTransfer, peer-2 is the new hostPeerId. A subsequent
+          // Leave from peer-1 (old host) must not trigger leaveRoom().
+          final t = makeT();
+          final store = _FakeStore(initial: 'Charlie');
+          store._peerId = 'peer-3';
+          final cubit = _makeCubit(
+            identityStore: store,
+            transport: t.transport,
+          );
+          await cubit.bootstrap();
+          cubit.emit(const SessionRoom(
+            myName: 'Charlie',
+            roomFreq: '104.3',
+            roomIsHost: false,
+            hostPeerId: 'peer-1',
+            macAddress: 'AA:BB:CC:DD:EE:FF',
+            sessionUuidLow8: '0011223344556677',
+            roster: [
+              ProtocolPeer(peerId: 'peer-1', displayName: 'Maya'),
+              ProtocolPeer(peerId: 'peer-2', displayName: 'Devon'),
+              ProtocolPeer(peerId: 'peer-3', displayName: 'Charlie'),
+            ],
+          ));
+
+          // First: HostTransfer moves hostPeerId to peer-2.
+          injectMsg(t.inbox, HostTransfer(
+            peerId: 'peer-1',
+            seq: 1,
+            atMs: 0,
+            newHostPeerId: 'peer-2',
+            sessionUuid: _testHostSessionUuid,
+          ));
+          await Future<void>.delayed(Duration.zero);
+
+          // Then: old host sends Leave.
+          injectMsg(t.inbox, const Leave(peerId: 'peer-1', seq: 2, atMs: 0));
+          await Future<void>.delayed(Duration.zero);
+
+          // Room should still be active (not Discovery).
+          expect(cubit.state, isA<SessionRoom>());
+          // peer-1 removed from roster by the Leave handler.
+          final room = cubit.state as SessionRoom;
+          expect(room.roster.map((p) => p.peerId), isNot(contains('peer-1')));
+
+          await cubit.close();
+          await t.inbox.close();
+          t.transport.dispose();
+        },
+      );
+    });
+
   });
 
   group('FrequencySessionState', () {

--- a/test/protocol/messages_test.dart
+++ b/test/protocol/messages_test.dart
@@ -461,6 +461,7 @@ void main() {
           LinkQuality() => 'link_quality',
           BitrateHint() => 'bitrate_hint',
           Heartbeat() => 'ping',
+          HostTransfer() => 'host_transfer',
         };
 
     test('every kind has a branch', () {


### PR DESCRIPTION
## Summary

Implements the **host handover** sub-item from issue #133 (the tracker for v1.5 deferred features). When the host voluntarily leaves a room that still has guests, the room now transfers to the next available peer instead of dying for everyone.

**Before**: host leaves → GATT server stops → guests' reconnect loop fails → all guests are kicked to Discovery with no indication of what happened.

**After**: host leaves → sends `HostTransfer` message → promoted peer takes over as host (starts advertising + GATT with the same session UUID, so the frequency stays stable) → non-promoted guests update their `hostPeerId` and enter `ConnectionPhase.reconnecting` while the new host spins up.

### Changes

- **`lib/protocol/messages.dart`** — new `HostTransfer` wire message (`kind: "host_transfer"`) carrying `newHostPeerId` and `sessionUuid`
- **`lib/bloc/frequency_session_cubit.dart`**:
  - `_sessionUuid` field to persist the host's session UUID across the lifetime of the room (needed for transfer)
  - `leaveRoom()`: if the departing node is host and guests are present, calls `_initiateHostTransfer()` first (picks first non-local roster peer, sends message, holds 200 ms for delivery) before normal GATT teardown
  - `_initiateHostTransfer()`: builds and sends `HostTransfer`, then awaits the 200 ms delivery hold
  - `_promoteToHost(sessionUuid)`: guest → host promotion; stops guest reporters, starts `startAdvertising` + `startGattServer`, updates state to `roomIsHost: true`
  - `_onTransportMessage()`: handles incoming `HostTransfer` — promoted peer calls `_promoteToHost`; non-promoted guests update `hostPeerId` and enter `reconnecting`
- **`test/bloc/frequency_session_cubit_test.dart`** — 5 new tests:
  1. Host with guests sends `HostTransfer` on leave
  2. Host with no guests does NOT send `HostTransfer`
  3. Promoted peer transitions to host role (state, roster, macAddress)
  4. Non-promoted guest updates `hostPeerId` + enters reconnecting
  5. Old host's subsequent `Leave` is not treated as a room-kill after `hostPeerId` update

### Limitations / follow-up

Non-promoted guests' reconnect path still uses the old host's MAC address (via the existing `ReconnectController`). Since that MAC is gone, they will fall back to Discovery after the reconnect budget expires. The new host is advertising with the same session UUID/frequency, so guests can rediscover the room immediately. Seamless reconnect (scan-by-session-UUID → connect to new host's MAC) is a natural v1.5 follow-up that would require injecting `DiscoveryService` into the cubit.

The other two #133 sub-items are handled in separate PRs: security FAQ in [#195](https://github.com/ElodinLaarz/walkie-talkie/pull/195) and report-abuse flow in [#191](https://github.com/ElodinLaarz/walkie-talkie/pull/191).

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test test/bloc/frequency_session_cubit_test.dart` — 97 tests passing (5 new)
- [ ] Manual: host a room with 2+ devices → host taps Leave → second device becomes host (advertising resumes at same frequency) → third device shows "Reconnecting…" and finds the new host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic host transfer mechanism: when the host leaves a room with remaining guests, session leadership automatically transfers to the next peer without triggering a full room reconnection, maintaining session stability and continuity.
  * New host-transfer protocol message enables seamless peer coordination and state synchronization during the handoff process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->