### PR TITLE
fix(#225): output picker shows BT row disabled when no device connected

### DIFF
--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -111,7 +111,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   bool _playing = false;
   int _progress = 0;
   late _LastAction _lastAction;
-  AudioOutput _output = AudioOutput.bluetooth;
+  AudioOutput _output = AudioOutput.speaker;
 
   /// The canonical media source for this session — the `source` string
   /// the protocol uses (`'Podcasts'`, `'YouTube Music'`, etc). Seeded
@@ -210,9 +210,29 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
             (e) => e.name == outputStr,
             orElse: () => _output,
           );
-          if (newOutput != _output) {
-            setState(() => _output = newOutput);
-          }
+          setState(() {
+            _output = newOutput;
+            if (newOutput == AudioOutput.bluetooth) {
+              // Record that a BT device is active. Use the name from the event
+              // if provided; otherwise keep the current known name or fall back
+              // to a generic placeholder so the row in the output sheet is
+              // shown as enabled (not greyed-out).
+              final btNameFromEvent = event['btName'] as String?;
+              if (btNameFromEvent != null && btNameFromEvent.isNotEmpty) {
+                _me = Person(
+                  id: _me.id, name: _me.name,
+                  initials: _me.initials, hue: _me.hue,
+                  btDevice: btNameFromEvent,
+                );
+              } else if (_me.btDevice.isEmpty) {
+                _me = Person(
+                  id: _me.id, name: _me.name,
+                  initials: _me.initials, hue: _me.hue,
+                  btDevice: 'Bluetooth',
+                );
+              }
+            }
+          });
         }
       } else if (type == 'leaveRoom') {
         widget.onLeave();
@@ -1111,11 +1131,19 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       if (success) {
         setState(() => _output = picked);
       } else {
-        // If routing failed (e.g., no Bluetooth device available), keep
-        // the current selection and optionally show a toast. For now, we
-        // silently keep the previous output rather than updating the UI
-        // to a non-functional state.
         if (kDebugMode) debugPrint('Failed to route audio to $outputStr, keeping current output');
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                picked == AudioOutput.bluetooth
+                    ? 'No Bluetooth device available — connect headphones first'
+                    : "Couldn't switch to ${picked.label}",
+              ),
+              duration: const Duration(seconds: 3),
+            ),
+          );
+        }
       }
     }
   }

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -231,6 +231,15 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                   btDevice: 'Bluetooth',
                 );
               }
+            } else if (_me.btDevice.isNotEmpty) {
+              // Native routed away from Bluetooth (device disconnected or
+              // switched by the system). Clear btDevice so the BT row in
+              // the output picker is shown as disabled.
+              _me = Person(
+                id: _me.id, name: _me.name,
+                initials: _me.initials, hue: _me.hue,
+                btDevice: '',
+              );
             }
           });
         }

--- a/lib/widgets/output_sheet.dart
+++ b/lib/widgets/output_sheet.dart
@@ -19,7 +19,9 @@ extension AudioOutputExtension on AudioOutput {
       };
 
   String subFor(String bt) => switch (this) {
-        AudioOutput.bluetooth => bt.isEmpty ? 'Paired headphones' : bt,
+        AudioOutput.bluetooth => bt.isEmpty
+            ? 'No headphones connected — pair in system Bluetooth settings'
+            : bt,
         AudioOutput.earpiece => 'Private, held to ear',
         AudioOutput.speaker => 'Loud · everyone nearby hears',
       };
@@ -131,16 +133,20 @@ class _OutputRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
+    final btUnavailable = output == AudioOutput.bluetooth && btName.isEmpty;
     return Semantics(
-      button: true,
-      selected: selected,
+      button: !btUnavailable,
+      enabled: !btUnavailable,
+      selected: selected && !btUnavailable,
       label: output.label,
       hint: output.subFor(btName),
       excludeSemantics: true,
-      child: Material(
-        color: selected ? c.surface2 : c.surface,
+      child: Opacity(
+        opacity: btUnavailable ? 0.45 : 1.0,
+        child: Material(
+        color: selected && !btUnavailable ? c.surface2 : c.surface,
         child: InkWell(
-          onTap: () => Navigator.pop(context, output),
+          onTap: btUnavailable ? null : () => Navigator.pop(context, output),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
             decoration: BoxDecoration(
@@ -154,14 +160,14 @@ class _OutputRow extends StatelessWidget {
                 width: 36,
                 height: 36,
                 decoration: BoxDecoration(
-                  color: selected ? c.accentSoft : c.surface2,
+                  color: selected && !btUnavailable ? c.accentSoft : c.surface2,
                   borderRadius: BorderRadius.circular(10),
                 ),
                 alignment: Alignment.center,
                 child: Icon(
                   output.icon,
                   size: 16,
-                  color: selected ? c.accentInk : c.ink2,
+                  color: selected && !btUnavailable ? c.accentInk : c.ink2,
                 ),
               ),
               const SizedBox(width: 12),
@@ -185,10 +191,11 @@ class _OutputRow extends StatelessWidget {
                   ],
                 ),
               ),
-              if (selected) Icon(Icons.check, size: 16, color: c.accent),
+              if (selected && !btUnavailable) Icon(Icons.check, size: 16, color: c.accent),
             ],
           ),
           ),
+        ),
         ),
       ),
     );

