### PR TITLE
fix(#227): make BT chip in Discovery chrome state-driven and interactive

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -174,7 +174,15 @@
 
     "discoveryBluetoothChip": "On",
     "@discoveryBluetoothChip": {
-        "description": "Trailing chip in the discovery chrome — shows that BT is on."
+        "description": "Bluetooth chip label — BT is on regardless of scan state."
+    },
+    "discoveryBluetoothChipSemanticsScanning": "Bluetooth scanning. Tap to pause.",
+    "@discoveryBluetoothChipSemanticsScanning": {
+        "description": "TalkBack announcement for the Bluetooth chip while scanning."
+    },
+    "discoveryBluetoothChipSemanticsIdle": "Bluetooth idle. Tap to scan.",
+    "@discoveryBluetoothChipSemanticsIdle": {
+        "description": "TalkBack announcement for the Bluetooth chip while idle."
     },
     "discoveryHeroEyebrowScanning": "TUNING THE DIAL",
     "@discoveryHeroEyebrowScanning": {

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -19,6 +19,10 @@ import 'frequency_privacy_policy_screen.dart';
 import 'frequency_settings_screen.dart';
 import 'security_faq_screen.dart';
 
+/// Key on the Bluetooth-state chip in the discovery chrome. Exposed so widget
+/// tests can locate the chip without coupling to its private class name.
+const Key discoveryBluetoothChipKey = ValueKey('bluetooth-chip');
+
 class DiscoveryResult {
   final String freq;
   final bool isHost;
@@ -161,10 +165,7 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
             FreqChrome(
               left: const FrequencyWordmark(),
               right: [
-                FreqChip(
-                  leading: Icon(Icons.bluetooth, size: 12, color: c.ink2),
-                  label: l10n.discoveryBluetoothChip,
-                ),
+                _BluetoothChip(onToggle: _toggleScan),
                 _IdentityChip(
                   name: widget.myName,
                   onTap: _openRenameSheet,
@@ -555,6 +556,15 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
     );
   }
 
+  void _toggleScan() {
+    final cubit = context.read<DiscoveryCubit>();
+    if (cubit.state is DiscoveryScanning) {
+      cubit.stopDiscovery();
+    } else {
+      cubit.startDiscovery();
+    }
+  }
+
   Future<void> _openSettings() async {
     final store = context.read<SettingsStore>();
     await Navigator.of(context).push(
@@ -591,6 +601,42 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
       context: context,
       applicationName: l10n.licensesPageTitle,
       applicationLegalese: l10n.licensesPageLegalese,
+    );
+  }
+}
+
+class _BluetoothChip extends StatelessWidget {
+  final VoidCallback onToggle;
+
+  const _BluetoothChip({required this.onToggle});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
+    return BlocBuilder<DiscoveryCubit, DiscoveryState>(
+      builder: (context, state) {
+        final scanning = state is DiscoveryScanning;
+        final semanticsLabel = scanning
+            ? l10n.discoveryBluetoothChipSemanticsScanning
+            : l10n.discoveryBluetoothChipSemanticsIdle;
+        return Semantics(
+          button: true,
+          label: semanticsLabel,
+          excludeSemantics: true,
+          child: GestureDetector(
+            key: discoveryBluetoothChipKey,
+            onTap: onToggle,
+            child: FreqChip(
+              leading: scanning
+                  ? PulseDot(size: 8, color: c.accent)
+                  : Icon(Icons.bluetooth, size: 12, color: c.ink2),
+              label: l10n.discoveryBluetoothChip,
+              live: scanning,
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -559,9 +559,9 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
   void _toggleScan() {
     final cubit = context.read<DiscoveryCubit>();
     if (cubit.state is DiscoveryScanning) {
-      cubit.stopDiscovery();
+      unawaited(cubit.stopDiscovery());
     } else {
-      cubit.startDiscovery();
+      unawaited(cubit.startDiscovery());
     }
   }
 
@@ -623,6 +623,7 @@ class _BluetoothChip extends StatelessWidget {
         return Semantics(
           button: true,
           label: semanticsLabel,
+          onTap: onToggle,
           excludeSemantics: true,
           child: GestureDetector(
             key: discoveryBluetoothChipKey,

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -875,8 +875,14 @@ void main() {
       ));
       await tester.pump();
       expect(find.byKey(discoveryBluetoothChipKey), findsOneWidget);
-      // PulseDot is visible when scanning.
-      expect(find.byType(PulseDot), findsWidgets);
+      // PulseDot is visible inside the chip (not relying on the nearby indicator).
+      expect(
+        find.descendant(
+          of: find.byKey(discoveryBluetoothChipKey),
+          matching: find.byType(PulseDot),
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('tapping chip starts discovery when idle', (tester) async {

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:walkie_talkie/screens/frequency_discovery_screen.dart';
 import 'package:walkie_talkie/screens/security_faq_screen.dart';
 import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
+import 'package:walkie_talkie/widgets/frequency_atoms.dart';
 
 class MockDiscoveryCubit extends Mock implements DiscoveryCubit {}
 
@@ -839,6 +840,89 @@ void main() {
         ),
         returnsNormally,
       );
+    });
+  });
+
+  group('Bluetooth chip', () {
+    testWidgets('renders chip in idle state when discovery is not scanning',
+        (tester) async {
+      await tester.pumpWidget(_wrap(FrequencyDiscoveryScreen(
+        onPick: (_) {},
+        myName: 'Mo Ali',
+        onRename: (_) {},
+      )));
+      await tester.pump();
+      // Chip is present and tappable.
+      expect(find.byKey(discoveryBluetoothChipKey), findsOneWidget);
+    });
+
+    testWidgets('chip renders with live styling when discovery is scanning',
+        (tester) async {
+      final mockCubit = MockDiscoveryCubit();
+      when(() => mockCubit.state).thenReturn(const DiscoveryScanning());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockCubit.startDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.stopDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.close()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(_wrap(
+        FrequencyDiscoveryScreen(
+          onPick: (_) {},
+          myName: 'Mo Ali',
+          onRename: (_) {},
+        ),
+        cubit: mockCubit,
+      ));
+      await tester.pump();
+      expect(find.byKey(discoveryBluetoothChipKey), findsOneWidget);
+      // PulseDot is visible when scanning.
+      expect(find.byType(PulseDot), findsWidgets);
+    });
+
+    testWidgets('tapping chip starts discovery when idle', (tester) async {
+      final mockCubit = MockDiscoveryCubit();
+      when(() => mockCubit.state).thenReturn(DiscoveryInitial());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockCubit.startDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.stopDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.close()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(_wrap(
+        FrequencyDiscoveryScreen(
+          onPick: (_) {},
+          myName: 'Mo Ali',
+          onRename: (_) {},
+        ),
+        cubit: mockCubit,
+      ));
+      await tester.pump();
+      clearInteractions(mockCubit);
+      await tester.tap(find.byKey(discoveryBluetoothChipKey));
+      await tester.pump();
+      verify(() => mockCubit.startDiscovery()).called(1);
+    });
+
+    testWidgets('tapping chip stops discovery when scanning', (tester) async {
+      final mockCubit = MockDiscoveryCubit();
+      when(() => mockCubit.state).thenReturn(const DiscoveryScanning());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockCubit.startDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.stopDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.close()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(_wrap(
+        FrequencyDiscoveryScreen(
+          onPick: (_) {},
+          myName: 'Mo Ali',
+          onRename: (_) {},
+        ),
+        cubit: mockCubit,
+      ));
+      await tester.pump();
+      clearInteractions(mockCubit);
+      await tester.tap(find.byKey(discoveryBluetoothChipKey));
+      await tester.pump();
+      verify(() => mockCubit.stopDiscovery()).called(1);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #227 — the Bluetooth chip in the Discovery chrome was a static, non-interactive label that gave no signal about scan state.

- **State-driven**: `_BluetoothChip` wraps the chip in a `BlocBuilder<DiscoveryCubit, DiscoveryState>`. While scanning, the chip renders with `live: true` accent styling and a `PulseDot`; while idle, it shows the static BT icon in muted grey.
- **Interactive**: Tapping the chip toggles scan start/stop (same behavior as the "Pause" / "Scan" link already in the Nearby section header).
- **Accessible**: `Semantics(button: true)` wraps the chip with a meaningful label — "Bluetooth scanning. Tap to pause." or "Bluetooth idle. Tap to scan." — so TalkBack announces a useful state rather than just "On".
- **Label unchanged**: The visible label stays "On" (short, avoids overflow in the chrome row). Visual differentiation (PulseDot vs BT icon + live color) carries the scanning state.

## Changes

- `lib/screens/frequency_discovery_screen.dart`: replace inline `FreqChip` with new `_BluetoothChip` widget; add `_toggleScan()` method; expose `discoveryBluetoothChipKey` for tests
- `lib/l10n/app_en.arb`: add `discoveryBluetoothChipSemanticsScanning` and `discoveryBluetoothChipSemanticsIdle` strings

## Test plan

- [x] `flutter test test/screens/frequency_discovery_screen_test.dart` — 32 tests pass (4 new BT chip tests)
- [x] `flutter test` — 585 tests pass, no regressions
- [x] `flutter analyze lib/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Bluetooth indicator with clearer accessibility labels that distinguish active scanning vs idle.
  * Added a pulsing visual when actively scanning for Bluetooth devices.
  * Improved visual distinction of Bluetooth status in the discovery interface.

* **Tests**
  * Added tests verifying the Bluetooth indicator’s idle vs scanning visuals and tap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->