### PR TITLE
feat(#126): deploy_internal lane + Play Store deploy CI workflow

### DIFF
--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -21,15 +21,19 @@ on:
 jobs:
   deploy:
     name: Upload AAB to Play Store internal track
-    # Only run when the upstream release build succeeded AND was triggered by a
-    # version tag (head_branch matches 'v*', e.g. v1.0.0). This prevents an
-    # accidental branch push or manual Release Build dispatch from deploying a
-    # non-release AAB to the internal track. The workflow_dispatch path always
-    # runs so operators can re-deploy a specific prior release run by ID.
+    # Only run when the upstream release build succeeded AND it was triggered
+    # by a push event — meaning a tag push, the only push trigger in the
+    # Release Build workflow (push.tags: v*). Checking `.event == 'push'` is
+    # more reliable than inspecting head_branch, which may not be set to the
+    # tag name in all workflow_run payloads.
+    #
+    # Release Build manual workflow_dispatch runs (e.g. for testing signing)
+    # will NOT auto-trigger a deploy — use the workflow_dispatch path below,
+    # supplying an explicit release_run_id, to redeploy those intentionally.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
-       startsWith(github.event.workflow_run.head_branch, 'v'))
+       github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -1,0 +1,81 @@
+name: Play Store — Deploy to Internal Track
+
+# Triggered automatically after the release build succeeds on a version tag,
+# or manually via workflow_dispatch (e.g. to re-submit an existing artifact).
+#
+# The job is a no-op when PLAY_STORE_JSON_KEY_BASE64 is not set, so it is
+# safe to land before the Play Console service-account key is wired up.
+on:
+  workflow_run:
+    workflows: ["Release Build"]
+    types: [completed]
+
+  # Manual trigger: supply the run ID of a successful "Release Build" run to
+  # fetch its AAB artifact, or leave RELEASE_RUN_ID blank to skip the upload.
+  workflow_dispatch:
+    inputs:
+      release_run_id:
+        description: "GitHub Actions run ID of the Release Build to deploy"
+        required: false
+
+jobs:
+  deploy:
+    name: Upload AAB to Play Store internal track
+    # Only run when the upstream release build succeeded (auto-trigger path).
+    # The workflow_dispatch path always runs so operators can re-trigger.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read    # needed to download artifacts from another run
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Determine source run ID
+        id: run_id
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "id=${{ github.event.inputs.release_run_id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download signed AAB from release build
+        if: steps.run_id.outputs.id != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: release-aab
+          run-id: ${{ steps.run_id.outputs.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: aab
+
+      - name: Decode Play Store service-account key
+        env:
+          PLAY_STORE_JSON_KEY_BASE64: ${{ secrets.PLAY_STORE_JSON_KEY_BASE64 }}
+        run: |
+          if [ -z "$PLAY_STORE_JSON_KEY_BASE64" ]; then
+            echo "PLAY_STORE_JSON_KEY_BASE64 secret not set — skipping deploy"
+            exit 0
+          fi
+          echo "$PLAY_STORE_JSON_KEY_BASE64" | base64 -d > "${{ runner.temp }}/play-store-key.json"
+          echo "PLAY_STORE_JSON_KEY_PATH=${{ runner.temp }}/play-store-key.json" >> "$GITHUB_ENV"
+
+      - name: Deploy AAB to internal track via fastlane supply
+        if: >
+          env.PLAY_STORE_JSON_KEY_PATH != '' &&
+          steps.run_id.outputs.id != ''
+        env:
+          AAB_PATH: aab/app-release.aab
+        run: bundle exec fastlane android deploy_internal
+
+      - name: Clean up key
+        if: always()
+        run: rm -f "${{ runner.temp }}/play-store-key.json"

--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -37,37 +37,57 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      actions: read    # needed to download artifacts from another run
+      actions: read    # needed to read run metadata and download artifacts
 
     steps:
+      # Resolve the source run ID and commit SHA before checking out so both
+      # the checkout and the artifact download use consistent references.
+      #
+      # - workflow_run path: run ID and head_sha come directly from the event.
+      # - workflow_dispatch path: look up the caller-supplied release_run_id
+      #   via the GitHub API to obtain the head_sha that produced the AAB.
+      #   Falling back to github.sha (the default branch) would check out a
+      #   different Fastfile/Gemfile than the one used during the release build,
+      #   making redeployment non-reproducible.
+      - name: Resolve source run ID and head SHA
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RUN_ID="${{ github.event.inputs.release_run_id }}"
+            if [ -n "$RUN_ID" ]; then
+              HEAD_SHA=$(gh api \
+                "repos/${{ github.repository }}/actions/runs/${RUN_ID}" \
+                --jq '.head_sha')
+            else
+              RUN_ID=""
+              HEAD_SHA="${{ github.sha }}"
+            fi
+          else
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
       # Check out the exact commit that produced the AAB so that Fastfile,
       # Appfile, and Gemfile are consistent with what the release build used.
-      # For workflow_run: use head_sha of the triggering run.
-      # For workflow_dispatch: fall back to default branch (operator's intent).
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ steps.source.outputs.head_sha }}
 
       - uses: ruby/setup-ruby@f02c009132dc7b50a5e286d2ec2394ab5d78172a # v1.306.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
 
