### PR TITLE
fix(#226): gate crash-reporting toggle on compile-time Sentry DSN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,18 +67,32 @@ jobs:
         # default GITHUB_RUN_NUMBER + GITHUB_RUN_ATTEMPT env vars (auto-set on
         # every step) so each CI run and each rerun gets a unique code — Play
         # rejects duplicates.
+        #
+        # SENTRY_DSN is optional: when the secret is present the DSN is baked
+        # into the binary via --dart-define so crash reporting is available to
+        # users who opt in. When absent the define is empty and the crash-
+        # reporting toggle in Settings is rendered disabled (compile-time gate
+        # in lib/services/sentry_config.dart).
         env:
           KEYSTORE_PATH: ${{ runner.temp }}/walkie-talkie.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           if [ -z "$KEYSTORE_PASSWORD" ] || [ -z "$KEY_ALIAS" ] || [ -z "$KEY_PASSWORD" ]; then
             echo "Error: One or more signing secrets are not set"
             echo "Required: KEYSTORE_PASSWORD, KEY_ALIAS, KEY_PASSWORD"
             exit 1
           fi
-          flutter build appbundle --release --target-platform=android-arm64,android-arm,android-x64
+          SENTRY_DEFINE=""
+          if [ -n "$SENTRY_DSN" ]; then
+            echo "::notice title=Sentry::SENTRY_DSN secret present — crash reporting enabled in this build."
+            SENTRY_DEFINE="--dart-define=SENTRY_DSN=$SENTRY_DSN"
+          else
+            echo "::notice title=Sentry::SENTRY_DSN secret not set — crash reporting toggle will be disabled in this build."
+          fi
+          flutter build appbundle --release --target-platform=android-arm64,android-arm,android-x64 $SENTRY_DEFINE
 
       - name: Assert vcsInfo metadata is present in AAB
         # Guards against silent regressions of bundle.vcsInfo.include in

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -24,10 +24,13 @@ and baked into the binary at compile time.
 
 **CI (release builds):** Add `SENTRY_DSN` as a [GitHub Actions
 secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
-The release workflow (`release.yml`) reads it automatically and appends the
-`--dart-define` flag when the secret is present. Builds without the secret get
-an empty define; the crash-reporting toggle in Settings is rendered disabled in
-those builds (see `lib/services/sentry_config.dart`).
+The release workflow (`release.yml`) reads it automatically and appends
+`--dart-define=SENTRY_DSN=…` when the secret is present. When the secret is
+absent the `--dart-define` flag is omitted entirely, so
+`String.fromEnvironment('SENTRY_DSN')` resolves to its `defaultValue: ''` at
+compile time and `kSentryConfigured` is false. The crash-reporting toggle in
+Settings is rendered disabled in those builds (see
+`lib/services/sentry_config.dart`).
 
 **Local development:**
 

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -19,22 +19,35 @@ Crash reporting is **disabled by default (opt-in)** to respect user privacy. The
 
 ### 2. Set the DSN for builds
 
-The Sentry DSN must be provided via an environment variable:
+The Sentry DSN is passed to the Flutter build via `--dart-define=SENTRY_DSN=...`
+and baked into the binary at compile time.
+
+**CI (release builds):** Add `SENTRY_DSN` as a [GitHub Actions
+secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
+The release workflow (`release.yml`) reads it automatically and appends the
+`--dart-define` flag when the secret is present. Builds without the secret get
+an empty define; the crash-reporting toggle in Settings is rendered disabled in
+those builds (see `lib/services/sentry_config.dart`).
+
+**Local development:**
+
+```bash
+flutter run --dart-define=SENTRY_DSN='https://your-dsn@sentry.io/project-id'
+```
+
+Or export it so any `flutter run`/`flutter build` in the shell picks it up:
 
 ```bash
 export SENTRY_DSN='https://your-dsn@sentry.io/project-id'
+flutter run --dart-define=SENTRY_DSN="$SENTRY_DSN"
 ```
-
-For local development, add this to your `~/.bashrc` or `~/.zshrc`.
-
-For CI/CD, add `SENTRY_DSN` as a secret environment variable.
 
 ### 3. Build the app
 
 ```bash
 # Build the release AAB (Android App Bundle)
-cd android
-./gradlew bundleRelease
+flutter build appbundle --release \
+  --dart-define=SENTRY_DSN='https://your-dsn@sentry.io/project-id'
 ```
 
 The Sentry Gradle plugin will automatically:
@@ -44,15 +57,13 @@ The Sentry Gradle plugin will automatically:
 
 ## User Opt-In Flow
 
-**Current state (this PR):**
-- Crash reporting is disabled by default
-- The opt-in preference is stored in `SettingsStore.crashReportingEnabled`
-- To enable for testing, manually set the flag in SQLite or wait for the Settings screen (issue #121)
-
-**Future (depends on #121):**
-- Users will see a toggle in Settings: "Help improve the app — share anonymous crash reports"
-- The toggle will be **off by default** (opt-out)
-- When enabled, crash reports are queued on-device and sent only on Wi-Fi
+- Crash reporting is **disabled by default** (opt-in).
+- The preference is stored in `SettingsStore.crashReportingEnabled`.
+- Users toggle it under **Settings → Privacy → Crash reporting**.
+- The toggle is rendered **disabled** (greyed out, non-interactive) when the
+  build was compiled without a DSN (`kSentryConfigured == false`). A status
+  row directly below the toggle shows "Not configured" in that case, so users
+  are never left with a control that silently does nothing.
 
 ## Privacy
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -518,6 +518,30 @@
     "@settingsCrashReportingDescription": {
         "description": "Subtitle under the crash-reporting toggle."
     },
+    "settingsCrashReportingDisabledSubtitle": "No crash reporting configured in this build.",
+    "@settingsCrashReportingDisabledSubtitle": {
+        "description": "Subtitle shown when crash reporting toggle is disabled because no Sentry DSN was compiled in."
+    },
+    "settingsCrashReportingEnabledSnackbar": "Crash reporting enabled. Restart the app to apply.",
+    "@settingsCrashReportingEnabledSnackbar": {
+        "description": "Snackbar shown when user enables crash reporting."
+    },
+    "settingsCrashReportingDisabledSnackbar": "Crash reporting disabled. Restart the app to apply.",
+    "@settingsCrashReportingDisabledSnackbar": {
+        "description": "Snackbar shown when user disables crash reporting."
+    },
+    "settingsCrashReportingStatusLabel": "Crash reporting status",
+    "@settingsCrashReportingStatusLabel": {
+        "description": "Label for the info row that shows the current Sentry configuration status."
+    },
+    "settingsCrashReportingStatusSentry": "Sentry",
+    "@settingsCrashReportingStatusSentry": {
+        "description": "Status row value when a Sentry DSN is configured in this build."
+    },
+    "settingsCrashReportingStatusNotConfigured": "Not configured",
+    "@settingsCrashReportingStatusNotConfigured": {
+        "description": "Status row value when no Sentry DSN is configured in this build."
+    },
     "settingsAboutSection": "About",
     "@settingsAboutSection": {
         "description": "Section header for the About section of settings."

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -22,6 +23,7 @@ import 'services/native_licenses.dart';
 import 'services/onboarding_permission_gateway.dart';
 import 'services/permission_watcher.dart';
 import 'services/recent_frequencies_store.dart';
+import 'services/sentry_config.dart';
 import 'services/settings_store.dart';
 import 'services/storage_migration.dart';
 import 'theme/app_theme.dart';
@@ -45,11 +47,12 @@ void main() async {
   final settingsStore = SqfliteSettingsStore();
   final crashReportingEnabled = await settingsStore.getCrashReportingEnabled();
 
-  if (crashReportingEnabled) {
-    // Sentry DSN should be provided via build args or environment variable.
-    // For now, we'll set up the infrastructure but won't initialize without a DSN.
-    const sentryDsn = String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+  if (!kSentryConfigured) {
+    developer.log('Sentry DSN not configured in this build — crash reporting unavailable.');
+  }
 
+  if (crashReportingEnabled && kSentryConfigured) {
+    const sentryDsn = String.fromEnvironment('SENTRY_DSN', defaultValue: '');
     if (sentryDsn.isNotEmpty) {
       await SentryFlutter.init(
         (options) {

--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -140,8 +140,8 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
                 SnackBar(
                   content: Text(
                     v
-                        ? 'Crash reporting enabled. Restart the app to apply.'
-                        : 'Crash reporting disabled. Restart the app to apply.',
+                        ? l10n.settingsCrashReportingEnabledSnackbar
+                        : l10n.settingsCrashReportingDisabledSnackbar,
                   ),
                   duration: const Duration(seconds: 4),
                 ),
@@ -151,15 +151,17 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
         else
           _SettingsToggle(
             title: l10n.settingsCrashReporting,
-            subtitle: 'No crash reporting configured in this build.',
-            value: false,
+            subtitle: l10n.settingsCrashReportingDisabledSubtitle,
+            value: _crashReporting,
             c: c,
             enabled: false,
             onChanged: (_) {},
           ),
         _SettingsInfoRow(
-          title: 'Crash reporting status',
-          value: kSentryConfigured ? 'Sentry' : 'Not configured',
+          title: l10n.settingsCrashReportingStatusLabel,
+          value: kSentryConfigured
+              ? l10n.settingsCrashReportingStatusSentry
+              : l10n.settingsCrashReportingStatusNotConfigured,
           c: c,
         ),
         _SettingsLink(

--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 import '../l10n/generated/app_localizations.dart';
+import '../services/sentry_config.dart';
 import '../services/settings_store.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
@@ -125,26 +126,41 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
         ),
         // Privacy
         _SectionHeader(label: l10n.settingsPrivacySection, c: c),
-        _SettingsToggle(
-          title: l10n.settingsCrashReporting,
-          subtitle: l10n.settingsCrashReportingDescription,
-          value: _crashReporting,
-          c: c,
-          onChanged: (v) {
-            setState(() => _crashReporting = v);
-            unawaited(widget.settingsStore.setCrashReportingEnabled(v));
-            if (!mounted) return;
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(
-                  v
-                      ? 'Crash reporting enabled. Restart the app to apply.'
-                      : 'Crash reporting disabled. Restart the app to apply.',
+        if (kSentryConfigured)
+          _SettingsToggle(
+            title: l10n.settingsCrashReporting,
+            subtitle: l10n.settingsCrashReportingDescription,
+            value: _crashReporting,
+            c: c,
+            onChanged: (v) {
+              setState(() => _crashReporting = v);
+              unawaited(widget.settingsStore.setCrashReportingEnabled(v));
+              if (!mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    v
+                        ? 'Crash reporting enabled. Restart the app to apply.'
+                        : 'Crash reporting disabled. Restart the app to apply.',
+                  ),
+                  duration: const Duration(seconds: 4),
                 ),
-                duration: const Duration(seconds: 4),
-              ),
-            );
-          },
+              );
+            },
+          )
+        else
+          _SettingsToggle(
+            title: l10n.settingsCrashReporting,
+            subtitle: 'No crash reporting configured in this build.',
+            value: false,
+            c: c,
+            enabled: false,
+            onChanged: (_) {},
+          ),
+        _SettingsInfoRow(
+          title: 'Crash reporting status',
+          value: kSentryConfigured ? 'Sentry' : 'Not configured',
+          c: c,
         ),
         _SettingsLink(
           title: l10n.settingsSecurityFaq,
@@ -215,6 +231,7 @@ class _SettingsToggle extends StatelessWidget {
   final bool value;
   final FrequencyColors c;
   final ValueChanged<bool> onChanged;
+  final bool enabled;
 
   const _SettingsToggle({
     required this.title,
@@ -222,6 +239,7 @@ class _SettingsToggle extends StatelessWidget {
     required this.value,
     required this.c,
     required this.onChanged,
+    this.enabled = true,
   });
 
   @override
@@ -236,7 +254,7 @@ class _SettingsToggle extends StatelessWidget {
             fontFamily: 'Inter',
             fontSize: 15,
             fontWeight: FontWeight.w500,
-            color: c.ink,
+            color: enabled ? c.ink : c.ink3,
           ),
         ),
         subtitle: Text(
@@ -251,7 +269,7 @@ class _SettingsToggle extends StatelessWidget {
           value: value,
           semanticLabel: title,
           semanticHint: subtitle,
-          onChanged: onChanged,
+          onChanged: enabled ? onChanged : null,
         ),
       ),
     );

--- a/lib/services/sentry_config.dart
+++ b/lib/services/sentry_config.dart
@@ -1,0 +1,12 @@
+// Compile-time Sentry configuration — values are baked in via
+// `--dart-define=SENTRY_DSN=...` at build time and never change at runtime.
+// Release CI injects SENTRY_DSN from the repository secret; dev/debug builds
+// that omit the flag get an empty string and `kSentryConfigured == false`.
+
+const String _kSentryDsn = String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+
+/// True when a Sentry DSN was provided at build time.
+///
+/// When false the crash-reporting toggle in Settings is inert and rendered
+/// disabled so users are not shown a control that silently does nothing.
+const bool kSentryConfigured = _kSentryDsn != '';

--- a/lib/widgets/frequency_atoms.dart
+++ b/lib/widgets/frequency_atoms.dart
@@ -411,7 +411,10 @@ class SignalBars extends StatelessWidget {
 /// Compact pill toggle — same shape as the design's `.switch`.
 class FreqSwitch extends StatelessWidget {
   final bool value;
-  final ValueChanged<bool> onChanged;
+
+  /// Null disables the switch (no interaction, visually dimmed), matching the
+  /// behaviour of Flutter's built-in [Switch.onChanged].
+  final ValueChanged<bool>? onChanged;
 
   /// Required for screen-reader announcement (e.g. "Mute peer", "Push to
   /// talk lock"). Without it TalkBack reads only "switch, on/off" and
@@ -429,23 +432,26 @@ class FreqSwitch extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
+    final enabled = onChanged != null;
     return Semantics(
       label: semanticLabel,
       hint: semanticHint,
       toggled: value,
-      enabled: true,
-      onTap: () => onChanged(!value),
+      enabled: enabled,
+      onTap: enabled ? () => onChanged!(!value) : null,
       excludeSemantics: true,
       child: GestureDetector(
-        onTap: () => onChanged(!value),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          width: 36,
-          height: 20,
-          decoration: BoxDecoration(
-            color: value ? c.accent : c.line2,
-            borderRadius: BorderRadius.circular(999),
-          ),
+        onTap: enabled ? () => onChanged!(!value) : null,
+        child: Opacity(
+          opacity: enabled ? 1.0 : 0.4,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            width: 36,
+            height: 20,
+            decoration: BoxDecoration(
+              color: value ? c.accent : c.line2,
+              borderRadius: BorderRadius.circular(999),
+            ),
           child: AnimatedAlign(
             duration: const Duration(milliseconds: 200),
             curve: Curves.easeOut,
@@ -471,7 +477,8 @@ class FreqSwitch extends StatelessWidget {
           ),
         ),
       ),
-    );
+    ),
+  );
   }
 }
 


### PR DESCRIPTION
Closes #226.

## Problem

The **Settings → Privacy → Crash reporting** toggle was misleading: toggling it on showed "Crash reporting enabled. Restart the app to apply." even in builds compiled without a Sentry DSN, where nothing was ever transmitted. Users had no signal that the toggle was a no-op.

## Changes

### `lib/services/sentry_config.dart` (new)
Compile-time constant `kSentryConfigured` derived from `String.fromEnvironment('SENTRY_DSN')`. True only when the build included `--dart-define=SENTRY_DSN=…`.

### `lib/screens/frequency_settings_screen.dart`
- When `kSentryConfigured` is **false**: renders the crash-reporting toggle disabled (greyed out, non-interactive) with subtitle "No crash reporting configured in this build."
- Adds a **"Crash reporting status"** info row below the toggle showing "Sentry" or "Not configured".

### `lib/widgets/frequency_atoms.dart`
`FreqSwitch.onChanged` is now `ValueChanged<bool>?` (nullable), matching Flutter's built-in `Switch`. A null value disables interaction and dims the widget via `Opacity(0.4)`.

### `.github/workflows/release.yml`
Reads `secrets.SENTRY_DSN` and appends `--dart-define=SENTRY_DSN=…` to `flutter build appbundle`. When the secret is absent the flag is omitted (soft-skip, not an error); CI logs a notice either way.

### `docs/sentry-setup.md`
Documents the new CI injection path and local-dev `--dart-define` usage. Removes stale "future work" copy that predated the Settings screen.

## Test plan
- [ ] `flutter analyze` — no issues
- [ ] `flutter test` — all 586 tests pass
- [ ] Builds compiled without `SENTRY_DSN` show the toggle disabled + "Not configured" status row
- [ ] Builds compiled with `SENTRY_DSN` show the toggle enabled + "Sentry" status row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Crash reporting now respects whether a build-time DSN was provided: the Settings toggle is disabled and shows “Not configured” when absent, and enabling/disabling shows a restart-required notice when applicable.
* **Documentation**
  * Updated setup guide and CI instructions to require passing the DSN at build time (or omit it to disable crash reporting).
* **Localization**
  * Added new strings for status row, disabled subtitle, and enable/disable snackbars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->