### PR TITLE
docs(#126): add hi-res icon to Play Store submission guide status table

### DIFF
--- a/docs/play-store-submission-guide.md
+++ b/docs/play-store-submission-guide.md
@@ -17,6 +17,7 @@ items marked ⏳ require action inside the Play Console.
 | Item | Status | Reference |
 |---|---|---|
 | App name / short / long description | ✅ Done | `fastlane/metadata/android/en-US/` |
+| Hi-res app icon (512×512) | ✅ Done | `fastlane/metadata/android/en-US/images/icon.png` |
 | Feature graphic (1024×500) | ✅ Done | `fastlane/metadata/android/en-US/images/featureGraphic.png` |
 | Phone screenshots (3×) | ✅ Done | `fastlane/metadata/android/en-US/images/phoneScreenshots/` |
 | 7-inch tablet screenshots (2×) | ✅ Done | `fastlane/metadata/android/en-US/images/sevenInchScreenshots/` |


### PR DESCRIPTION
PR #213 committed the 512x512 hi-res app icon required by Play Console, but the submission guide status table didn't reflect this. Added a 'Hi-res app icon (512x512) Done' row pointing to the committed file. Closes part of #126.