-      - name: Determine source run ID
-        id: run_id
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "id=${{ github.event.inputs.release_run_id }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Download signed AAB from release build
-        if: steps.run_id.outputs.id != ''
+        if: steps.source.outputs.run_id != ''
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-aab
-          run-id: ${{ steps.run_id.outputs.id }}
+          run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: aab
 
@@ -85,7 +105,7 @@ jobs:
       - name: Deploy AAB to internal track via fastlane supply
         if: >
           env.PLAY_STORE_JSON_KEY_PATH != '' &&
-          steps.run_id.outputs.id != ''
+          steps.source.outputs.run_id != ''
         env:
           AAB_PATH: aab/app-release.aab
         run: bundle exec fastlane android deploy_internal

--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -60,6 +60,11 @@ jobs:
               HEAD_SHA=$(gh api \
                 "repos/${{ github.repository }}/actions/runs/${RUN_ID}" \
                 --jq '.head_sha')
+              if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" = "null" ]; then
+                echo "::error::Could not resolve head_sha for run ${RUN_ID}." \
+                     "Verify the run ID is correct and GITHUB_TOKEN has actions:read access."
+                exit 1
+              fi
             else
               RUN_ID=""
               HEAD_SHA="${{ github.sha }}"
@@ -92,6 +97,7 @@ jobs:
           path: aab
 
       - name: Decode Play Store service-account key
+        if: steps.source.outputs.run_id != ''
         env:
           PLAY_STORE_JSON_KEY_BASE64: ${{ secrets.PLAY_STORE_JSON_KEY_BASE64 }}
         run: |

--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -11,7 +11,7 @@ on:
     types: [completed]
 
   # Manual trigger: supply the run ID of a successful "Release Build" run to
-  # fetch its AAB artifact, or leave RELEASE_RUN_ID blank to skip the upload.
+  # fetch its AAB artifact, or leave release_run_id blank to skip the upload.
   workflow_dispatch:
     inputs:
       release_run_id:
@@ -32,9 +32,15 @@ jobs:
       actions: read    # needed to download artifacts from another run
 
     steps:
-      - uses: actions/checkout@v4
+      # Check out the exact commit that produced the AAB so that Fastfile,
+      # Appfile, and Gemfile are consistent with what the release build used.
+      # For workflow_run: use head_sha of the triggering run.
+      # For workflow_dispatch: fall back to default branch (operator's intent).
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@f02c009132dc7b50a5e286d2ec2394ab5d78172a # v1.306.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -50,7 +56,7 @@ jobs:
 
       - name: Download signed AAB from release build
         if: steps.run_id.outputs.id != ''
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-aab
           run-id: ${{ steps.run_id.outputs.id }}

--- a/.github/workflows/play-store-deploy.yml
+++ b/.github/workflows/play-store-deploy.yml
@@ -21,11 +21,15 @@ on:
 jobs:
   deploy:
     name: Upload AAB to Play Store internal track
-    # Only run when the upstream release build succeeded (auto-trigger path).
-    # The workflow_dispatch path always runs so operators can re-trigger.
+    # Only run when the upstream release build succeeded AND was triggered by a
+    # version tag (head_branch matches 'v*', e.g. v1.0.0). This prevents an
+    # accidental branch push or manual Release Build dispatch from deploying a
+    # non-release AAB to the internal track. The workflow_dispatch path always
+    # runs so operators can re-deploy a specific prior release run by ID.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,6 +63,13 @@ platform :android do
       "AAB_PATH",
       "build/app/outputs/bundle/release/app-release.aab",
     )
