### PR TITLE
docs(#126): Play Store submission guide + scripts/README

### DIFF
--- a/docs/play-store-submission-guide.md
+++ b/docs/play-store-submission-guide.md
@@ -120,7 +120,9 @@ After completing: click **Apply rating** to save.
 
 **Play Console → App content → Data safety**
 
-Use the answers in [`docs/play-store-data-safety.md`](play-store-data-safety.md).
+Use the answers in
+[`docs/play-store-data-safety.md`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/docs/play-store-data-safety.md)
+(repository link — this file is excluded from the GitHub Pages build).
 Key declarations:
 - Audio/voice: collected, processed in real time, not stored, not shared
 - Bluetooth device IDs: collected for connectivity only, not shared, deleted on uninstall
@@ -137,7 +139,9 @@ Data deletion URL: `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#
 
 **Play Console → App content → Permissions** (shown during review if required)
 
-Use the justifications in [`docs/play-store-permissions-rationale.md`](play-store-permissions-rationale.md).
+Use the justifications in
+[`docs/play-store-permissions-rationale.md`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/docs/play-store-permissions-rationale.md)
+(repository link — this file is excluded from the GitHub Pages build).
 
 ---
 

--- a/docs/play-store-submission-guide.md
+++ b/docs/play-store-submission-guide.md
@@ -1,0 +1,207 @@
+---
+layout: page
+title: Play Store Submission Guide
+permalink: /play-store-submission/
+---
+
+# Play Store Submission Guide
+
+Step-by-step checklist for submitting Frequency to the Google Play Store.
+Items marked ✅ are complete (all code and assets are committed); items marked
+⏳ require action inside the Play Console.
+
+---
+
+## Status overview
+
+| Item | Status | Reference |
+|---|---|---|
+| App name / short / long description | ✅ Done | `fastlane/metadata/android/en-US/` |
+| Feature graphic (1024×500) | ✅ Done | `fastlane/metadata/android/en-US/images/featureGraphic.png` |
+| Phone screenshots (3×) | ✅ Done | `fastlane/metadata/android/en-US/images/phoneScreenshots/` |
+| 7-inch tablet screenshots (2×) | ✅ Done | `fastlane/metadata/android/en-US/images/sevenInchScreenshots/` |
+| 10-inch tablet screenshots (2×) | ✅ Done | `fastlane/metadata/android/en-US/images/tenInchScreenshots/` |
+| Data safety form answers | ✅ Done | `docs/play-store-data-safety.md` |
+| Permissions justification text | ✅ Done | `docs/play-store-permissions-rationale.md` |
+| Privacy policy URL | ✅ Done | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/` |
+| Account & data deletion URL | ✅ Done | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion` |
+| Content rating (IARC) questionnaire | ⏳ Play Console | `docs/play-store-content-rating.md` |
+| Target audience (13+) | ⏳ Play Console | See below |
+| Signed AAB upload to internal track | ⏳ First time | See below |
+| Closed testing track (12 testers × 14 days) | ⏳ Play Console | See below |
+| Pre-launch report | ⏳ Auto after AAB upload | See below |
+| Promo video | Optional | — |
+
+---
+
+## Step 1 — Upload listing text and images
+
+Run once after credentials are set up:
+
+```bash
+# Set the PLAY_STORE_JSON_KEY_BASE64 secret in GitHub Settings → Secrets,
+# then trigger the workflow manually:
+#   GitHub → Actions → "Play Store — Upload Metadata & Images" → Run workflow
+
+# Or run locally with a service-account key:
+export PLAY_STORE_JSON_KEY_PATH=/path/to/key.json
+bundle exec fastlane android upload_all
+```
+
+This uploads the title, descriptions, changelogs, feature graphic, and
+all screenshots in one shot.
+
+---
+
+## Step 2 — Build and upload the signed AAB
+
+```bash
+# The release workflow runs automatically on v* tags.
+# To trigger manually:
+git tag v1.0.0
+git push origin v1.0.0
+
+# The "Play Store — Deploy to Internal Track" workflow picks up the built
+# AAB and uploads it to the internal testing track.
+```
+
+Alternatively, trigger "Release Build" then "Play Store — Deploy to Internal
+Track" from GitHub → Actions → Run workflow.
+
+---
+
+## Step 3 — Content rating (IARC)
+
+**Play Console → App content → Content rating → Start questionnaire**
+
+Select category: **Communication** (real-time audio between nearby users).
+
+Use the reference answers in [`docs/play-store-content-rating.md`](play-store-content-rating.md)
+to complete the questionnaire. Key answers:
+- User-to-user communication: **Yes** (voice)
+- User-generated content: **Yes** (real-time voice)
+- Violent / sexual content: **No**
+- Gambling: **No**
+- Location sharing: **No**
+
+After completing: click **Apply rating** to save.
+
+---
+
+## Step 4 — Target audience and content
+
+**Play Console → App content → Target audience and content**
+
+1. Select age group: **13 and over** (audio capture from minors is not intended)
+2. Confirm the app is not designed for children under 13
+3. Under "Ads" confirm the app contains no ads
+
+---
+
+## Step 5 — Data safety form
+
+**Play Console → App content → Data safety**
+
+Use the answers in [`docs/play-store-data-safety.md`](play-store-data-safety.md).
+Key declarations:
+- Audio/voice: collected, processed in real time, not stored, not shared
+- Bluetooth device IDs: collected for connectivity only, not shared, deleted on uninstall
+- Data is encrypted in transit (BLE link-layer AES)
+- No third-party data sharing (except opt-in Sentry crash reports)
+
+Data deletion URL: `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion`
+
+---
+
+## Step 6 — Permissions declaration
+
+**Play Console → App content → Permissions** (shown during review if required)
+
+Use the justifications in [`docs/play-store-permissions-rationale.md`](play-store-permissions-rationale.md).
+
+---
+
+## Step 7 — Closed testing track setup
+
+Google requires **12 testers × 14 continuous days** on the internal or closed
+testing track before a new personal developer account can publish to production.
+
+**Play Console → Testing → Internal testing → Testers**
+
+1. Create a testers list and add at least 12 Google accounts
+2. Share the opt-in link with your testers
+3. Each tester must accept the opt-in **and** install the app
+4. The 14-day clock starts once testers are active
+
+Practical notes:
+- You can use the internal track for the mandatory period (internal is
+  separate from closed/alpha/beta but counts toward the requirement in
+  newer Google policies — verify in your Play Console dashboard).
+- The clock **does not restart** if you push a new AAB; keep testers
+  on the same track throughout.
+
+---
+
+## Step 8 — Pre-launch report
+
+Uploading an AAB to any track automatically triggers Google's automated
+pre-launch report (robot crawling on Pixel, Galaxy, Xiaomi emulators).
+No manual action required.
+
+**Play Console → Android vitals → Pre-launch report**
+
+Review the report for:
+- Crashes on launch
+- ANRs during the robot test (expected: the robot cannot interact with
+  BLE features, so audio-related screens may timeout — this is acceptable)
+- Accessibility issues (screen reader labels, contrast)
+- Security findings
+
+---
+
+## Step 9 — Promote to production
+
+After the 14-day closed testing window closes:
+
+1. **Play Console → Testing → Internal testing → Promote release**
+2. Set rollout percentage (start at 10–20% for staged rollout)
+3. Add release notes in the changelog field (already in `fastlane/metadata/android/en-US/changelogs/1.txt`)
+4. Click **Review release** then **Start rollout to production**
+
+---
+
+## Service-account key setup (one-time)
+
+1. **Play Console → Setup → API access → Link to Google Cloud project**
+2. Create a service account in Google Cloud Console with "Service Account" role
+3. Grant the service account access in Play Console (Release manager or higher)
+4. Download the JSON key
+5. Base64-encode and store in GitHub: `Settings → Secrets → PLAY_STORE_JSON_KEY_BASE64`
+
+```bash
+base64 -w0 /path/to/key.json | pbcopy  # macOS — paste into GitHub secret
+base64 -w0 /path/to/key.json | xclip   # Linux
+```
+
+---
+
+## Regenerating screenshots
+
+If the app UI changes, regenerate screenshots with:
+
+```bash
+# Phone screenshots (1080×1920)
+python3 scripts/gen_screenshots.py
+
+# Tablet screenshots (1200×1920 and 1600×2560)
+python3 scripts/gen_tablet_screenshots.py
+
+# Or capture real device screenshots via adb:
+adb exec-out screencap -p > fastlane/metadata/android/en-US/images/phoneScreenshots/1.png
+```
+
+Then re-upload:
+
+```bash
+bundle exec fastlane android upload_images
+```

--- a/docs/play-store-submission-guide.md
+++ b/docs/play-store-submission-guide.md
@@ -23,14 +23,28 @@ items marked ⏳ require action inside the Play Console.
 | 10-inch tablet screenshots (2×) | ✅ Done | `fastlane/metadata/android/en-US/images/tenInchScreenshots/` |
 | Data safety form answers | ✅ Done | `docs/play-store-data-safety.md` |
 | Permissions justification text | ✅ Done | `docs/play-store-permissions-rationale.md` |
-| Privacy policy URL | ✅ Done | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/` |
-| Account & data deletion URL | ✅ Done | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion` |
+| Privacy policy URL | ✅ Done (needs Pages enabled) | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/` |
+| Account & data deletion URL | ✅ Done (needs Pages enabled) | `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion` |
 | Content rating (IARC) questionnaire | ⏳ Play Console | `docs/play-store-content-rating.md` |
 | Target audience (13+) | ⏳ Play Console | See below |
 | Signed AAB upload to internal track | ⏳ First time | See below |
 | Closed testing track (12 testers × 14 days) | ⏳ Play Console | See below |
 | Pre-launch report | ⏳ Auto after AAB upload | See below |
 | Promo video | Optional | — |
+
+---
+
+## Step 0 — Enable GitHub Pages (one-time prerequisite)
+
+The privacy policy URL required by the Play Store is served from GitHub Pages.
+Before submitting, enable it:
+
+**Repository → Settings → Pages → Source: GitHub Actions**
+
+After enabling, the workflow (`.github/workflows/pages.yml`) will publish on
+the next push to `main` that touches `docs/`. The privacy policy URL will then
+be live at:
+`https://elodinlaarz.github.io/walkie-talkie/privacy-policy/`
 
 ---
 

--- a/docs/play-store-submission-guide.md
+++ b/docs/play-store-submission-guide.md
@@ -6,9 +6,9 @@ permalink: /play-store-submission/
 
 # Play Store Submission Guide
 
-Step-by-step checklist for submitting Frequency to the Google Play Store.
-Items marked ✅ are complete (all code and assets are committed); items marked
-⏳ require action inside the Play Console.
+Step-by-step checklist for submitting the **Walkie Talkie** app to the Google
+Play Store. Items marked ✅ are complete (all code and assets are committed);
+items marked ⏳ require action inside the Play Console.
 
 ---
 
@@ -55,18 +55,22 @@ all screenshots in one shot.
 
 ## Step 2 — Build and upload the signed AAB
 
+**Auto-trigger (recommended):** push a `v*` tag — the "Release Build" workflow
+builds and signs the AAB, then the "Play Store — Deploy to Internal Track"
+workflow automatically picks it up and uploads it.
+
 ```bash
-# The release workflow runs automatically on v* tags.
-# To trigger manually:
 git tag v1.0.0
 git push origin v1.0.0
-
-# The "Play Store — Deploy to Internal Track" workflow picks up the built
-# AAB and uploads it to the internal testing track.
 ```
 
-Alternatively, trigger "Release Build" then "Play Store — Deploy to Internal
-Track" from GitHub → Actions → Run workflow.
+**Manual re-deploy:** if you need to re-upload an existing build:
+
+1. Find the run ID of the Release Build run to redeploy
+   (`GitHub → Actions → Release Build → <run>` — the run ID is in the URL).
+2. **GitHub → Actions → "Play Store — Deploy to Internal Track" → Run workflow**
+3. Enter the run ID in the `release_run_id` input field, then click
+   **Run workflow**.
 
 ---
 
@@ -106,7 +110,9 @@ Use the answers in [`docs/play-store-data-safety.md`](play-store-data-safety.md)
 Key declarations:
 - Audio/voice: collected, processed in real time, not stored, not shared
 - Bluetooth device IDs: collected for connectivity only, not shared, deleted on uninstall
-- Data is encrypted in transit (BLE link-layer AES)
+- Voice transport uses Bluetooth LE (L2CAP CoC); link-layer encryption
+  depends on device pairing state — see `docs/play-store-data-safety.md`
+  for the current declared security posture
 - No third-party data sharing (except opt-in Sentry crash reports)
 
 Data deletion URL: `https://elodinlaarz.github.io/walkie-talkie/privacy-policy/#data-retention-and-deletion`
@@ -179,24 +185,30 @@ After the 14-day closed testing window closes:
 5. Base64-encode and store in GitHub: `Settings → Secrets → PLAY_STORE_JSON_KEY_BASE64`
 
 ```bash
-base64 -w0 /path/to/key.json | pbcopy  # macOS — paste into GitHub secret
-base64 -w0 /path/to/key.json | xclip   # Linux
+# macOS (uses BSD base64 — no -w flag needed; tr removes wrapping newlines)
+base64 /path/to/key.json | tr -d '\n' | pbcopy
+
+# Linux (GNU base64 — -w0 disables line wrapping)
+base64 -w0 /path/to/key.json | xclip -selection clipboard
 ```
 
 ---
 
 ## Regenerating screenshots
 
-If the app UI changes, regenerate screenshots with:
+The committed screenshots were generated from code; they may be updated if the
+UI changes. The generator scripts require Python + Pillow and run on Windows
+(they hard-code Segoe UI from `C:/Windows/Fonts/`). On macOS/Linux, either
+install Segoe UI or edit the font paths at the top of each script.
 
 ```bash
-# Phone screenshots (1080×1920)
+# Phone screenshots (1080×1920) — Windows only as-is
 python3 scripts/gen_screenshots.py
 
-# Tablet screenshots (1200×1920 and 1600×2560)
+# Tablet screenshots (1200×1920 and 1600×2560) — Windows only as-is
 python3 scripts/gen_tablet_screenshots.py
 
-# Or capture real device screenshots via adb:
+# Or capture real device screenshots via adb (cross-platform):
 adb exec-out screencap -p > fastlane/metadata/android/en-US/images/phoneScreenshots/1.png
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,73 @@
+# scripts/
+
+Helper scripts for development, release, and Play Store operations.
+
+## validate_store_metadata.sh
+
+Validates Play Store character limits across all locale metadata files.
+Run automatically in CI (before Flutter SDK setup) and in the
+play-store-metadata upload workflow.
+
+```bash
+bash scripts/validate_store_metadata.sh
+# or with a custom metadata root:
+bash scripts/validate_store_metadata.sh /path/to/fastlane/metadata/android
+```
+
+Limits enforced:
+- `title.txt` ≤ 30 chars
+- `short_description.txt` ≤ 80 chars
+- `full_description.txt` ≤ 4000 chars
+- `changelogs/*.txt` ≤ 500 chars each
+
+## gen_screenshots.py
+
+Generates three 1080×1920 phone screenshots for the Play Store listing
+using Python + Pillow (no device required).
+
+```bash
+python3 scripts/gen_screenshots.py
+# Output: fastlane/metadata/android/en-US/images/phoneScreenshots/{1,2,3}.png
+```
+
+Screenshots produced:
+1. Discovery screen — nearby frequency rows, radar animation, Start card
+2. Frequency Room — central dial, peer chips, PTT and Mute buttons
+3. Settings screen — VOICE / DISPLAY / PRIVACY / ABOUT sections
+
+## gen_tablet_screenshots.py
+
+Generates four tablet screenshots for the Play Store listing:
+two at 1200×1920 (7-inch) and two at 1600×2560 (10-inch).
+All dimensions scale proportionally from the 1080 px phone baseline.
+
+```bash
+python3 scripts/gen_tablet_screenshots.py
+# Output: fastlane/metadata/android/en-US/images/sevenInchScreenshots/{1,2}.png
+#         fastlane/metadata/android/en-US/images/tenInchScreenshots/{1,2}.png
+```
+
+## measure_app_size.sh
+
+Downloads bundletool, signs the release AAB with the debug keystore,
+and measures per-device download size via `bundletool get-size total`.
+Used by the Flutter CI workflow to enforce the < 30 MB download budget.
+
+```bash
+# Normally run by CI; to run locally:
+AAB_PATH=build/app/outputs/bundle/release/app-release.aab \
+KEYSTORE_PATH=~/.android/debug.keystore \
+KEYSTORE_PASSWORD=android \
+KEY_ALIAS=androiddebugkey \
+KEY_PASSWORD=android \
+bash scripts/measure_app_size.sh
+```
+
+## presubmit.sh
+
+Runs the full local presubmit gate (formatting, analysis, tests, native
+C++ tests). Mirrors what CI runs on every push.
+
+```bash
+bash scripts/presubmit.sh
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -25,6 +25,11 @@ Limits enforced:
 Generates three 1080×1920 phone screenshots for the Play Store listing
 using Python + Pillow (no device required).
 
+**Platform note:** the script hard-codes Windows font paths
+(`C:/Windows/Fonts/segoeuib.ttf`). On macOS/Linux, install Segoe UI or
+edit the `FONT_BD` / `FONT_REG` constants at the top of the script to
+point at available system fonts before running.
+
 ```bash
 python3 scripts/gen_screenshots.py
 # Output: fastlane/metadata/android/en-US/images/phoneScreenshots/{1,2,3}.png
@@ -41,6 +46,9 @@ Generates four tablet screenshots for the Play Store listing:
 two at 1200×1920 (7-inch) and two at 1600×2560 (10-inch).
 All dimensions scale proportionally from the 1080 px phone baseline.
 
+**Platform note:** same Windows font dependency as `gen_screenshots.py`
+above — update `FONT_BD` / `FONT_REG` if running on macOS/Linux.
+
 ```bash
 python3 scripts/gen_tablet_screenshots.py
 # Output: fastlane/metadata/android/en-US/images/sevenInchScreenshots/{1,2}.png
@@ -49,17 +57,23 @@ python3 scripts/gen_tablet_screenshots.py
 
 ## measure_app_size.sh
 
-Downloads bundletool, signs the release AAB with the debug keystore,
-and measures per-device download size via `bundletool get-size total`.
-Used by the Flutter CI workflow to enforce the < 30 MB download budget.
+Downloads bundletool, generates device-specific APK splits from a signed AAB
+(signing the split APKs with the provided keystore for bundletool's alignment
+step), and reports per-device download size via `bundletool get-size total`.
+Used by the **release workflow** (`release.yml`) to enforce the < 30 MB
+download-size budget after a production build.
+
+Note: the Flutter CI workflow (`flutter.yml`) uses a separate inline AAB
+size check and does not call this script.
 
 ```bash
-# Normally run by CI; to run locally:
+# Normally run by the release workflow; to run locally against a
+# release AAB (already signed with the production keystore):
 AAB_PATH=build/app/outputs/bundle/release/app-release.aab \
-KEYSTORE_PATH=~/.android/debug.keystore \
-KEYSTORE_PASSWORD=android \
-KEY_ALIAS=androiddebugkey \
-KEY_PASSWORD=android \
+KEYSTORE_PATH=/path/to/release.jks \
+KEYSTORE_PASSWORD=<password> \
+KEY_ALIAS=<alias> \
+KEY_PASSWORD=<key-password> \
 bash scripts/measure_app_size.sh
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,11 +60,14 @@ python3 scripts/gen_tablet_screenshots.py
 Downloads bundletool, generates device-specific APK splits from a signed AAB
 (signing the split APKs with the provided keystore for bundletool's alignment
 step), and reports per-device download size via `bundletool get-size total`.
-Used by the **release workflow** (`release.yml`) to enforce the < 30 MB
-download-size budget after a production build.
+Used by the **release workflow** (`release.yml`) after a production build.
 
-Note: the Flutter CI workflow (`flutter.yml`) uses a separate inline AAB
-size check and does not call this script.
+Thresholds (configurable via env vars in `release.yml`):
+- **Soft-warn target**: 30 MiB — logs a warning if exceeded, build continues
+- **Hard-fail ceiling**: 50 MiB — fails the build if exceeded
+
+Note: the Flutter CI workflow (`flutter.yml`) uses a separate inline raw-AAB
+size check (not per-device download size) and does not call this script.
 
 ```bash
 # Normally run by the release workflow; to run locally against a


### PR DESCRIPTION
## Summary

Adds two documents that complete the code-side work for issue #126 by giving the developer a clear roadmap for the remaining Play Console admin tasks, and documenting all the helper scripts.

### `docs/play-store-submission-guide.md`

A comprehensive, step-by-step Play Store submission guide covering:

| Step | Action | Status |
|---|---|---|
| 1 | Upload listing text + images via fastlane | ✅ scripts ready |
| 2 | Build + deploy signed AAB to internal track | ✅ workflows ready |
| 3 | IARC content-rating questionnaire | ⏳ Play Console |
| 4 | Target audience (13+) declaration | ⏳ Play Console |
| 5 | Data safety form | ⏳ Play Console |
| 6 | Permissions declaration | ⏳ Play Console |
| 7 | Closed testing track (12 testers × 14 days) | ⏳ Play Console |
| 8 | Pre-launch report (auto after AAB upload) | ⏳ automatic |
| 9 | Promote to production with staged rollout | ⏳ Play Console |

Also includes service-account key setup and screenshot regeneration instructions.

### `scripts/README.md`

Documents all five scripts in `scripts/` with usage examples:
- `validate_store_metadata.sh` — enforces Play Store character limits
- `gen_screenshots.py` — generates phone screenshots (1080×1920)
- `gen_tablet_screenshots.py` — generates tablet screenshots (1200×1920, 1600×2560)
- `measure_app_size.sh` — per-device download size via bundletool
- `presubmit.sh` — full local presubmit gate

### #126 checklist status

All code-implementable items from #126 are now done. This PR documents the remaining Play Console admin actions so the developer has a single reference for completing the submission.

## Test plan

- [x] Markdown renders correctly (headers, tables, code blocks, links)
- [x] All referenced docs (`play-store-content-rating.md`, `play-store-data-safety.md`, `play-store-permissions-rationale.md`) exist
- [x] All referenced scripts exist in `scripts/`
- [x] Service-account key setup instructions match the pattern used in CI workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Play Store submission guide with checklist, publishing/testing workflow, signing/build/deploy guidance, content rating, data safety/permissions instructions, testing window and staged rollout procedures.
  * Expanded developer scripts documentation describing tools to validate store metadata limits, generate phone/tablet screenshots, measure bundle/download size, and run the local presubmit workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->