### PR TITLE
security(#126): pin actions in play-store-metadata.yml to full commit SHAs

### DIFF
--- a/.github/workflows/play-store-metadata.yml
+++ b/.github/workflows/play-store-metadata.yml
@@ -19,12 +19,12 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Validate metadata character limits
         run: bash scripts/validate_store_metadata.sh
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@f02c009132dc7b50a5e286d2ec2394ab5d78172a # v1.306.0
         with:
           ruby-version: '3.3'
           bundler-cache: true


### PR DESCRIPTION
## Summary

PR #206 pinned all GitHub Actions to full commit SHAs in `play-store-deploy.yml` to prevent supply-chain attacks via tag retargeting. The same workflow handles the Play Store service-account key and uploads store assets — `play-store-metadata.yml` — was not updated at that time and still uses floating tags.

This PR applies the same hardening.

### Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) |
| `ruby/setup-ruby` | `@v1` | `@f02c009132dc7b50a5e286d2ec2394ab5d78172a` (v1.306.0) |

Both SHAs match what `play-store-deploy.yml` already uses, keeping the two Play Store workflows consistent.

### Why this matters

`play-store-metadata.yml` decodes `PLAY_STORE_JSON_KEY_BASE64` (a secret with upload access to the Play Console) and runs fastlane commands. If `actions/checkout@v4` were retargeted to a malicious commit, that commit would have access to the decoded key. SHA-pinning prevents this by ensuring only the exact audited version of the action runs.

Closes part of #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)