### PR TITLE
fix(#222): eliminate host-flash in peer roster on room entry

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -200,9 +200,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   @visibleForTesting
   int get debugSeq => _seq;
 
-  /// The local peer's stable id, cached during [bootstrap]. Non-null after
-  /// bootstrap completes; screens can read this synchronously to avoid an
-  /// extra round-trip to the identity store.
+  /// The local peer's stable id, cached during [bootstrap]. May be null if
+  /// the identity-store read in bootstrap failed; screens can read this
+  /// synchronously and fall back to [IdentityStore.getPeerId] if null.
   String? get localPeerId => _localPeerId;
 
   /// Full session UUID for the current room. Set on the host path by

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -200,6 +200,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   @visibleForTesting
   int get debugSeq => _seq;
 
+  /// The local peer's stable id, cached during [bootstrap]. Non-null after
+  /// bootstrap completes; screens can read this synchronously to avoid an
+  /// extra round-trip to the identity store.
+  String? get localPeerId => _localPeerId;
+
   /// Full session UUID for the current room. Set on the host path by
   /// [joinRoom] and on the guest path by [_promoteToHost]. Used by
   /// [_initiateHostTransfer] to tell the promoted peer what UUID to advertise.

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -172,7 +172,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // dispose has fired stopVoice and tell a torn-down engine to change state.
     final cubit = context.read<FrequencySessionCubit>();
     // Seed _myPeerId from the cubit's already-cached localPeerId so the
-    // roster filter is correct from frame 1, eliminating the flash where
+    // roster filter is correct from frame 0, eliminating the flash where
     // the local user briefly appears as a peer (issue #222).
     _myPeerId = cubit.localPeerId;
     unawaited(() async {
@@ -267,14 +267,14 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   }
 
   Future<void> _resolveMyPeerId() async {
+    // Fast path: cubit already cached the id during bootstrap (the normal
+    // production case). Skip the extra identity-store round-trip entirely.
+    if (_myPeerId != null) return;
     try {
       final peerId = await context.read<FrequencySessionCubit>().identityStore.getPeerId();
       if (!mounted) return;
-      // setState so the roster filter re-renders with the resolved id.
-      // In practice _myPeerId was already seeded synchronously from the
-      // cubit in initState, so this is a no-op except when bootstrap
-      // hasn't completed yet (e.g. in tests that construct the screen
-      // before the cubit finishes bootstrapping).
+      // setState triggers a re-render so the roster filter uses the
+      // resolved id (only reached when bootstrap hadn't completed yet).
       setState(() => _myPeerId = peerId);
     } catch (_) {
       // Identity store failure is non-fatal here: if this one-time read

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -171,6 +171,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // startVoice resolves — without it, the trailing calls would land after
     // dispose has fired stopVoice and tell a torn-down engine to change state.
     final cubit = context.read<FrequencySessionCubit>();
+    // Seed _myPeerId from the cubit's already-cached localPeerId so the
+    // roster filter is correct from frame 1, eliminating the flash where
+    // the local user briefly appears as a peer (issue #222).
+    _myPeerId = cubit.localPeerId;
     unawaited(() async {
       final serviceStarted = await _audio.startService(freq: widget.freq);
       if (!mounted || !serviceStarted) return;
@@ -266,9 +270,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     try {
       final peerId = await context.read<FrequencySessionCubit>().identityStore.getPeerId();
       if (!mounted) return;
-      // Stored without setState — the field only affects attribution in
-      // the next [_onMediaCommand], which sets state itself.
-      _myPeerId = peerId;
+      // setState so the roster filter re-renders with the resolved id.
+      // In practice _myPeerId was already seeded synchronously from the
+      // cubit in initState, so this is a no-op except when bootstrap
+      // hasn't completed yet (e.g. in tests that construct the screen
+      // before the cubit finishes bootstrapping).
+      setState(() => _myPeerId = peerId);
     } catch (_) {
       // Identity store failure is non-fatal here: if this one-time read
       // fails, attribution falls back to "remote sender" for this

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -533,6 +533,12 @@ void main() {
         // correct before any async resolution lands.
         await tester.pump();
 
+        // After joinRoom the initial roster already has the local peer's
+        // entry. Assert it is excluded on this very first frame — this is
+        // the regression guard for #222.  Peer rows are keyed by peerId
+        // so the check is key-based and doesn't collide with the me-row.
+        expect(find.byKey(const ValueKey('me-peer-id')), findsNothing);
+
         // Land a roster that includes the local peer's id (as a host
         // joining their own room does). The host's own entry is in the
         // roster so the filter is exercised.

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -46,6 +46,7 @@ Widget _wrap(Widget child, {FrequencySessionCubit? cubit, AudioService? audio, B
   if (cubit == null) {
     when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
     when(() => mockCubit.identityStore).thenReturn(mockStore);
+    when(() => mockCubit.localPeerId).thenReturn(null);
     when(() => mockCubit.state).thenReturn(const SessionBooting());
     when(() => mockCubit.stream).thenAnswer((_) => const Stream<FrequencySessionState>.empty());
 
@@ -497,6 +498,59 @@ void main() {
         // drawer's label track `_kDefaultPeerVolume` (0.7) for
         // unknown peer ids.
         expect(find.text('70%'), findsNWidgets(2));
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      'local peer is filtered from roster on first frame when cubit is bootstrapped (issue #222)',
+      // Regression: when the cubit's localPeerId is already cached (production
+      // path — bootstrap completes before the room screen opens), the screen
+      // must read it synchronously in initState so the roster filter is
+      // correct from frame 0. Before the fix, _myPeerId was always null on
+      // the first frame, so the local user appeared briefly as a remote peer.
+      (tester) async {
+        // Bootstrap with a display name so bootstrap() emits SessionDiscovery
+        // (no display name → SessionOnboarding, which blocks joinRoom).
+        final store = _MemoryStore(displayName: 'Caleb');
+        final cubit = FrequencySessionCubit(
+          identityStore: store,
+          recentFrequenciesStore: _NullRecentFrequenciesStore(),
+        );
+        addTearDown(cubit.close);
+
+        // Bootstrap so _localPeerId is populated ('me-peer-id') and the
+        // cubit lands in SessionDiscovery.
+        await cubit.bootstrap();
+        expect(cubit.localPeerId, 'me-peer-id');
+
+        // joinRoom(isHost: true) reads _localPeerId from cache (no extra
+        // identity-store round-trip) and emits SessionRoom.
+        await cubit.joinRoom(isHost: true);
+
+        await tester.pumpWidget(_wrap(_room(isHost: true), cubit: cubit));
+        // Single pump: the synchronous seed means the filter is already
+        // correct before any async resolution lands.
+        await tester.pump();
+
+        // Land a roster that includes the local peer's id (as a host
+        // joining their own room does). The host's own entry is in the
+        // roster so the filter is exercised.
+        cubit.applyJoinAccepted(JoinAccepted(
+          peerId: 'me-peer-id',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'me-peer-id',
+          roster: const [
+            ProtocolPeer(peerId: 'me-peer-id', displayName: 'Myself'),
+            ProtocolPeer(peerId: 'p-guest', displayName: 'Guest'),
+          ],
+        ));
+        await tester.pump();
+
+        // The local peer must not appear in the peers list — only the guest.
+        expect(find.text('Guest'), findsOneWidget);
+        expect(find.text('Myself'), findsNothing);
         expect(tester.takeException(), isNull);
       },
     );


### PR DESCRIPTION
## Summary

Fixes #222 — on entering a freshly-hosted room, the host briefly appeared as a peer in the \"On this frequency\" list for ~1–2 frames.

- **Root cause**: `_myPeerId` was always `null` on the first render frame because `_resolveMyPeerId()` is async, so the filter `p.peerId != _myPeerId` passed for the host's own roster entry.
- **Fix**: exposes `localPeerId` getter on `FrequencySessionCubit` (already cached synchronously during `bootstrap()`), and reads it synchronously in `initState` to seed `_myPeerId` before the first frame. `_resolveMyPeerId()` now calls `setState` as a fallback so a rebuild fires in the edge case where the cubit hasn't bootstrapped yet.

## Changes

- `FrequencySessionCubit`: add `String? get localPeerId => _localPeerId;` getter
- `_FrequencyRoomScreenState.initState`: seed `_myPeerId` from `cubit.localPeerId` synchronously
- `_resolveMyPeerId`: use `setState(() => _myPeerId = peerId)` so the BlocBuilder re-renders if needed
- `MockFrequencySessionCubit` stub: add `when(() => mockCubit.localPeerId).thenReturn(null)`
- New regression test: verifies local peer is filtered from the roster when the cubit is bootstrapped (the production path)

## Test plan

- [x] `flutter test test/screens/frequency_room_screen_test.dart` — all 34 tests pass including new regression test
- [x] `flutter test test/bloc/frequency_session_cubit_test.dart` — all 116 tests pass
- [x] No new `flutter analyze` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the local user briefly appeared in the participant roster on first render; the roster now correctly excludes the local user immediately.

* **Tests**
  * Added a widget test to verify roster filtering at initialization and to ensure no exceptions occur when a cached local identity is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->