--- a/test/widgets/output_sheet_test.dart
+++ b/test/widgets/output_sheet_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+import 'package:walkie_talkie/widgets/output_sheet.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(
+    theme: AppTheme.light(),
+    home: Scaffold(
+      body: SingleChildScrollView(child: child),
+    ),
+  );
+}
+
+/// Returns the first [Semantics] widget that is an ancestor of the widget
+/// matched by [finder] and has a non-null [SemanticsProperties.enabled].
+Semantics _rowSemantics(WidgetTester tester, Finder finder) {
+  return tester
+      .widgetList<Semantics>(
+        find.ancestor(of: finder, matching: find.byType(Semantics)),
+      )
+      .firstWhere((s) => s.properties.enabled != null);
+}
+
+void main() {
+  group('OutputSheet — BT row availability (#225)', () {
+    testWidgets('BT row shows "no headphones" subtitle when btName is empty',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        const OutputSheet(current: AudioOutput.speaker, btName: ''),
+      ));
+
+      expect(
+        find.text('No headphones connected — pair in system Bluetooth settings'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('BT row is semantically disabled when btName is empty',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        const OutputSheet(current: AudioOutput.speaker, btName: ''),
+      ));
+
+      final s = _rowSemantics(tester, find.text('Bluetooth headphones'));
+      expect(s.properties.enabled, isFalse);
+    });
+
+    testWidgets('BT row shows device name as subtitle when btName is provided',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        const OutputSheet(current: AudioOutput.bluetooth, btName: 'AirPods Pro'),
+      ));
+
+      expect(find.text('AirPods Pro'), findsOneWidget);
+      expect(
+        find.text('No headphones connected — pair in system Bluetooth settings'),
+        findsNothing,
+      );
+    });
+
+    testWidgets('BT row is semantically enabled when btName is provided',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        const OutputSheet(current: AudioOutput.bluetooth, btName: 'AirPods Pro'),
+      ));
+
+      final s = _rowSemantics(tester, find.text('Bluetooth headphones'));
+      expect(s.properties.enabled, isTrue);
+    });
+
+    testWidgets('speaker and earpiece rows are always semantically enabled',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        const OutputSheet(current: AudioOutput.speaker, btName: ''),
+      ));
+
+      final speakerS = _rowSemantics(tester, find.text('Phone speaker'));
+      expect(speakerS.properties.enabled, isTrue);
+
+      final earpieceS = _rowSemantics(tester, find.text('Phone earpiece'));
+      expect(earpieceS.properties.enabled, isTrue);
+    });
+
+    testWidgets('check icon absent on BT row when btName is empty',
+        (tester) async {
+      // Even if _output == bluetooth, the check icon must not render on the
+      // BT row when there is no device connected (btName is empty).
+      await tester.pumpWidget(_wrap(
+        const OutputSheet(current: AudioOutput.bluetooth, btName: ''),
+      ));
+
+      // The check icon uses Icons.check; earpiece/speaker rows are not
+      // selected, so only the BT row could show it — but btUnavailable.
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Closes #225.

## Problem

The **output picker** had three bugs:

1. **False Bluetooth default** — `_output` was hard-coded to `AudioOutput.bluetooth` at startup, so the on-screen chrome always said "Bluetooth headphones" even when no BT device was connected.
2. **Misleading BT row subtitle** — with no device paired, `OutputSheet` showed "Paired headphones" as the row subtitle, implying a real device was connected.
3. **Silent routing failure** — when `setAudioOutput` returned `false` (e.g. user taps BT with no device), the error was only printed in debug mode; the UI gave the user no feedback.

## Changes

### `lib/screens/frequency_room_screen.dart`
- Default `_output` changed from `AudioOutput.bluetooth` → `AudioOutput.speaker`.
- `audioOutputChanged` handler now also reads an optional `btName` field from the native event and updates `_me.btDevice` when native routes to Bluetooth, so the output picker's BT row reflects the live connection state.
- `_showOutputSheet` now shows a `SnackBar` (e.g. "No Bluetooth device available — connect headphones first") when `setAudioOutput` returns `false`.

### `lib/widgets/output_sheet.dart`
- `_OutputRow`: when `output == AudioOutput.bluetooth && btName.isEmpty`, renders at 0.45 opacity with `onTap: null` and the subtitle "No headphones connected — pair in system Bluetooth settings". The check icon and selected-state highlighting are also suppressed.
- `subFor()` extension updated to match.

### `test/widgets/output_sheet_test.dart` (new)
6 widget tests covering: disabled subtitle, semantic disabled/enabled state for BT row, device-name subtitle, and check-icon suppression.

## Test plan
- [ ] `flutter analyze` — no new issues
- [ ] `flutter test` — 6 new tests pass; pre-existing AppLocalizations failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio routing error handling with user-friendly Snackbar messages when switching outputs fails.
  * Unavailable Bluetooth devices now appear disabled and cannot be selected.

* **Style**
  * Enhanced visual feedback: disabled Bluetooth rows show reduced opacity and no selected/checkmark visuals.
  * Default audio output changed from Bluetooth to speaker.

* **Tests**
  * Added widget tests covering Bluetooth row availability, semantics, and checkmark behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->