### PR TITLE
fix(#228): wire queue source picker — replace stub onPressed with MediaSourceSheet

### DIFF
--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -21,6 +21,7 @@ import '../widgets/output_sheet.dart';
 import '../widgets/peer_drawer.dart';
 import '../widgets/peer_row.dart';
 import '../widgets/push_to_talk_button.dart';
+import '../widgets/media_source_sheet.dart';
 import '../widgets/queue_sheet.dart';
 
 /// Main "On air" room — voice + now playing.
@@ -1104,6 +1105,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           _playAt(i);
           Navigator.pop(ctx);
         },
+        onChangeSource: widget.isHost
+            ? () {
+                Navigator.pop(ctx);
+                _showSourceSheet();
+              }
+            : null,
       ),
     );
   }
@@ -1155,6 +1162,39 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         }
       }
     }
+  }
+
+  Future<void> _showSourceSheet() async {
+    final c = FrequencyTheme.of(context).colors;
+    final picked = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: c.bg,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => MediaSourceSheet(current: _source),
+    );
+    if (picked != null && mounted && picked != _source) {
+      _switchSource(picked);
+    }
+  }
+
+  void _switchSource(String newSource) {
+    final lib = _buildPlaceholderLib(source: newSource, trackIdx: 0);
+    setState(() {
+      _source = newSource;
+      _lib = lib;
+      _trackIdx = 0;
+      _progress = 0;
+      _playing = false;
+    });
+    // Broadcast the source switch to peers via a queuePlay at track 0.
+    context.read<FrequencySessionCubit>().sendMediaCommand(
+      op: MediaOp.queuePlay,
+      source: newSource,
+      trackIdx: 0,
+    );
   }
 
   String _outputName() {

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -517,13 +517,14 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           break;
         case MediaOp.queuePlay:
           if (cmd.trackIdx != null) {
+            final nextSource = cmd.source;
             final nextIdx = cmd.trackIdx!;
-            // Without a real catalog the placeholder queue is sized
-            // to the highest trackIdx we've seen; if the host hops
-            // to a higher index, grow it so `_track` stays in range
-            // (Copilot review on PR #153).
-            if (nextIdx >= _lib.queue.length) {
-              _lib = _buildPlaceholderLib(source: _source, trackIdx: nextIdx);
+            // When the host switches source, rebuild the placeholder lib for
+            // the new source; otherwise grow the existing one if the incoming
+            // trackIdx exceeds the current queue length (Copilot review #153).
+            if (nextSource != _source || nextIdx >= _lib.queue.length) {
+              _source = nextSource;
+              _lib = _buildPlaceholderLib(source: nextSource, trackIdx: nextIdx);
             }
             _trackIdx = nextIdx;
             _progress = 0;

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -677,7 +677,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                     NowPlayingCard(
                       track: _track,
                       source: source,
-                      isPodcast: _source == 'Podcasts',
+                      isPodcast: MediaSourceExtension.fromWireKey(_source).isPodcast,
                       playing: _playing,
                       progress: _progress,
                       lastActionBy: _lastAction.by,

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -43,6 +43,12 @@ extension MediaSourceExtension on MediaSource {
         MediaSource.pocketCasts => 'Podcast episodes',
       };
 
+  bool get isPodcast => switch (this) {
+        MediaSource.podcasts => true,
+        MediaSource.pocketCasts => true,
+        _ => false,
+      };
+
   static MediaSource fromWireKey(String key) {
     for (final s in MediaSource.values) {
       if (s.wireKey == key) return s;
@@ -95,7 +101,7 @@ class MediaSourceSheet extends StatelessWidget {
                       ),
                     ),
                     Text(
-                      'Switch what everyone in the room hears',
+                      'Change the shared media source for this room',
                       style: TextStyle(fontFamily: 'Inter', fontSize: 12, color: c.ink3),
                     ),
                   ],
@@ -151,6 +157,7 @@ class _SourceRow extends StatelessWidget {
       label: source.label,
       hint: source.subtitle,
       excludeSemantics: true,
+      onTap: () => Navigator.pop(context, source.wireKey),
       child: Material(
         color: selected ? c.surface2 : c.surface,
         child: InkWell(

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_theme.dart';
+import 'frequency_atoms.dart';
+
+/// Available media sources the host can switch to.
+enum MediaSource {
+  youtubeMusic,
+  podcasts,
+  spotify,
+  pocketCasts,
+}
+
+extension MediaSourceExtension on MediaSource {
+  String get label => switch (this) {
+        MediaSource.youtubeMusic => 'YouTube Music',
+        MediaSource.podcasts => 'Podcasts',
+        MediaSource.spotify => 'Spotify',
+        MediaSource.pocketCasts => 'Pocket Casts',
+      };
+
+  IconData get icon => switch (this) {
+        MediaSource.youtubeMusic => Icons.music_note,
+        MediaSource.podcasts => Icons.podcasts,
+        MediaSource.spotify => Icons.queue_music,
+        MediaSource.pocketCasts => Icons.radio,
+      };
+
+  String get subtitle => switch (this) {
+        MediaSource.youtubeMusic => 'Music and playlists',
+        MediaSource.podcasts => 'Episodes and shows',
+        MediaSource.spotify => 'Music and podcasts',
+        MediaSource.pocketCasts => 'Podcast episodes',
+      };
+
+  static MediaSource fromLabel(String label) {
+    for (final s in MediaSource.values) {
+      if (s.label == label) return s;
+    }
+    return MediaSource.youtubeMusic;
+  }
+}
+
+class MediaSourceSheet extends StatelessWidget {
+  final String current;
+
+  const MediaSourceSheet({
+    super.key,
+    required this.current,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(top: 8, bottom: 14),
+              decoration: BoxDecoration(
+                color: c.line2,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+          ),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Choose source',
+                      style: TextStyle(
+                        fontFamily: 'Inter',
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: c.ink,
+                      ),
+                    ),
+                    Text(
+                      'Switch what everyone in the room hears',
+                      style: TextStyle(fontFamily: 'Inter', fontSize: 12, color: c.ink3),
+                    ),
+                  ],
+                ),
+              ),
+              Semantics(
+                button: true,
+                label: 'Close source picker',
+                child: GhostButton(
+                  icon: Icons.close,
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          FreqCard(
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              children: [
+                for (int i = 0; i < MediaSource.values.length; i++)
+                  _SourceRow(
+                    source: MediaSource.values[i],
+                    selected: MediaSource.values[i].label == current,
+                    first: i == 0,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SourceRow extends StatelessWidget {
+  final MediaSource source;
+  final bool selected;
+  final bool first;
+
+  const _SourceRow({
+    required this.source,
+    required this.selected,
+    required this.first,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: source.label,
+      hint: source.subtitle,
+      excludeSemantics: true,
+      child: Material(
+        color: selected ? c.surface2 : c.surface,
+        child: InkWell(
+          onTap: () => Navigator.pop(context, source.label),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+            decoration: BoxDecoration(
+              border: Border(
+                top: first ? BorderSide.none : BorderSide(color: c.line),
+              ),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: selected ? c.accentSoft : c.surface2,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  alignment: Alignment.center,
+                  child: Icon(
+                    source.icon,
+                    size: 16,
+                    color: selected ? c.accentInk : c.ink2,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        source.label,
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                          color: c.ink,
+                        ),
+                      ),
+                      Text(
+                        source.subtitle,
+                        style: TextStyle(fontFamily: 'Inter', fontSize: 12, color: c.ink3),
+                      ),
+                    ],
+                  ),
+                ),
+                if (selected) Icon(Icons.check, size: 16, color: c.accent),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -19,6 +19,16 @@ extension MediaSourceExtension on MediaSource {
         MediaSource.pocketCasts => 'Pocket Casts',
       };
 
+  /// Stable identifier used on the wire. The first two values intentionally
+  /// match the strings the existing protocol already sends ('YouTube Music',
+  /// 'Podcasts') for backward compat; new sources use snake_case.
+  String get wireKey => switch (this) {
+        MediaSource.youtubeMusic => 'YouTube Music',
+        MediaSource.podcasts => 'Podcasts',
+        MediaSource.spotify => 'spotify',
+        MediaSource.pocketCasts => 'pocket_casts',
+      };
+
   IconData get icon => switch (this) {
         MediaSource.youtubeMusic => Icons.music_note,
         MediaSource.podcasts => Icons.podcasts,
@@ -33,9 +43,9 @@ extension MediaSourceExtension on MediaSource {
         MediaSource.pocketCasts => 'Podcast episodes',
       };
 
-  static MediaSource fromLabel(String label) {
+  static MediaSource fromWireKey(String key) {
     for (final s in MediaSource.values) {
-      if (s.label == label) return s;
+      if (s.wireKey == key) return s;
     }
     return MediaSource.youtubeMusic;
   }
@@ -109,7 +119,7 @@ class MediaSourceSheet extends StatelessWidget {
                 for (int i = 0; i < MediaSource.values.length; i++)
                   _SourceRow(
                     source: MediaSource.values[i],
-                    selected: MediaSource.values[i].label == current,
+                    selected: MediaSource.values[i].wireKey == current,
                     first: i == 0,
                   ),
               ],
@@ -144,7 +154,7 @@ class _SourceRow extends StatelessWidget {
       child: Material(
         color: selected ? c.surface2 : c.surface,
         child: InkWell(
-          onTap: () => Navigator.pop(context, source.label),
+          onTap: () => Navigator.pop(context, source.wireKey),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
             decoration: BoxDecoration(

--- a/lib/widgets/queue_sheet.dart
+++ b/lib/widgets/queue_sheet.dart
@@ -155,7 +155,7 @@ class QueueSheet extends StatelessWidget {
               const SizedBox(height: 10),
               FreqButton(
                 icon: Icons.add,
-                label: 'Add from ${lib.name}',
+                label: lib.name.isEmpty ? 'Add source' : 'Add from ${lib.name}',
                 block: true,
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 onPressed: onChangeSource,

--- a/lib/widgets/queue_sheet.dart
+++ b/lib/widgets/queue_sheet.dart
@@ -8,12 +8,14 @@ class QueueSheet extends StatelessWidget {
   final MediaSourceLib lib;
   final int currentIdx;
   final ValueChanged<int> onPlay;
+  final VoidCallback? onChangeSource;
 
   const QueueSheet({
     super.key,
     required this.lib,
     required this.currentIdx,
     required this.onPlay,
+    this.onChangeSource,
   });
 
   @override
@@ -156,7 +158,7 @@ class QueueSheet extends StatelessWidget {
                 label: 'Add from ${lib.name}',
                 block: true,
                 padding: const EdgeInsets.symmetric(vertical: 12),
-                onPressed: () {},
+                onPressed: onChangeSource,
               ),
             ],
           ),


### PR DESCRIPTION
## Summary

Fixes the stub `onPressed: () {}` on the "Add from {source}" button in the queue sheet (part of issue #228).

- Adds `lib/widgets/media_source_sheet.dart`: a bottom sheet listing YouTube Music, Podcasts, Spotify, and Pocket Casts, modelled on the existing `OutputSheet` pattern
- `QueueSheet` gains an optional `onChangeSource: VoidCallback?` — when `null` (guests) the button is disabled; when set (host) it opens the source picker
- `frequency_room_screen.dart` gains `_showSourceSheet()` / `_switchSource()`: selecting a new source resets the placeholder lib to track 0, updates `_source`, and broadcasts a `queuePlay(trackIdx: 0, source: newSource)` so peers switch along with the host

## What this does NOT include (larger sub-tasks in #228)
- Actual audio capture / host-media broadcast (requires `AudioPlaybackCaptureConfiguration` + `MediaProjection`)
- Real catalog metadata on the wire (title/artist/artwork)
- Deep-link intent into the chosen app

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] `flutter test` — all 592 tests pass
- [ ] Host opens queue sheet → "Add from YouTube Music" button is tappable → source picker appears with all 4 options → selecting Podcasts closes the sheet, updates the NowPlayingCard source label, and resets track to 0
- [ ] Guest opens queue sheet → "Add from …" button is visually present but does not respond to taps (null onPressed)
- [ ] Picking the already-selected source is a no-op (guarded by `picked != _source`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosts can change the session media source from the queue UI via a new source picker.
  * Added selectable sources: YouTube Music, Podcasts, Spotify, Pocket Casts.
  * Source picker rows are accessible and return the chosen source to the session.

* **Bug Fixes**
  * Source changes apply immediately (resetting playback to the new source) and are synchronized to all peers.
  * Now Playing correctly detects podcast content based on the selected source.

* **UI**
  * The queue’s “Add from …” button opens the source picker for hosts and updates its label when no source is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->