### PR TITLE
docs(#126): add Play Store submission guide to GitHub Pages navigation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,6 +14,7 @@ minima:
 header_pages:
   - privacy-policy.md
   - protocol.md
+  - play-store-submission-guide.md
 
 # Keep internal reference docs out of the public site; they live in the repo
 # for contributor reference only.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,3 +22,5 @@ anonymised diagnostic data if enabled in Settings.
   Data Safety form.
 - **[Wire Protocol]({% link protocol.md %})** — the on-wire format for discovery
   advertisements, control messages, and audio framing.
+- **[Play Store Submission Guide]({% link play-store-submission-guide.md %})** — step-by-step
+  checklist for completing the Google Play Store listing and publishing the app.


### PR DESCRIPTION
## Summary

The Play Store submission guide added in PR #208 was not reachable from the GitHub Pages site — neither from the top navigation bar nor from the homepage documentation list. This PR makes it discoverable.

### Changes

**`docs/_config.yml`**
- Adds `play-store-submission-guide.md` to `header_pages` so it appears in the minima theme's top navigation bar alongside Privacy Policy and Wire Protocol

**`docs/index.md`**
- Adds a bullet link to the submission guide in the Documentation section so visitors landing on the home page can navigate to it

### Before / After

**Before**: Submission guide existed at `/walkie-talkie/play-store-submission/` but was only reachable by direct URL — no nav link, no homepage link.

**After**: Guide appears in top nav and homepage doc list.

## Test plan

- [x] `_config.yml` YAML is valid (no trailing whitespace, correct indentation)
- [x] `index.md` Liquid tag uses `{% link %}` consistent with existing links
- [ ] Manual: after Pages is enabled, confirm the guide appears in nav bar and homepage links work

Closes part of #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)