### PR TITLE
fix(#220): expand discovery preview to full 200-bucket FM range

### DIFF
--- a/lib/protocol/frequency_session.dart
+++ b/lib/protocol/frequency_session.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 /// Identity of a single frequency room.
 ///
 /// `sessionUuid` is canonical and used for all routing decisions. The
@@ -29,6 +31,15 @@ class FrequencySession {
       n >>= 5;
     }
     return out.toString();
+  }
+
+  /// Returns a random display frequency in [88.0, 107.9] MHz using the same
+  /// 200-bucket arithmetic as [mhzDisplay], so preview UIs stay in sync with
+  /// the real range without duplicating the formula.
+  static String randomMhzDisplay(math.Random rnd) {
+    const baseTenths = 880;
+    const buckets = 200;
+    return ((baseTenths + rnd.nextInt(buckets)) / 10.0).toStringAsFixed(1);
   }
 
   static const _codeAlphabet = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -100,11 +100,17 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
 
   late final String _newFreq;
 
+  // FM band: 88.0–107.9 MHz at 0.1-MHz precision → 200 buckets stored as
+  // integer tenths (880–1079). Matches FrequencySession.mhzDisplay arithmetic.
+  static const _freqBaseTenths = 880;
+  static const _freqBuckets = 200;
+
   @override
   void initState() {
     super.initState();
     final rnd = Random();
-    _newFreq = ((880 + rnd.nextInt(200)) / 10.0).toStringAsFixed(1);
+    _newFreq =
+        ((_freqBaseTenths + rnd.nextInt(_freqBuckets)) / 10.0).toStringAsFixed(1);
     
     // Start scanning automatically when entering the screen.
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -9,6 +9,7 @@ import '../bloc/discovery_state.dart';
 import '../l10n/generated/app_localizations.dart';
 import '../l10n/styled_template.dart';
 import '../protocol/discovery.dart';
+import '../protocol/frequency_session.dart';
 import '../services/recent_frequencies_store.dart';
 import '../services/settings_store.dart';
 import '../theme/app_theme.dart';
@@ -100,17 +101,10 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
 
   late final String _newFreq;
 
-  // FM band: 88.0–107.9 MHz at 0.1-MHz precision → 200 buckets stored as
-  // integer tenths (880–1079). Matches FrequencySession.mhzDisplay arithmetic.
-  static const _freqBaseTenths = 880;
-  static const _freqBuckets = 200;
-
   @override
   void initState() {
     super.initState();
-    final rnd = Random();
-    _newFreq =
-        ((_freqBaseTenths + rnd.nextInt(_freqBuckets)) / 10.0).toStringAsFixed(1);
+    _newFreq = FrequencySession.randomMhzDisplay(Random());
     
     // Start scanning automatically when entering the screen.
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -99,13 +99,12 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
   DiscoveryCubit? _cubit;
 
   late final String _newFreq;
-  static const _freqRng = 20;
 
   @override
   void initState() {
     super.initState();
     final rnd = Random();
-    _newFreq = (88 + rnd.nextInt(_freqRng) + 0.1).toStringAsFixed(1);
+    _newFreq = ((880 + rnd.nextInt(200)) / 10.0).toStringAsFixed(1);
     
     // Start scanning automatically when entering the screen.
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -186,6 +186,10 @@ void main() {
     testWidgets(
       'preview freq is in the full FM range [88.0, 107.9] and has .1 precision',
       (tester) async {
+        // Range bounds match _freqBaseTenths / _freqBuckets in the screen.
+        const minFreq = 88.0;
+        const maxFreq = 107.9;
+
         // Run several widget instances to sample the RNG and confirm every
         // value falls in the 200-bucket range that matches mhzDisplay.
         for (var i = 0; i < 20; i++) {
@@ -203,10 +207,10 @@ void main() {
 
           expect(picked, isNotNull);
           final freq = double.parse(picked!.freq);
-          expect(freq, greaterThanOrEqualTo(88.0),
-              reason: 'freq $freq below 88.0');
-          expect(freq, lessThanOrEqualTo(107.9),
-              reason: 'freq $freq above 107.9');
+          expect(freq, greaterThanOrEqualTo(minFreq),
+              reason: 'freq $freq below $minFreq');
+          expect(freq, lessThanOrEqualTo(maxFreq),
+              reason: 'freq $freq above $maxFreq');
           // All values must end in exactly one decimal digit (0.1 MHz precision).
           expect(picked!.freq, matches(r'^\d+\.\d$'),
               reason: 'freq ${picked!.freq} lacks single-decimal precision');

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -184,6 +184,37 @@ void main() {
     });
 
     testWidgets(
+      'preview freq is in the full FM range [88.0, 107.9] and has .1 precision',
+      (tester) async {
+        // Run several widget instances to sample the RNG and confirm every
+        // value falls in the 200-bucket range that matches mhzDisplay.
+        for (var i = 0; i < 20; i++) {
+          DiscoveryResult? picked;
+          await tester.pumpWidget(_wrap(
+            FrequencyDiscoveryScreen(
+              myName: 'Maya',
+              onPick: (r) => picked = r,
+              onRename: (_) {},
+            ),
+          ));
+          await tester.pump();
+          await tester.tap(find.text('Start a new Frequency'));
+          await tester.pump();
+
+          expect(picked, isNotNull);
+          final freq = double.parse(picked!.freq);
+          expect(freq, greaterThanOrEqualTo(88.0),
+              reason: 'freq $freq below 88.0');
+          expect(freq, lessThanOrEqualTo(107.9),
+              reason: 'freq $freq above 107.9');
+          // All values must end in exactly one decimal digit (0.1 MHz precision).
+          expect(picked!.freq, matches(r'^\d+\.\d$'),
+              reason: 'freq ${picked!.freq} lacks single-decimal precision');
+        }
+      },
+    );
+
+    testWidgets(
       'omits the Recent section when there are no persisted frequencies',
       (tester) async {
         await tester.pumpWidget(_wrap(

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -216,7 +216,7 @@ void main() {
           // All values must end in exactly one decimal digit (0.1 MHz precision).
           expect(picked!.freq, matches(r'^\d+\.\d$'),
               reason: 'freq ${picked!.freq} lacks single-decimal precision');
-          if (!picked.freq.endsWith('.1')) sawNonDotOne = true;
+          if (!picked!.freq.endsWith('.1')) sawNonDotOne = true;
         }
 
         // Regression guard: old 20-bucket logic always produced `*.1`.

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -186,16 +186,18 @@ void main() {
     testWidgets(
       'preview freq is in the full FM range [88.0, 107.9] and has .1 precision',
       (tester) async {
-        // Range bounds match _freqBaseTenths / _freqBuckets in the screen.
+        // Range bounds match FrequencySession.randomMhzDisplay.
         const minFreq = 88.0;
         const maxFreq = 107.9;
+        var sawNonDotOne = false;
 
-        // Run several widget instances to sample the RNG and confirm every
-        // value falls in the 200-bucket range that matches mhzDisplay.
+        // Use a unique ValueKey per iteration so each pumpWidget call triggers
+        // a fresh State and a new initState() / _newFreq draw from the RNG.
         for (var i = 0; i < 20; i++) {
           DiscoveryResult? picked;
           await tester.pumpWidget(_wrap(
             FrequencyDiscoveryScreen(
+              key: ValueKey(i),
               myName: 'Maya',
               onPick: (r) => picked = r,
               onRename: (_) {},
@@ -214,7 +216,15 @@ void main() {
           // All values must end in exactly one decimal digit (0.1 MHz precision).
           expect(picked!.freq, matches(r'^\d+\.\d$'),
               reason: 'freq ${picked!.freq} lacks single-decimal precision');
+          if (!picked.freq.endsWith('.1')) sawNonDotOne = true;
         }
+
+        // Regression guard: old 20-bucket logic always produced `*.1`.
+        // With 200 buckets, 90% of values don't end in .1, so 20 draws almost
+        // certainly include at least one non-.1 value.
+        expect(sawNonDotOne, isTrue,
+            reason:
+                'all samples ended in .1 — old 20-bucket logic may have regressed');
       },
     );
 


### PR DESCRIPTION
## Summary

Closes #220.

The "Start a new frequency" preview card was picking from only **20 buckets** (`88.1, 89.1, … 107.1`) because the formula added a fixed `+ 0.1` offset to an integer drawn from `nextInt(20)`. The real `mhzDisplay` on `FrequencySession` uses `880 + (uuid_bits % 200)` for **200 evenly-distributed tenths** across `[88.0, 107.9]`.

**Root cause** (`lib/screens/frequency_discovery_screen.dart:101–108`):
```dart
// Before: 20 buckets, all ending in .1
static const _freqRng = 20;
_newFreq = (88 + rnd.nextInt(_freqRng) + 0.1).toStringAsFixed(1);

// After: 200 buckets matching FrequencySession.mhzDisplay
_newFreq = ((880 + rnd.nextInt(200)) / 10.0).toStringAsFixed(1);
```

This arithmetic mirrors the UUID-based derivation exactly, so the preview distribution is now identical to what the user sees in the room header.

> The second ask in the issue ("commit to the previewed freq or remove the preview") is a larger refactor (minting a sessionUuid from the preview value and threading it through the router). Fixing the distribution alone resolves the misleading feedback while leaving that follow-on open for a separate PR.

## Tests added

- `preview freq is in the full FM range [88.0, 107.9] and has .1 precision` — samples 20 independent widget instances and asserts every generated value is in range with single-decimal precision.

## Test plan

- [ ] Open Discovery screen several times — confirm "Start a new Frequency" card shows varying tenths (not always `.1`).
- [ ] Confirm all values are in `[88.0, 107.9]` range.
- [ ] Existing test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frequency discovery now consistently produces start frequencies within the FM broadcast range (88.0–107.9 MHz) and displays them with a single decimal.
  * Reduced repetitive frequency patterns so generated start frequencies vary more naturally.

* **Tests**
  * Added a widget test that repeatedly triggers frequency discovery and verifies picked frequencies are present, in-range, and formatted with one decimal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->