### PR TITLE
fix(#219): persist sessionUuid so Resume rejoins the same room

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1049,19 +1049,27 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// Enters Room. [isHost] is true when the user created the frequency,
   /// false when they tuned in to an existing one. The [freq] argument is
   /// required on the guest path (it carries the discovered MHz string)
-  /// and ignored on the host path (the room frequency is derived from a
-  /// freshly-minted sessionUuid). No-op if the user isn't on Discovery
-  /// (shouldn't happen — Discovery is the only screen that triggers it).
+  /// and ignored on the host path (the room frequency is derived from
+  /// the host's sessionUuid — either freshly minted or, on Resume,
+  /// supplied via [existingSessionUuid]). No-op if the user isn't on
+  /// Discovery (shouldn't happen — Discovery is the only screen that
+  /// triggers it).
   ///
-  /// **Host path.** Mints a fresh `sessionUuid`, derives the room's
-  /// cosmetic [roomFreq] from its low 12 bits (the same mapping guests
-  /// use when decoding the advertisement), self-seeds the roster with
-  /// the local user, and asks the audio service to start LE advertising
-  /// + the GATT server so other phones can see and dial the room. The
-  /// [freq] argument is ignored on this path — the freshly-minted UUID
-  /// is the source of truth for both the cosmetic display and what
-  /// guests will eventually see in their discovery list. Recorded to
-  /// the recent-hosted list as a side-effect.
+  /// **Host path.** When [existingSessionUuid] is null (the "Start a new
+  /// frequency" path), mints a fresh `sessionUuid`. When provided (the
+  /// "Resume" path tapped on a recent row), reuses it so the room's
+  /// `mhzDisplay` matches the original session and guests reconnecting to
+  /// the same advertised UUID land in the same room. Either way, derives
+  /// the room's cosmetic [roomFreq] from the UUID's low 12 bits (the same
+  /// mapping guests use when decoding the advertisement), self-seeds the
+  /// roster with the local user, and asks the audio service to start LE
+  /// advertising + the GATT server so other phones can see and dial the
+  /// room. The [freq] argument is ignored on this path — the UUID is the
+  /// source of truth for both the cosmetic display and what guests
+  /// eventually see in their discovery list. Recorded to the recent-hosted
+  /// list as a side-effect, with the sessionUuid persisted alongside the
+  /// freq so a subsequent Resume can reconstitute the same session
+  /// (#219).
   ///
   /// **Guest path.** Uses [freq] as the room's cosmetic display (it
   /// already matches the advertised UUID's mhzDisplay since both flow
@@ -1084,16 +1092,23 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     String? freq,
     String? macAddress,
     String? sessionUuidLow8,
+    String? existingSessionUuid,
   }) async {
+    assert(
+      existingSessionUuid == null || isHost,
+      'existingSessionUuid is only meaningful on the host (Resume) path — '
+      'guests dial the host\'s advertised UUID, they do not reuse a stored one',
+    );
     final current = state;
     if (current is! SessionDiscovery) return;
     _seq = 0;
     final SessionRoom room;
     if (isHost) {
-      // Mint the canonical session identity. Everything else on the host
+      // Reuse the recent row's sessionUuid on Resume; otherwise mint a
+      // fresh canonical session identity. Everything else on the host
       // path (advertised manufacturer payload, cosmetic mhz, hostPeerId
       // self-seed) flows from this UUID + the local peerId.
-      final sessionUuid = _mintSessionUuid();
+      final sessionUuid = existingSessionUuid ?? _mintSessionUuid();
       // Resolve the local peerId for the self-seed. The cache covers
       // the common case where bootstrap has already run; falls back to
       // the store otherwise. A hard failure aborts the host path —
@@ -1129,7 +1144,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // room, so we shouldn't await disk I/O before emitting. Errors are
       // logged on the future and surfaced on next launch as a missing
       // entry; nothing else depends on success here.
-      unawaited(_recordRecentFrequency(roomFreq));
+      //
+      // sessionUuid rides along so the recent row carries the canonical
+      // session identity — Resume on this row reads it back through
+      // `joinRoom(existingSessionUuid: ...)` and lands in the same room
+      // instead of minting a fresh UUID (#219).
+      unawaited(_recordRecentFrequency(roomFreq, sessionUuid: sessionUuid));
       _sessionUuid = sessionUuid;
       room = SessionRoom(
         myName: myName,
@@ -1425,9 +1445,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     }
   }
 
-  Future<void> _recordRecentFrequency(String freq) async {
+  Future<void> _recordRecentFrequency(
+    String freq, {
+    String? sessionUuid,
+  }) async {
     try {
-      await recentFrequenciesStore.record(freq);
+      await recentFrequenciesStore.record(freq, sessionUuid: sessionUuid);
     } catch (error, stackTrace) {
       if (kDebugMode) debugPrint('Failed to record recent frequency: $error');
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -361,13 +361,19 @@ class _FrequencyAppState extends State<FrequencyApp> with WidgetsBindingObserver
             unawaited(
               cubit.joinRoom(
                 isHost: result.isHost,
-                // Host path ignores `freq` — the cubit derives it from a
-                // freshly-minted sessionUuid (#39). Pass it through anyway
-                // for the guest path, where it carries the discovered
-                // session's cosmetic mhzDisplay.
+                // Host path ignores `freq` — the cubit derives it from
+                // the sessionUuid (freshly minted, or supplied via
+                // existingSessionUuid on Resume — see #219). Pass it
+                // through anyway for the guest path, where it carries
+                // the discovered session's cosmetic mhzDisplay.
                 freq: result.isHost ? null : result.freq,
                 macAddress: result.macAddress,
                 sessionUuidLow8: result.sessionUuidLow8,
+                // Populated only on Resume — recent-row taps thread the
+                // persisted sessionUuid through so the cubit reuses it
+                // instead of minting a new one (#219). Null on "Start a
+                // new frequency" and on legacy rows that pre-date v4.
+                existingSessionUuid: result.hostSessionUuid,
               ),
             );
           },

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -32,11 +32,25 @@ class DiscoveryResult {
   /// to a discovered session so the guest can identify the host's room.
   final String? sessionUuidLow8;
 
+  /// Full sessionUuid the user previously hosted, for the Resume path on
+  /// a recent row. Plumbed through to [FrequencySessionCubit.joinRoom] as
+  /// `existingSessionUuid` so the room reconstitutes the same session
+  /// instead of minting a fresh one (#219). Null on the "Start a new
+  /// frequency" host path (no prior session) and on the guest path
+  /// (guests dial the host's advertised UUID via [sessionUuidLow8]).
+  ///
+  /// Resume rows recorded before #219 carry `null` here because their
+  /// sessionUuid wasn't persisted; the cubit falls back to minting a
+  /// fresh UUID for those, so the user gets pre-#219 behaviour for
+  /// legacy rows until they re-host.
+  final String? hostSessionUuid;
+
   const DiscoveryResult({
     required this.freq,
     required this.isHost,
     this.macAddress,
     this.sessionUuidLow8,
+    this.hostSessionUuid,
   })  : assert(
           !isHost || (macAddress == null && sessionUuidLow8 == null),
           'host DiscoveryResult must have null macAddress + sessionUuidLow8 — '
@@ -46,6 +60,10 @@ class DiscoveryResult {
           isHost || (macAddress != null && sessionUuidLow8 != null),
           'guest DiscoveryResult must carry both macAddress and sessionUuidLow8 — '
           'the GATT-client transport reads both off the room state to dial the host',
+        ),
+        assert(
+          hostSessionUuid == null || isHost,
+          'hostSessionUuid is only meaningful on the host (Resume) path',
         );
 }
 
@@ -402,6 +420,12 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
               onResume: () => widget.onPick(DiscoveryResult(
                 freq: widget.recentHostedFrequencies[i].freq,
                 isHost: true,
+                // Plumb the persisted sessionUuid through so the cubit's
+                // host path reuses it instead of minting a fresh one
+                // (#219). Null for legacy rows recorded before v4 of the
+                // db schema; cubit falls back to minting in that case.
+                hostSessionUuid:
+                    widget.recentHostedFrequencies[i].sessionUuid,
               )),
               onRename: widget.onSetRecentNickname == null
                   ? null

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -226,6 +226,15 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
   Future<void> _doRecord(String freq, String? sessionUuid) async {
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
+    // Normalize an empty / whitespace-only sessionUuid to null on write so
+    // the COALESCE upsert below can't be tricked into "overwriting" a
+    // valid stored uuid with an empty string. Mirrors the [setNickname]
+    // trim-to-null rule and lines up with [_rowToRecent]'s read-side
+    // normalization, so an empty string never round-trips as a non-null
+    // value through the store.
+    final normalizedUuid = (sessionUuid == null || sessionUuid.trim().isEmpty)
+        ? null
+        : sessionUuid.trim();
     final db = await WalkieTalkieDatabase.open();
     final orderingTimestamp = _nextOrderingTimestamp();
     await db.transaction((txn) async {
@@ -254,7 +263,7 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
           recorded_at = excluded.recorded_at,
           session_uuid = COALESCE(excluded.session_uuid, $_table.session_uuid)
         ''',
-        [trimmed, orderingTimestamp, sessionUuid],
+        [trimmed, orderingTimestamp, normalizedUuid],
       );
       await _capUnpinnedRows(txn);
     });

--- a/lib/services/recent_frequencies_store.dart
+++ b/lib/services/recent_frequencies_store.dart
@@ -27,10 +27,22 @@ class RecentFrequency {
   /// applied during [RecentFrequenciesStore.record].
   final bool pinned;
 
+  /// The original `FrequencySession.sessionUuid` the user hosted on. `null`
+  /// for rows that pre-date #219 (DB schema v4) — the cubit's Resume path
+  /// falls back to minting a fresh UUID in that case, matching pre-#219
+  /// behaviour. Populated for any row recorded after the upgrade.
+  ///
+  /// Persisting this is what lets Resume reconstitute the *same* room the
+  /// user previously hosted: `mhzDisplay` is derived from the UUID, so
+  /// without it Resume would derive a fresh freq off a fresh UUID and the
+  /// user would silently land in a new room.
+  final String? sessionUuid;
+
   const RecentFrequency({
     required this.freq,
     this.nickname,
     this.pinned = false,
+    this.sessionUuid,
   });
 
   @override
@@ -38,14 +50,16 @@ class RecentFrequency {
       other is RecentFrequency &&
       other.freq == freq &&
       other.nickname == nickname &&
-      other.pinned == pinned;
+      other.pinned == pinned &&
+      other.sessionUuid == sessionUuid;
 
   @override
-  int get hashCode => Object.hash(freq, nickname, pinned);
+  int get hashCode => Object.hash(freq, nickname, pinned, sessionUuid);
 
   @override
   String toString() =>
-      'RecentFrequency(freq: $freq, nickname: $nickname, pinned: $pinned)';
+      'RecentFrequency(freq: $freq, nickname: $nickname, pinned: $pinned, '
+      'sessionUuid: $sessionUuid)';
 }
 
 /// Persisted "frequencies the local user has hosted" list, most-recent
@@ -93,7 +107,16 @@ abstract class RecentFrequenciesStore {
   /// you've nicknamed or pinned must not silently strip the metadata.
   /// Unpinned entries past [maxEntries] roll off; pinned entries are
   /// exempt from the cap.
-  Future<void> record(String freq);
+  ///
+  /// [sessionUuid] is the host's `FrequencySession.sessionUuid`. When
+  /// supplied (the post-#219 host path), it's persisted alongside the freq
+  /// so a later Resume can reconstitute the same room. On dedupe re-hosting
+  /// the same `freq`, a non-null incoming uuid **overwrites** any stored
+  /// uuid — the most recent host's session is the one Resume should target.
+  /// `null` leaves the stored uuid untouched on dedupe (preserves any value
+  /// from a previous post-#219 host) and writes `NULL` on a fresh row;
+  /// pre-#219 callers and tests don't need to thread a uuid through.
+  Future<void> record(String freq, {String? sessionUuid});
 
   /// Sets (or clears, when [nickname] is `null`) the display label for
   /// [freq]. No-op when [freq] hasn't been recorded yet — nicknames
@@ -156,7 +179,7 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
     // between the reads.
     final rows = await db.query(
       _table,
-      columns: ['freq', 'nickname', 'pinned'],
+      columns: ['freq', 'nickname', 'pinned', 'session_uuid'],
       orderBy: 'pinned DESC, recorded_at DESC',
     );
     final result = <RecentFrequency>[];
@@ -174,6 +197,7 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
 
   RecentFrequency _rowToRecent(Map<String, Object?> r) {
     final rawNickname = r['nickname'] as String?;
+    final rawSessionUuid = r['session_uuid'] as String?;
     return RecentFrequency(
       freq: r['freq']! as String,
       // NULL stays null; an empty string in storage (shouldn't happen via
@@ -184,17 +208,22 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
           ? null
           : rawNickname,
       pinned: (r['pinned'] as int? ?? 0) != 0,
+      // Pre-v4 rows are NULL; an empty-string written by a buggy caller is
+      // normalized to null with the same rationale as [nickname].
+      sessionUuid: (rawSessionUuid == null || rawSessionUuid.isEmpty)
+          ? null
+          : rawSessionUuid,
     );
   }
 
   @override
-  Future<void> record(String freq) {
-    final next = _writeChain.then((_) => _doRecord(freq));
+  Future<void> record(String freq, {String? sessionUuid}) {
+    final next = _writeChain.then((_) => _doRecord(freq, sessionUuid));
     _writeChain = next.catchError((_) {});
     return next;
   }
 
-  Future<void> _doRecord(String freq) async {
+  Future<void> _doRecord(String freq, String? sessionUuid) async {
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
     final db = await WalkieTalkieDatabase.open();
@@ -205,14 +234,27 @@ class SqfliteRecentFrequenciesStore implements RecentFrequenciesStore {
       // already set; new freq → insert with no nickname and unpinned.
       // ConflictAlgorithm.replace would wipe nickname + pinned, so use a
       // sqlite UPSERT (INSERT ... ON CONFLICT DO UPDATE) that touches
-      // only `recorded_at` on conflict.
+      // only `recorded_at` (and `session_uuid` when a non-null uuid is
+      // provided — see below) on conflict.
+      //
+      // session_uuid handling on conflict: COALESCE(excluded, existing)
+      // means a non-null incoming uuid overwrites whatever was stored,
+      // and a null incoming leaves the stored value alone. Rationale:
+      // - The most recent host's sessionUuid is what Resume should target,
+      //   so when the cubit re-records on a fresh host we want the new
+      //   uuid to win.
+      // - Pre-#219 callers (and any future caller that doesn't have a
+      //   uuid handy) pass `null` and shouldn't blow away a uuid that a
+      //   prior post-#219 host already persisted.
       await txn.rawInsert(
         '''
-        INSERT INTO $_table (freq, recorded_at, nickname, pinned)
-        VALUES (?, ?, NULL, 0)
-        ON CONFLICT(freq) DO UPDATE SET recorded_at = excluded.recorded_at
+        INSERT INTO $_table (freq, recorded_at, nickname, pinned, session_uuid)
+        VALUES (?, ?, NULL, 0, ?)
+        ON CONFLICT(freq) DO UPDATE SET
+          recorded_at = excluded.recorded_at,
+          session_uuid = COALESCE(excluded.session_uuid, $_table.session_uuid)
         ''',
-        [trimmed, orderingTimestamp],
+        [trimmed, orderingTimestamp, sessionUuid],
       );
       await _capUnpinnedRows(txn);
     });

--- a/lib/services/walkie_talkie_database.dart
+++ b/lib/services/walkie_talkie_database.dart
@@ -18,7 +18,13 @@ class WalkieTalkieDatabase {
   // the #125 naming/pinning sub-feature. Existing rows get `nickname=NULL`
   // and `pinned=0`, so the legacy unpinned-most-recent-first ordering is
   // unchanged for users who upgrade with no pinned entries.
-  static const int _dbVersion = 3;
+  // v4 (2026-05): added `session_uuid` to `recent_frequencies` for #219 so
+  // tapping Resume on a recent row reconstitutes the original
+  // `FrequencySession` instead of minting a fresh UUID (and therefore a
+  // fresh mhzDisplay). Existing rows get `session_uuid=NULL`; the cubit's
+  // host path falls back to minting a new UUID for those, matching pre-#219
+  // behaviour until the row is re-recorded.
+  static const int _dbVersion = 4;
 
   static DatabaseFactory? _factoryOverride;
   static String? _pathOverride;
@@ -79,7 +85,8 @@ class WalkieTalkieDatabase {
         freq TEXT PRIMARY KEY NOT NULL,
         recorded_at INTEGER NOT NULL,
         nickname TEXT,
-        pinned INTEGER NOT NULL DEFAULT 0
+        pinned INTEGER NOT NULL DEFAULT 0,
+        session_uuid TEXT
       )
     ''');
     await db.execute(
@@ -102,6 +109,27 @@ class WalkieTalkieDatabase {
     }
     if (oldVersion < 3) {
       await _addRecentFrequenciesNicknameAndPinned(db);
+    }
+    if (oldVersion < 4) {
+      await _addRecentFrequenciesSessionUuid(db);
+    }
+  }
+
+  /// Adds the v4 `session_uuid` (TEXT, NULL until the row is re-recorded
+  /// post-upgrade) column to `recent_frequencies`. Same `PRAGMA table_info`
+  /// guard pattern as [_addRecentFrequenciesNicknameAndPinned] so re-running
+  /// on a partially-migrated install is a no-op rather than a duplicate-
+  /// column error. Rows that pre-date this migration carry `NULL`; the
+  /// cubit's Resume path treats `NULL` as "fall back to minting a fresh
+  /// UUID" so users on legacy rows keep getting today's behaviour until
+  /// they re-host.
+  static Future<void> _addRecentFrequenciesSessionUuid(Database db) async {
+    final cols = await db.rawQuery('PRAGMA table_info(recent_frequencies)');
+    final existing = cols.map((r) => r['name'] as String?).toSet();
+    if (!existing.contains('session_uuid')) {
+      await db.execute(
+        'ALTER TABLE recent_frequencies ADD COLUMN session_uuid TEXT',
+      );
     }
   }
 

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -117,9 +117,16 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
     return List<RecentFrequency>.unmodifiable(result);
   }
 
+  /// Most recent `(freq, sessionUuid)` pair passed to [record], so tests
+  /// can assert that the cubit's host path threads the freshly-minted UUID
+  /// through to the store (#219). `null` for the uuid when the caller
+  /// didn't supply one — pre-#219 callers and a few legacy test paths.
+  ({String freq, String? sessionUuid})? lastRecordCall;
+
   @override
-  Future<void> record(String freq) async {
+  Future<void> record(String freq, {String? sessionUuid}) async {
     recordCalls++;
+    lastRecordCall = (freq: freq, sessionUuid: sessionUuid);
     if (throwOnRecord) throw StateError('boom');
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
@@ -128,11 +135,26 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
       orElse: () => _FakeRecentRow(RecentFrequency(freq: trimmed), -1),
     );
     if (existing.recordedAt < 0) {
-      _rows.add(_FakeRecentRow(existing.entry, _nextRecordedAt++));
+      // Fresh row — adopt the supplied uuid (or null on legacy callers).
+      _rows.add(_FakeRecentRow(
+        RecentFrequency(freq: trimmed, sessionUuid: sessionUuid),
+        _nextRecordedAt++,
+      ));
     } else {
       // Bump the existing row's recordedAt; nickname + pinned preserved
       // so re-recording a curated entry doesn't silently strip metadata.
+      // sessionUuid follows the production store's COALESCE rule: a
+      // non-null incoming uuid overwrites whatever was stored, a null
+      // incoming leaves the stored value alone.
       existing.recordedAt = _nextRecordedAt++;
+      if (sessionUuid != null) {
+        existing.entry = RecentFrequency(
+          freq: existing.entry.freq,
+          nickname: existing.entry.nickname,
+          pinned: existing.entry.pinned,
+          sessionUuid: sessionUuid,
+        );
+      }
     }
     // Mirror the production cap on UNPINNED entries; pinned rows exempt.
     final unpinnedSorted = _rows.where((r) => !r.entry.pinned).toList()
@@ -156,6 +178,7 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
       freq: _rows[idx].entry.freq,
       nickname: value,
       pinned: _rows[idx].entry.pinned,
+      sessionUuid: _rows[idx].entry.sessionUuid,
     );
   }
 
@@ -169,6 +192,7 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
       freq: _rows[idx].entry.freq,
       nickname: _rows[idx].entry.nickname,
       pinned: pinned,
+      sessionUuid: _rows[idx].entry.sessionUuid,
     );
     // Intentionally do NOT touch recordedAt — unpinning should demote a
     // row back to its real recency position relative to other unpinned
@@ -825,6 +849,74 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         expect(recent.recordCalls, 0);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'joinRoom as host threads the freshly-minted sessionUuid into record() '
+      'so a later Resume can reconstitute the same room (#219)',
+      () async {
+        // The Resume bug: pre-#219, the cubit recorded only the freq, so
+        // tapping Resume re-minted a fresh UUID and landed the user in a
+        // different room. The fix persists the host-mint sessionUuid
+        // alongside the freq.
+        final recent = _FakeRecentFrequenciesStore();
+        final cubit = _makeCubit(recentFrequenciesStore: recent);
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(isHost: true);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(recent.lastRecordCall, isNotNull);
+        expect(recent.lastRecordCall!.freq, '104.3');
+        expect(recent.lastRecordCall!.sessionUuid, _testHostSessionUuid);
+        // And the value round-trips through the store so Discovery sees it.
+        final detailed = await recent.getRecentDetailed();
+        expect(detailed.single.sessionUuid, _testHostSessionUuid);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'joinRoom as host with existingSessionUuid reuses it instead of '
+      'minting a fresh one (#219 Resume path)',
+      () async {
+        // Resume: the discovery screen plumbs the recent row's stored
+        // sessionUuid through `existingSessionUuid`. The cubit must use
+        // it verbatim so the room's `roomFreq` matches the row the user
+        // tapped — _mintSessionUuid is only the fallback.
+        var mintCalls = 0;
+        final recent = _FakeRecentFrequenciesStore();
+        final cubit = _makeCubit(
+          recentFrequenciesStore: recent,
+          mintSessionUuid: () {
+            mintCalls++;
+            return 'fresh-uuid-should-not-be-used';
+          },
+        );
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+
+        await cubit.joinRoom(
+          isHost: true,
+          existingSessionUuid: _testHostSessionUuid,
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(mintCalls, 0, reason: 'Resume must not mint a fresh UUID');
+        expect(cubit.state, isA<SessionRoom>());
+        final room = cubit.state as SessionRoom;
+        expect(room.roomFreq, '104.3');
+        // And the re-record carries the same uuid so a subsequent Resume
+        // sees an updated recorded_at but the same identity — the
+        // recents row doesn't fork into a new entry.
+        expect(recent.lastRecordCall!.sessionUuid, _testHostSessionUuid);
+        final detailed = await recent.getRecentDetailed();
+        expect(detailed, hasLength(1));
+        expect(detailed.single.freq, '104.3');
+        expect(detailed.single.sessionUuid, _testHostSessionUuid);
 
         await cubit.close();
       },
@@ -3912,7 +4004,7 @@ class _GatedRecentFrequenciesStore implements RecentFrequenciesStore {
   }
 
   @override
-  Future<void> record(String freq) async {}
+  Future<void> record(String freq, {String? sessionUuid}) async {}
 
   @override
   Future<void> setNickname(String freq, String? nickname) async {}

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -256,6 +256,65 @@ void main() {
     );
 
     testWidgets(
+      'tapping Resume threads the row\'s sessionUuid through to onPick (#219)',
+      (tester) async {
+        // The fix for #219: Resume must carry the persisted sessionUuid so
+        // the cubit reuses it instead of minting a fresh one. This is what
+        // makes Resume actually rejoin the same room.
+        const uuid = '00000000-0000-4000-8000-0000000000a3';
+        DiscoveryResult? picked;
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (r) => picked = r,
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '104.3', sessionUuid: uuid),
+            ],
+          ),
+        ));
+        await tester.pump();
+
+        await tester.tap(find.text('Resume'));
+        await tester.pump();
+
+        expect(picked, isNotNull);
+        expect(picked!.isHost, isTrue);
+        expect(picked!.freq, '104.3');
+        expect(picked!.hostSessionUuid, uuid);
+      },
+    );
+
+    testWidgets(
+      'Resume on a legacy row without a sessionUuid passes null through '
+      '(falls back to mint on the cubit side)',
+      (tester) async {
+        // Pre-#219 rows have sessionUuid == null. The screen must pass that
+        // through verbatim — the cubit's host path treats null as "mint
+        // fresh," which preserves pre-fix behaviour for legacy rows until
+        // the user re-hosts.
+        DiscoveryResult? picked;
+        await tester.pumpWidget(_wrap(
+          FrequencyDiscoveryScreen(
+            myName: 'Maya',
+            onPick: (r) => picked = r,
+            onRename: (_) {},
+            recentHostedFrequencies: const [
+              RecentFrequency(freq: '92.4'),
+            ],
+          ),
+        ));
+        await tester.pump();
+
+        await tester.tap(find.text('Resume'));
+        await tester.pump();
+
+        expect(picked, isNotNull);
+        expect(picked!.hostSessionUuid, isNull);
+      },
+    );
+
+    testWidgets(
       'renders nickname instead of default title when one is set on a recent',
       (tester) async {
         await tester.pumpWidget(_wrap(

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -974,7 +974,7 @@ class _NullRecentFrequenciesStore implements RecentFrequenciesStore {
   @override
   Future<List<RecentFrequency>> getRecentDetailed() async => const [];
   @override
-  Future<void> record(String freq) async {}
+  Future<void> record(String freq, {String? sessionUuid}) async {}
   @override
   Future<void> setNickname(String freq, String? nickname) async {}
   @override

--- a/test/services/recent_frequencies_store_test.dart
+++ b/test/services/recent_frequencies_store_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
@@ -327,6 +329,39 @@ void main() {
     });
 
     test(
+        'record with empty / whitespace-only sessionUuid normalizes to null '
+        'and does NOT clobber a stored uuid',
+        () async {
+      // Without the write-side normalization, an empty string would be
+      // non-null to COALESCE and overwrite a valid stored uuid — Resume
+      // would then dial a blank session and silently fall back to mint.
+      final store = SqfliteRecentFrequenciesStore();
+      const uuid = '00000000-0000-4000-8000-0000000000a3';
+      await store.record('104.3', sessionUuid: uuid);
+      // Empty + whitespace-only buggy callers must not clobber.
+      await store.record('104.3', sessionUuid: '');
+      await store.record('104.3', sessionUuid: '   ');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.sessionUuid, uuid);
+    });
+
+    test(
+        'record with empty sessionUuid on a fresh row leaves the column NULL '
+        '(not the literal empty string)',
+        () async {
+      // The other half of the normalization: a fresh row with an empty
+      // incoming uuid must not be written as `''` and round-trip as
+      // null on read, since that would make `setNickname`-style updates
+      // misleading and break the equality of the model's null sentinel.
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('104.3', sessionUuid: '   ');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.sessionUuid, isNull);
+    });
+
+    test(
         're-recording the same freq with a new uuid overwrites the stored uuid',
         () async {
       // The most-recent host's sessionUuid is what Resume should target.
@@ -403,6 +438,144 @@ void main() {
       expect(detailed.single.freq, '92.4');
       expect(detailed.single.nickname, 'Family channel');
       expect(detailed.single.pinned, isTrue);
+    });
+  });
+
+  group('schema migration v3 → v4 (#219)', () {
+    // These tests open a real on-disk file (not :memory:, which would lose
+    // its contents between opens) so we can simulate "user upgrading from
+    // a v3 install" — write a v3 schema + row, close, reopen with the
+    // production WalkieTalkieDatabase (v4) and assert the upgrade lands.
+    late Directory tmpDir;
+    late String dbPath;
+
+    setUp(() async {
+      // Override needs to be cleared before tests in this group can use
+      // their own paths — the outer setUp installed an in-memory override.
+      WalkieTalkieDatabase.clearDatabaseFactoryOverride();
+      await WalkieTalkieDatabase.resetForTesting();
+      tmpDir = await Directory.systemTemp.createTemp('walkie_talkie_v3_v4_');
+      dbPath = '${tmpDir.path}/walkie_talkie.db';
+    });
+
+    tearDown(() async {
+      await WalkieTalkieDatabase.resetForTesting();
+      WalkieTalkieDatabase.clearDatabaseFactoryOverride();
+      if (tmpDir.existsSync()) {
+        await tmpDir.delete(recursive: true);
+      }
+    });
+
+    /// Hand-rolls a v3 schema at [dbPath] (no `session_uuid`) so the next
+    /// open with the production v4 factory triggers the upgrade.
+    Future<void> seedV3Database({Map<String, Object?>? row}) async {
+      final v3 = await databaseFactoryFfi.openDatabase(
+        dbPath,
+        options: OpenDatabaseOptions(
+          version: 3,
+          onCreate: (db, _) async {
+            await db.execute('''
+              CREATE TABLE kv (
+                key TEXT PRIMARY KEY NOT NULL,
+                value TEXT NOT NULL
+              )
+            ''');
+            await db.execute('''
+              CREATE TABLE recent_frequencies (
+                freq TEXT PRIMARY KEY NOT NULL,
+                recorded_at INTEGER NOT NULL,
+                nickname TEXT,
+                pinned INTEGER NOT NULL DEFAULT 0
+              )
+            ''');
+            await db.execute(
+              'CREATE INDEX idx_recent_freq_time ON recent_frequencies (recorded_at)',
+            );
+            await db.execute('''
+              CREATE TABLE blocked_peers (
+                peer_id TEXT PRIMARY KEY NOT NULL,
+                blocked_at INTEGER NOT NULL
+              )
+            ''');
+          },
+        ),
+      );
+      if (row != null) {
+        await v3.insert('recent_frequencies', row);
+      }
+      await v3.close();
+    }
+
+    test('opens a v3 install, runs the upgrade, surfaces session_uuid as NULL',
+        () async {
+      // Pre-existing legacy row gets a NULL session_uuid post-upgrade
+      // (the cubit's host path will mint a fresh uuid for it on Resume,
+      // matching pre-#219 behaviour until the user re-hosts).
+      await seedV3Database(row: {
+        'freq': '92.4',
+        'recorded_at': 12345,
+        'nickname': 'Family channel',
+        'pinned': 1,
+      });
+
+      WalkieTalkieDatabase.overrideDatabaseFactoryForTesting(
+        databaseFactoryFfi,
+        path: dbPath,
+      );
+      final store = SqfliteRecentFrequenciesStore();
+      final detailed = await store.getRecentDetailed();
+
+      expect(detailed, hasLength(1));
+      expect(detailed.single.freq, '92.4');
+      expect(detailed.single.nickname, 'Family channel');
+      expect(detailed.single.pinned, isTrue);
+      expect(
+        detailed.single.sessionUuid,
+        isNull,
+        reason: 'pre-#219 row carries no uuid; expected NULL post-upgrade',
+      );
+    });
+
+    test('post-upgrade record() can write into the new session_uuid column',
+        () async {
+      // Catches a migration that adds the column but somehow doesn't
+      // make it writable (typo'd ALTER, missing default, etc).
+      await seedV3Database();
+
+      WalkieTalkieDatabase.overrideDatabaseFactoryForTesting(
+        databaseFactoryFfi,
+        path: dbPath,
+      );
+      final store = SqfliteRecentFrequenciesStore();
+      const uuid = '00000000-0000-4000-8000-0000000000a3';
+      await store.record('104.3', sessionUuid: uuid);
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.sessionUuid, uuid);
+    });
+
+    test('upgrade is idempotent — already-upgraded install opens cleanly',
+        () async {
+      // First open: triggers v3 → v4 upgrade.
+      await seedV3Database();
+      WalkieTalkieDatabase.overrideDatabaseFactoryForTesting(
+        databaseFactoryFfi,
+        path: dbPath,
+      );
+      final first = SqfliteRecentFrequenciesStore();
+      await first.record('92.4');
+      await WalkieTalkieDatabase.resetForTesting();
+
+      // Second open: already at v4. The migration's `PRAGMA table_info`
+      // guard skips the ALTER, so this must not throw "duplicate column".
+      WalkieTalkieDatabase.overrideDatabaseFactoryForTesting(
+        databaseFactoryFfi,
+        path: dbPath,
+      );
+      final second = SqfliteRecentFrequenciesStore();
+      final detailed = await second.getRecentDetailed();
+      expect(detailed, hasLength(1));
+      expect(detailed.single.freq, '92.4');
     });
   });
 

