### PR TITLE
security(#126): gitignore play-store-credentials.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,11 @@ app.*.symbols
 key.properties
 *.jks
 
+# Play Store service-account key (fastlane/Appfile fallback path).
+# Never commit a real service-account key — store it as a base64-encoded
+# GitHub Secret (PLAY_STORE_JSON_KEY_BASE64) and decode it at runtime.
+play-store-credentials.json
+
 # iOS/XCode related
 **/ios/**/*.mode1v3
 **/ios/**/*.mode2v3


### PR DESCRIPTION
Adds play-store-credentials.json to .gitignore — the fastlane/Appfile fallback path for the Play Store service-account key. Closes part of #126.