+    unless File.exist?(aab_path)
+      UI.user_error!(
+        "AAB not found at '#{aab_path}'. " \
+        "Run `flutter build appbundle --release` first, or set AAB_PATH " \
+        "to the path of an already-built AAB.",
+      )
+    end
     supply(
       track:                   "internal",
       aab:                     aab_path,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,6 +41,39 @@ platform :android do
     )
   end
 
+  # Upload a signed AAB to the Play Store internal track for the closed
+  # testing programme and pre-launch report.
+  #
+  # The AAB must be built and signed first:
+  #   flutter build appbundle --release
+  #   # (signing configured in android/app/build.gradle.kts)
+  #
+  # Then:
+  #   bundle exec fastlane android deploy_internal
+  #
+  # Or with an explicit path:
+  #   AAB_PATH=build/app/outputs/bundle/release/app-release.aab \
+  #     bundle exec fastlane android deploy_internal
+  #
+  # Secrets needed:
+  #   PLAY_STORE_JSON_KEY_PATH — service-account JSON key file path
+  desc "Upload signed AAB to the Play Store internal track (for closed testing + pre-launch report)"
+  lane :deploy_internal do
+    aab_path = ENV.fetch(
+      "AAB_PATH",
+      "build/app/outputs/bundle/release/app-release.aab",
+    )
+    supply(
+      track:                   "internal",
+      aab:                     aab_path,
+      skip_upload_apk:         true,
+      skip_upload_metadata:    true,
+      skip_upload_changelogs:  true,
+      skip_upload_images:      true,
+      skip_upload_screenshots: true,
+    )
+  end
+
   # Upload everything — listing text, changelogs, feature graphic, and
   # screenshots — in one shot. Useful for initial Play Console population
   # or after large batches of changes.


### PR DESCRIPTION
## Summary

Closes the final automation gap in issue #126 — pushing the signed AAB to the Play Store internal track for the closed testing programme and pre-launch report. All previous PRs in this series handled text, images, and metadata upload; this one handles the **binary distribution** step.

### Changes

**`fastlane/Fastfile` — new `deploy_internal` lane**

Uploads a pre-built, signed AAB to the Play Store internal track without touching metadata or images:

```ruby
bundle exec fastlane android deploy_internal
# or with an explicit path:
AAB_PATH=path/to/app.aab bundle exec fastlane android deploy_internal
```

Defaults to `build/app/outputs/bundle/release/app-release.aab` — the standard `flutter build appbundle --release` output.

**`.github/workflows/play-store-deploy.yml` — new CI workflow**

| Trigger | Behaviour |
|---|---|
| `workflow_run` on "Release Build" success | Auto-downloads the `release-aab` artifact and deploys to internal track |
| `workflow_dispatch` with `release_run_id` | Re-deploys a specific past release run |

Both paths are no-ops when `PLAY_STORE_JSON_KEY_BASE64` is not set (safe to land before the key is configured).

### #126 checklist progress

| Item | Status |
|---|---|
| App name / short / long description | Done (PRs #184, #198) |
| Feature graphic 1024×500 | Done (PR #202) |
| Phone screenshots | Done (PR #203) |
| 7-inch + 10-inch tablet screenshots | Done (PR #204) |
| CI: upload metadata + images | Done (PR #205) |
| **CI: deploy AAB to internal track** | **Done — this PR** |
| Content rating (IARC) | Pending — Play Console form |
| Target audience (13+) | Pending — Play Console form |
| Closed testing track (12 testers × 14 days) | Unblocked by this PR |
| Pre-launch report | Unblocked by this PR |

## Test plan

- [x] `fastlane/Fastfile` lints without errors (valid Ruby DSL)
- [x] `play-store-deploy.yml` YAML is well-formed
- [ ] End-to-end: set `PLAY_STORE_JSON_KEY_BASE64` secret, push a `v*` tag, verify the "Release Build" triggers "Deploy to Internal Track" and the AAB appears in Play Console → Internal testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic deployment of signed Android builds to Google Play’s internal testing track, making builds available to closed testers and pre-launch reports.
  * New deployment lane to upload an Android App Bundle (AAB) to the internal track.

* **Chores**
  * CI workflow to trigger deployments after release builds, with optional manual invocation and safe skipping when credentials or artifacts are absent.
  * Temporary credential handling and cleanup during deploys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->