### PR TITLE
ci(#126): add Play Store metadata validation to presubmit.sh

### DIFF
--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -e
 
+# Change to the repo root regardless of where the script is invoked from,
+# so all subsequent relative paths (dart format, test/cpp/, etc.) resolve
+# correctly whether the caller is inside the scripts/ directory or elsewhere.
+cd "$(dirname "$0")/.."
+
 echo "Validating Play Store metadata character limits..."
-bash "$(dirname "$0")/validate_store_metadata.sh"
+bash scripts/validate_store_metadata.sh
 
 echo "Running formatting checks..."
 dart format --output=none --set-exit-if-changed .

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+echo "Validating Play Store metadata character limits..."
+bash "$(dirname "$0")/validate_store_metadata.sh"
+
 echo "Running formatting checks..."
 dart format --output=none --set-exit-if-changed .
 


### PR DESCRIPTION
## Summary

`scripts/validate_store_metadata.sh` already runs as the **first step** in the Flutter CI workflow (`flutter.yml`), but the local presubmit gate (`scripts/presubmit.sh`) didn't call it. This PR adds it there so the local and CI checks are consistent.

### Change

```diff
+echo "Validating Play Store metadata character limits..."
+bash "$(dirname "$0")/validate_store_metadata.sh"
+
 echo "Running formatting checks..."
```

The validator runs before any Dart/Flutter tooling is touched, so a metadata character-limit violation fails fast locally — the same way CI fails fast (the validator is position 1 in `flutter.yml`, before `flutter-action` and before `flutter pub get`).

## Test plan

- [x] `bash scripts/presubmit.sh` — first line of output is the metadata check, exits 0 with current metadata
- [x] `bash scripts/validate_store_metadata.sh` — still exits 0 independently

Closes part of #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build validation process to include additional validation checks during the pre-submission workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->