### PR TITLE
fix(#223): correct NowPlayingCard idle state — static VuMeter, no negative time

### DIFF
--- a/lib/data/frequency_models.dart
+++ b/lib/data/frequency_models.dart
@@ -55,7 +55,7 @@ const MediaSourceLib emptyMediaLib = MediaSourceLib(
   name: '',
   kind: MediaKind.music,
   queue: [
-    Track(title: 'Nothing playing', artist: '—', durationSeconds: 1, tag: ''),
+    Track(title: 'Nothing playing', artist: '—', durationSeconds: 0, tag: ''),
   ],
 );
 

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -108,8 +108,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   bool _didReadInitialSnapshot = false;
 
   int _trackIdx = 0;
-  bool _playing = true;
-  int _progress = 37;
+  bool _playing = false;
+  int _progress = 0;
   late _LastAction _lastAction;
   AudioOutput _output = AudioOutput.bluetooth;
 
@@ -522,7 +522,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   void _startProgressTick() {
     _progressTimer?.cancel();
     _progressTimer = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (!_playing || !mounted) return;
+      if (!_playing || !mounted || _track.durationSeconds <= 0) return;
       setState(() => _progress = (_progress + 1) % _track.durationSeconds);
     });
   }

--- a/lib/widgets/frequency_atoms.dart
+++ b/lib/widgets/frequency_atoms.dart
@@ -295,13 +295,28 @@ class VuMeter extends StatefulWidget {
 }
 
 class _VuMeterState extends State<VuMeter> with SingleTickerProviderStateMixin {
-  late final AnimationController _ctrl = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 900),
-  )..repeat();
+  late final AnimationController _ctrl;
 
   static const _heights = [0.40, 0.90, 0.55, 0.75];
   static const _delays = [0.0, 0.167, 0.333, 0.5];
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this, duration: const Duration(milliseconds: 900));
+    if (widget.active) _ctrl.repeat();
+  }
+
+  @override
+  void didUpdateWidget(VuMeter old) {
+    super.didUpdateWidget(old);
+    if (widget.active == old.active) return;
+    if (widget.active) {
+      _ctrl.repeat();
+    } else {
+      _ctrl.stop();
+    }
+  }
 
   @override
   void dispose() {

--- a/lib/widgets/now_playing_card.dart
+++ b/lib/widgets/now_playing_card.dart
@@ -39,6 +39,11 @@ class NowPlayingCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
+    // Guard: durationSeconds == 0 means no track is loaded yet (emptyMediaLib).
+    // Skip the slider/time row to avoid a max==0 Slider assertion and negative
+    // time display; hold the VuMeter static regardless of the playing flag.
+    final bool idle = track.durationSeconds <= 0;
+    final bool liveActive = playing && !idle;
     return FreqCard(
       padding: const EdgeInsets.all(16),
       child: Column(
@@ -61,10 +66,10 @@ class NowPlayingCard extends StatelessWidget {
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  VuMeter(active: playing),
+                  VuMeter(active: liveActive),
                   const SizedBox(width: 5),
                   Text(
-                    playing ? 'Live' : 'Paused',
+                    liveActive ? 'Live' : 'Paused',
                     style: TextStyle(
                       fontFamily: 'Inter',
                       fontSize: 10,
@@ -118,21 +123,23 @@ class NowPlayingCard extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 14),
-          Slider(
-            value: progress.toDouble().clamp(0.0, track.durationSeconds.toDouble()).toDouble(),
-            min: 0,
-            max: track.durationSeconds.toDouble(),
-            onChanged: onScrub,
-          ),
-          Row(
-            children: [
-              Text(formatTime(progress), style: kMonoStyle.copyWith(fontSize: 11, color: c.ink3)),
-              const Spacer(),
-              Text('-${formatTime(track.durationSeconds - progress)}',
-                  style: kMonoStyle.copyWith(fontSize: 11, color: c.ink3)),
-            ],
-          ),
+          if (!idle) ...[
+            const SizedBox(height: 14),
+            Slider(
+              value: progress.toDouble().clamp(0.0, track.durationSeconds.toDouble()),
+              min: 0,
+              max: track.durationSeconds.toDouble(),
+              onChanged: onScrub,
+            ),
+            Row(
+              children: [
+                Text(formatTime(progress), style: kMonoStyle.copyWith(fontSize: 11, color: c.ink3)),
+                const Spacer(),
+                Text('-${formatTime(track.durationSeconds - progress)}',
+                    style: kMonoStyle.copyWith(fontSize: 11, color: c.ink3)),
+              ],
+            ),
+          ],
           const SizedBox(height: 8),
           Row(
             children: [

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -292,16 +292,34 @@ void main() {
 
     testWidgets('play/pause flips the transport icon and the Live/Paused badge',
         (tester) async {
-      await tester.pumpWidget(_wrap(_room()));
+      final cubit = _seededCubit();
+      addTearDown(cubit.close);
+
+      await tester.pumpWidget(_wrap(_room(), cubit: cubit));
       await tester.pump();
 
-      // Initial: playing → pause icon visible (the transport button shows
-      // "what tapping it will do"), badge says Live.
+      // Land a playing snapshot so there is a real track and liveActive=true.
+      cubit.applyJoinAccepted(JoinAccepted(
+        peerId: 'p-host',
+        seq: 1,
+        atMs: 0,
+        hostPeerId: 'p-host',
+        roster: const [],
+        mediaState: const MediaState(
+          source: 'YouTube Music',
+          trackIdx: 0,
+          playing: true,
+          positionMs: 0,
+        ),
+      ));
+      await tester.pump();
+
+      // Playing with real track: pause icon visible, badge says Live.
       expect(find.byIcon(Icons.pause), findsOneWidget);
       expect(find.byIcon(Icons.play_arrow), findsNothing);
       expect(find.text('Live'), findsOneWidget);
 
-      // Tap the play/pause button.
+      // Tap pause — command echoes back through the real cubit's stream.
       await tester.tap(find.byIcon(Icons.pause));
       await tester.pump();
 
@@ -881,6 +899,63 @@ void main() {
           audioCalls.last,
           isMethodCall('setMuted', arguments: {'muted': true}),
         );
+      },
+    );
+
+    // --- NowPlayingCard idle state (issue #223) ---
+
+    testWidgets(
+      'idle state: VuMeter is static and slider/time row are absent '
+      'before any media snapshot lands (#223)',
+      (tester) async {
+        await tester.pumpWidget(_wrap(_room()));
+        await tester.pump();
+
+        // No media snapshot → emptyMediaLib (durationSeconds == 0).
+        // The card must show "Paused" (not "Live") and must not render
+        // the Slider or time labels that would show negative numbers.
+        expect(find.text('Paused'), findsOneWidget);
+        expect(find.text('Live'), findsNothing);
+        expect(find.byType(Slider), findsNothing);
+        // 'Nothing playing' is the emptyMediaLib placeholder title.
+        expect(find.text('Nothing playing'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'idle → live: slider and time row appear once a playing snapshot lands (#223)',
+      (tester) async {
+        final cubit = _seededCubit();
+        addTearDown(cubit.close);
+
+        await tester.pumpWidget(_wrap(_room(), cubit: cubit));
+        await tester.pump();
+
+        // Idle state — no Slider yet.
+        expect(find.byType(Slider), findsNothing);
+        expect(find.text('Live'), findsNothing);
+
+        // Host publishes a playing snapshot.
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [],
+          mediaState: const MediaState(
+            source: 'YouTube Music',
+            trackIdx: 0,
+            playing: true,
+            positionMs: 5000,
+          ),
+        ));
+        await tester.pump();
+
+        // Slider and time labels are now visible.
+        expect(find.byType(Slider), findsOneWidget);
+        expect(find.text('Live'), findsOneWidget);
+        // Elapsed time (5 s).
+        expect(find.text('0:05'), findsOneWidget);
       },
     );
 

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:walkie_talkie/services/blocked_peers_store.dart';
 import 'package:walkie_talkie/services/identity_store.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
+import 'package:walkie_talkie/widgets/frequency_atoms.dart';
 import 'package:walkie_talkie/widgets/frequency_toast_host.dart';
 
 /// MethodChannel name the audio service uses to talk to the native engine.
@@ -919,6 +920,9 @@ void main() {
         expect(find.byType(Slider), findsNothing);
         // 'Nothing playing' is the emptyMediaLib placeholder title.
         expect(find.text('Nothing playing'), findsOneWidget);
+        // VuMeter must be inactive (static bars) in the idle state.
+        final vuMeter = tester.widget<VuMeter>(find.byType(VuMeter).first);
+        expect(vuMeter.active, false);
       },
     );
 
@@ -931,9 +935,10 @@ void main() {
         await tester.pumpWidget(_wrap(_room(), cubit: cubit));
         await tester.pump();
 
-        // Idle state — no Slider yet.
+        // Idle state — no Slider yet, VuMeter inactive.
         expect(find.byType(Slider), findsNothing);
         expect(find.text('Live'), findsNothing);
+        expect(tester.widget<VuMeter>(find.byType(VuMeter).first).active, false);
 
         // Host publishes a playing snapshot.
         cubit.applyJoinAccepted(JoinAccepted(
@@ -956,6 +961,8 @@ void main() {
         expect(find.text('Live'), findsOneWidget);
         // Elapsed time (5 s).
         expect(find.text('0:05'), findsOneWidget);
+        // VuMeter must now be active (animating bars).
+        expect(tester.widget<VuMeter>(find.byType(VuMeter).first).active, true);
       },
     );
 


### PR DESCRIPTION
## Summary

Closes #223.

Two visual bugs surfaced when the room screen first opened with no media loaded:

- The VuMeter bars animated continuously because `_playing` was initialised to `true`.
- The time row showed a negative value (`-0:37` or similar) because `_progress` was `37` against an `emptyMediaLib` track with `durationSeconds: 0`.

Both symptoms share the same root cause: demo-mode initial values left in after the placeholder catalog was removed.

## What changed

- **`frequency_room_screen.dart`** — initial state is `_playing = false`, `_progress = 0`. The progress-tick timer also guards `_track.durationSeconds <= 0` to avoid a modulo-by-zero if the play button is tapped before any host snapshot arrives.
- **`frequency_models.dart`** — `emptyMediaLib` track uses `durationSeconds: 0` so `NowPlayingCard` can distinguish the pre-snapshot idle state with a simple `<= 0` guard.
- **`now_playing_card.dart`** — when `durationSeconds <= 0` (idle), the `Slider` and time-row are skipped entirely (avoids a `max == 0` Slider assertion and the negative display). VuMeter is held static via `liveActive = playing && !idle`.
- **`frequency_atoms.dart`** — fixed a latent `VuMeter` bug: `_ctrl` was `late final` with `..repeat()` in the lazy initialiser, so `dispose()` would trigger the initialiser (creating *and* repeating an `AnimationController`) even when `active` was always `false`, leaving stale tickers in widget tests. Replaced with eager init in `initState` + `didUpdateWidget` to start/stop the repeat as `active` changes.

## Tests

- Updated `play/pause flips the transport icon and the Live/Paused badge` — now seeds a playing snapshot before asserting `'Live'`, which only appears when a real track is loaded.
- Added `idle state: VuMeter is static and slider/time row are absent before any media snapshot lands (#223)`.
- Added `idle → live: slider and time row appear once a playing snapshot lands (#223)`.

All 554 tests pass; `flutter analyze` clean.

## Test plan

- [ ] Fresh join: open the room before any host — VuMeter is static, time row is absent, card shows "Nothing playing".
- [ ] Host starts playing — Slider and time labels appear, VuMeter animates, badge flips to "Live".
- [ ] Tap pause — VuMeter goes static, badge reads "Paused".
- [ ] Resume — VuMeter animates again, badge reads "Live".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VU meter now only animates during active playback, avoiding idle animations.
  * “Nothing playing” is treated as idle: progress slider and time are hidden when no valid track duration exists.
  * Initial playback state corrected so UI starts paused (no false-playing state).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->