### PR TITLE
ci(#126): upload screenshots + feature graphic in play-store CI workflow

### DIFF
--- a/.github/workflows/play-store-metadata.yml
+++ b/.github/workflows/play-store-metadata.yml
@@ -1,4 +1,4 @@
-name: Play Store — Upload Metadata
+name: Play Store — Upload Metadata & Images
 
 on:
   push:
@@ -6,12 +6,12 @@ on:
     paths:
       - 'fastlane/metadata/android/**'
 
-  # Allow manual trigger (e.g. after adding screenshots).
+  # Allow manual trigger (e.g. to force a re-upload after key rotation).
   workflow_dispatch:
 
 jobs:
   upload-metadata:
-    name: Upload listing text to Play Console
+    name: Upload listing text + images to Play Console
     runs-on: ubuntu-latest
     # Minimum permissions: read checkout only.
     # The Play Store credential is a service-account key, not a GitHub token.
@@ -37,9 +37,13 @@ jobs:
           echo "$PLAY_STORE_JSON_KEY_BASE64" | base64 -d > "${{ runner.temp }}/play-store-key.json"
           echo "PLAY_STORE_JSON_KEY_PATH=${{ runner.temp }}/play-store-key.json" >> "$GITHUB_ENV"
 
-      - name: Upload metadata via fastlane supply
+      - name: Upload listing text + changelogs via fastlane supply
         if: env.PLAY_STORE_JSON_KEY_PATH != ''
         run: bundle exec fastlane android upload_metadata
+
+      - name: Upload screenshots + feature graphic via fastlane supply
+        if: env.PLAY_STORE_JSON_KEY_PATH != ''
+        run: bundle exec fastlane android upload_images
 
       - name: Clean up key
         if: always()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,4 +40,16 @@ platform :android do
       metadata_path:           "fastlane/metadata/android",
     )
   end
+
+  # Upload everything — listing text, changelogs, feature graphic, and
+  # screenshots — in one shot. Useful for initial Play Console population
+  # or after large batches of changes.
+  #
+  # Run locally:
+  #   bundle exec fastlane android upload_all
+  desc "Upload metadata + images to the Play Store internal track (full listing refresh)"
+  lane :upload_all do
+    upload_metadata
+    upload_images
+  end
 end


### PR DESCRIPTION
## Summary

The `play-store-metadata.yml` workflow called only `upload_metadata` (which sets `skip_upload_images: true`). Now that `featureGraphic.png`, `phoneScreenshots/`, `sevenInchScreenshots/`, and `tenInchScreenshots/` are all committed (PRs #202–#204), CI needs to upload them to Play Console too.

### Changes

**`.github/workflows/play-store-metadata.yml`**
- Renamed to "Play Store — Upload Metadata & Images"
- Added a new step after `upload_metadata` that runs `bundle exec fastlane android upload_images`
- Both steps still guard on `PLAY_STORE_JSON_KEY_PATH != ''` so CI is a harmless no-op until the `PLAY_STORE_JSON_KEY_BASE64` secret is configured in Settings → Secrets

**`fastlane/Fastfile`**
- Added `upload_all` convenience lane that chains `upload_metadata → upload_images` for a one-shot full listing refresh (useful for initial Play Console population or after large batch changes)

### Before / After

| Event | Before | After |
|---|---|---|
| Push to main touching `fastlane/metadata/**` | Uploads listing text + changelogs only | Uploads listing text + changelogs **+ all images** |
| `workflow_dispatch` (manual trigger) | Text only | Text + images |
| `bundle exec fastlane android upload_all` | Not available | Uploads everything in one command |

## Test plan

- [x] Workflow YAML lints without errors (standard `actions/checkout` + `ruby/setup-ruby` + `bundle exec fastlane` pattern)
- [x] `upload_all` lane chains the two existing lanes without duplicating supply configuration
- [ ] End-to-end: set `PLAY_STORE_JSON_KEY_BASE64` secret, push a change to `fastlane/metadata/android/**`, verify both metadata and images appear in the Play Console internal track

Closes part of #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Google Play Store release automation to support automated image uploads (screenshots and feature graphics) alongside metadata.
  * New consolidated workflow command combines listing text, changelog, and image uploads in a single operation.
  * CI/CD pipeline now conditionally uploads images when credentials are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->