--- a/test/services/recent_frequencies_store_test.dart
+++ b/test/services/recent_frequencies_store_test.dart
@@ -299,6 +299,98 @@ void main() {
       expect(await store.getRecentDetailed(), isEmpty);
     });
 
+    // ── sessionUuid (#219) ──────────────────────────────────────────
+
+    test('record(sessionUuid: ...) round-trips through getRecentDetailed',
+        () async {
+      // The Resume path on Discovery reads sessionUuid off the
+      // RecentFrequency record so it can reconstitute the same room
+      // instead of minting a fresh UUID.
+      final store = SqfliteRecentFrequenciesStore();
+      const uuid = '00000000-0000-4000-8000-0000000000a3';
+      await store.record('104.3', sessionUuid: uuid);
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.freq, '104.3');
+      expect(detailed.single.sessionUuid, uuid);
+    });
+
+    test('record without a sessionUuid leaves the column NULL', () async {
+      // Pre-#219 callers and any future caller without a uuid handy.
+      // Reads back as null on the model so the cubit's "fall back to
+      // minting" branch fires for legacy rows.
+      final store = SqfliteRecentFrequenciesStore();
+      await store.record('92.4');
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.sessionUuid, isNull);
+    });
+
+    test(
+        're-recording the same freq with a new uuid overwrites the stored uuid',
+        () async {
+      // The most-recent host's sessionUuid is what Resume should target.
+      // If a user re-hosts the same freq from a different session, the
+      // stored uuid must move forward; otherwise Resume would dial a stale
+      // session that is no longer being advertised.
+      final store = SqfliteRecentFrequenciesStore();
+      const uuidA = '00000000-0000-4000-8000-0000000000a3';
+      const uuidB = '11111111-1111-4111-8111-1111111111a3';
+      await store.record('104.3', sessionUuid: uuidA);
+      await store.record('104.3', sessionUuid: uuidB);
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed, hasLength(1));
+      expect(detailed.single.sessionUuid, uuidB);
+    });
+
+    test(
+        're-recording with null does NOT clobber an already-stored uuid',
+        () async {
+      // COALESCE rule: a null incoming uuid means "I don't have one to
+      // contribute," not "clear the field." Important for migration —
+      // legacy callers that pass no uuid must not silently strip a uuid
+      // that a post-#219 caller already persisted.
+      final store = SqfliteRecentFrequenciesStore();
+      const uuid = '00000000-0000-4000-8000-0000000000a3';
+      await store.record('104.3', sessionUuid: uuid);
+      await store.record('104.3'); // legacy-style, no uuid
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.sessionUuid, uuid);
+    });
+
+    test(
+        're-recording preserves nickname + pinned alongside the uuid update',
+        () async {
+      // Existing #125 invariant (record preserves user-curated metadata)
+      // continues to hold when the sessionUuid is being updated.
+      final store = SqfliteRecentFrequenciesStore();
+      const uuid = '00000000-0000-4000-8000-0000000000a3';
+      await store.record('104.3');
+      await store.setNickname('104.3', 'Family channel');
+      await store.setPinned('104.3', true);
+      await store.record('104.3', sessionUuid: uuid);
+
+      final detailed = await store.getRecentDetailed();
+      expect(detailed.single.nickname, 'Family channel');
+      expect(detailed.single.pinned, isTrue);
+      expect(detailed.single.sessionUuid, uuid);
+    });
+
+    test('sessionUuid persists across new store instances', () async {
+      // Same persistence guarantee as nickname + pinned — a fresh store
+      // instance reads the uuid back off disk so a Resume after restart
+      // still targets the original session.
+      const uuid = '00000000-0000-4000-8000-0000000000a3';
+      final first = SqfliteRecentFrequenciesStore();
+      await first.record('104.3', sessionUuid: uuid);
+
+      final second = SqfliteRecentFrequenciesStore();
+      final detailed = await second.getRecentDetailed();
+      expect(detailed.single.sessionUuid, uuid);
+    });
+
     test('nickname + pinned both persist across new store instances',
         () async {
       final first = SqfliteRecentFrequenciesStore();
@@ -315,30 +407,41 @@ void main() {
   });
 
   group('RecentFrequency value type', () {
-    test('value equality covers freq + nickname + pinned', () {
+    test('value equality covers freq + nickname + pinned + sessionUuid', () {
       const a = RecentFrequency(
         freq: '92.4',
         nickname: 'Family',
         pinned: true,
+        sessionUuid: '00000000-0000-4000-8000-0000000000a3',
       );
       const b = RecentFrequency(
         freq: '92.4',
         nickname: 'Family',
         pinned: true,
+        sessionUuid: '00000000-0000-4000-8000-0000000000a3',
       );
       const cDifferentNickname = RecentFrequency(
         freq: '92.4',
         nickname: 'Other',
         pinned: true,
+        sessionUuid: '00000000-0000-4000-8000-0000000000a3',
       );
       const dDifferentPinned = RecentFrequency(
         freq: '92.4',
         nickname: 'Family',
+        sessionUuid: '00000000-0000-4000-8000-0000000000a3',
+      );
+      const eDifferentUuid = RecentFrequency(
+        freq: '92.4',
+        nickname: 'Family',
+        pinned: true,
+        sessionUuid: '11111111-1111-4111-8111-1111111111a3',
       );
       expect(a, b);
       expect(a.hashCode, b.hashCode);
       expect(a == cDifferentNickname, isFalse);
       expect(a == dDifferentPinned, isFalse);
+      expect(a == eDifferentUuid, isFalse);
     });
 
     test('toString surfaces every field for debug logs', () {
@@ -346,10 +449,12 @@ void main() {
         freq: '92.4',
         nickname: 'Family',
         pinned: true,
+        sessionUuid: '00000000-0000-4000-8000-0000000000a3',
       );
       expect(r.toString(), contains('92.4'));
       expect(r.toString(), contains('Family'));
       expect(r.toString(), contains('true'));
+      expect(r.toString(), contains('00000000-0000-4000-8000-0000000000a3'));
     });
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -82,7 +82,7 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
   }
 
   @override
-  Future<void> record(String freq) async {
+  Future<void> record(String freq, {String? sessionUuid}) async {
     final trimmed = freq.trim();
     if (trimmed.isEmpty) return;
     final existing = _rows.firstWhere(
@@ -90,9 +90,20 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
       orElse: () => _FakeRecentRow(RecentFrequency(freq: trimmed), -1),
     );
     if (existing.recordedAt < 0) {
-      _rows.add(_FakeRecentRow(existing.entry, _nextRecordedAt++));
+      _rows.add(_FakeRecentRow(
+        RecentFrequency(freq: trimmed, sessionUuid: sessionUuid),
+        _nextRecordedAt++,
+      ));
     } else {
       existing.recordedAt = _nextRecordedAt++;
+      if (sessionUuid != null) {
+        existing.entry = RecentFrequency(
+          freq: existing.entry.freq,
+          nickname: existing.entry.nickname,
+          pinned: existing.entry.pinned,
+          sessionUuid: sessionUuid,
+        );
+      }
     }
     final unpinnedSorted = _rows.where((r) => !r.entry.pinned).toList()
       ..sort((a, b) => b.recordedAt.compareTo(a.recordedAt));

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -124,6 +124,11 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
       freq: _rows[idx].entry.freq,
       nickname: value,
       pinned: _rows[idx].entry.pinned,
+      // Preserve the persisted sessionUuid — production's UPDATE only
+      // touches the nickname column. Without this, renaming a recent
+      // would silently strip its sessionUuid in widget tests and Resume
+      // would fall back to minting (#219).
+      sessionUuid: _rows[idx].entry.sessionUuid,
     );
   }
 
@@ -135,6 +140,9 @@ class _FakeRecentFrequenciesStore implements RecentFrequenciesStore {
       freq: _rows[idx].entry.freq,
       nickname: _rows[idx].entry.nickname,
       pinned: pinned,
+      // Same rationale as setNickname above — pin/unpin must not strip
+      // the sessionUuid (#219).
+      sessionUuid: _rows[idx].entry.sessionUuid,
     );
     // Intentionally do NOT touch recordedAt — unpinning should demote a
     // row back to its real recency position relative to other unpinned


### PR DESCRIPTION
## Summary

Closes #219.

Pre-fix, tapping Resume on a Discovery → Recent row always minted a fresh `sessionUuid` and landed the user in a *different* room each tap, polluting the Recent list with phantom entries. This PR persists the host's `sessionUuid` alongside the freq so Resume reconstitutes the same `FrequencySession`.

## What changed

- **DB schema v4 migration** (`walkie_talkie_database.dart`) — add nullable `session_uuid TEXT` column to `recent_frequencies`. Idempotent, same `PRAGMA table_info` guard pattern as the v3 nickname/pinned migration.
- **Store API** (`recent_frequencies_store.dart`) — `RecentFrequency.sessionUuid` field; `record(freq, {sessionUuid})` upsert uses `COALESCE(excluded.session_uuid, existing)` so a non-null incoming uuid wins (most-recent host's session is what Resume should target) but a null incoming preserves any prior value (so legacy callers don't clobber post-#219 data).
- **Cubit** (`frequency_session_cubit.dart`) — `joinRoom(existingSessionUuid:)` skips `_mintSessionUuid()` when supplied; record call threads the uuid through with the same value used to derive `roomFreq`.
- **UI** (`frequency_discovery_screen.dart`, `main.dart`) — `DiscoveryResult.hostSessionUuid` plumbs the recent row's stored uuid through to the router, which passes it on as `existingSessionUuid`.

## Migration safety

Rows recorded before this change have `session_uuid = NULL`. The cubit treats null as "fall back to mint," so users on legacy rows get pre-#219 behaviour until they re-host — no broken Resume on upgrade.

## Tests added

- **Store** — uuid round-trip, NULL stays null for legacy callers, COALESCE preserves vs. overwrites on re-record, persistence across store instances, value-type equality + toString.
- **Cubit** — host path threads minted uuid into `record()`; Resume path reuses `existingSessionUuid` without minting and re-records the same uuid (no fork into a new entry).
- **Discovery screen** — Resume widget threads sessionUuid through; legacy null rows pass null.

All 562 tests pass; `flutter analyze` clean.

## Test plan

- [ ] Fresh install: Start a new frequency, leave, tap Resume — same freq, same room.
- [ ] Resume twice on the same row — Recent list still has one entry, not three.
- [ ] Cold restart with a recorded recent → Resume — same room.
- [ ] Pre-existing install (legacy v3 row): Resume mints a fresh UUID once, then subsequent re-hosts populate `session_uuid` and Resume becomes stable.
- [ ] Re-hosting same freq from a different session: stored uuid moves forward to the latest host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosts can resume previously active sessions using stored session identifiers.
  * Recent frequency history now persists session identifiers so resumed hosts rejoin the same session.

* **Chores**
  * Local storage schema upgraded to record session identifiers and migrate legacy data safely.

* **Tests**
  * Added comprehensive tests for resume behavior, session persistence, migration, and legacy handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->