### PR TITLE
fix(#118): migrate BLE scan to onScanResults + cancelWhenScanComplete

### DIFF
--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -28,8 +28,8 @@ class DiscoveryService {
       throw Exception('Bluetooth LE is not supported on this device');
     }
 
-    if (await FlutterBluePlus.adapterState.first == BluetoothAdapterState.off) {
-      throw Exception('Bluetooth adapter is off');
+    if (await FlutterBluePlus.adapterState.first != BluetoothAdapterState.on) {
+      throw Exception('Bluetooth adapter is not on');
     }
 
     // Check runtime permissions.
@@ -43,8 +43,11 @@ class DiscoveryService {
     _emit();
 
     // 2. Listen for scan results.
+    // onScanResults is preferred over scanResults: it does not replay stale
+    // results after scanning stops, avoiding a spurious re-emission on the
+    // next startScan() call before the new results arrive.
     await _scanSubscription?.cancel();
-    _scanSubscription = FlutterBluePlus.scanResults.listen((results) {
+    _scanSubscription = FlutterBluePlus.onScanResults.listen((results) {
       for (ScanResult r in results) {
         final session = parseResult(r);
         if (session != null) {
@@ -57,6 +60,9 @@ class DiscoveryService {
       // of range — the listener still needs to see the empty list).
       _emit();
     });
+    // Auto-cancel the subscription if the OS stops the scan unexpectedly
+    // (e.g. adapter turned off, or platform scan timeout).
+    FlutterBluePlus.cancelWhenScanComplete(_scanSubscription!);
 
     // 3. Start scanning.
     // We filter by the service UUID defined in the protocol.


### PR DESCRIPTION
## Summary

Applies flutter_blue_plus 2.x best-practice API improvements to `DiscoveryService`, the only file that imports the package. No 3.x version exists yet (latest stable: 2.2.1, published 2026-02-25); this commit closes the remaining 2.x actionable work in #118.

- **`onScanResults` instead of `scanResults`** — the 2.x-preferred stream does not replay stale results after scanning stops, preventing a spurious re-emission on the next `startScan()` call before fresh results arrive
- **`cancelWhenScanComplete`** — registers the subscription for auto-cancellation if the OS stops the scan unexpectedly (Bluetooth disabled mid-scan, platform timeout, etc.), acting as a safety net alongside the explicit `cancel()` in `stopScan()`
- **Adapter state guard tightened** — previously `== BluetoothAdapterState.off`, which would pass through on transient states (`turningOn`, `unknown`); now `!= BluetoothAdapterState.on` so we fail-fast in any non-ready state

## Test plan

- [x] `flutter test test/services/bluetooth_discovery_service_test.dart` — 11/11 pass
- [x] `flutter test` — all pre-existing passes still pass (69 analyze errors are pre-existing from open PRs #191/#192 and unrelated to this change)
- [ ] Manual smoke test: discovery screen finds nearby hosts after upgrade

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth device discovery reliability by preventing stale scan results from reappearing
  * Enhanced handling of unexpected scan interruptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->