### PR TITLE
fix(#126): pin fastlane to ~> 2 in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
-gem "fastlane"
+# Pin to fastlane 2.x to prevent unintended breaking changes from a future
+# major version. Patch and minor updates within 2.x remain allowed by bundler.
+gem "fastlane", "~> 2"


### PR DESCRIPTION
## Summary

The `Gemfile` used a bare `gem "fastlane"` with no version constraint, meaning `bundle install` would pull in any future major release and could silently break the Play Store upload CI workflows.

### Change

```ruby
# Before
gem "fastlane"

# After
gem "fastlane", "~> 2"
```

The `~> 2` pessimistic constraint allows patch and minor updates within fastlane 2.x (e.g., 2.220 → 2.221 is fine) while blocking a future major version 3.x from being installed automatically.

### Why this matters

Both `play-store-metadata.yml` and `play-store-deploy.yml` run `bundle exec fastlane android ...` to upload the Play Store listing. A major fastlane upgrade could change the `supply` plugin API or default behaviors, breaking uploads silently.

Closes part of #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)