### PR TITLE
fix(#228): wire queue source picker and open-in-app button for host

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -81,7 +81,19 @@
         <package android:name="com.google.android.apps.podcasts" />
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="https" />
+            <data android:scheme="https" android:host="music.youtube.com" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" android:host="open.spotify.com" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" android:host="pca.st" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" android:host="podcasts.google.com" />
         </intent>
     </queries>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -74,5 +74,14 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- url_launcher: streaming apps the host can open from the shared queue -->
+        <package android:name="com.google.android.apps.youtube.music" />
+        <package android:name="com.spotify.music" />
+        <package android:name="au.com.shiftyjelly.pocketcasts" />
+        <package android:name="com.google.android.apps.podcasts" />
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -78,7 +78,6 @@
         <package android:name="com.google.android.apps.youtube.music" />
         <package android:name="com.spotify.music" />
         <package android:name="au.com.shiftyjelly.pocketcasts" />
-        <package android:name="com.google.android.apps.podcasts" />
         <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https" android:host="music.youtube.com" />

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -517,7 +517,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           break;
         case MediaOp.queuePlay:
           if (cmd.trackIdx != null) {
-            final nextIdx = cmd.trackIdx!;
+            const maxPlaceholderTracks = 500;
+            final nextIdx = cmd.trackIdx!.clamp(0, maxPlaceholderTracks - 1);
             final nextSource = cmd.source;
             // Rebuild placeholder whenever source or index changes so the queue
             // label and track list stay in sync with the host's selection.

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -1112,7 +1112,13 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                 _showSourceSheet();
               }
             : null,
-        onOpenInSource: widget.isHost
+        // Only show "Open in app" when there's a real source with a known app
+        // URI. Hides for the generic 'Podcasts' source (no canonical app) and
+        // for the initial empty-lib state where lib.name is '' — prevents the
+        // button from rendering as "Open " before the first snapshot lands.
+        onOpenInSource: widget.isHost &&
+                _lib.name.isNotEmpty &&
+                MediaSourceExtension.fromLabel(_source)?.appUri != null
             ? () {
                 Navigator.pop(ctx);
                 _openSourceApp();

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -518,13 +518,13 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         case MediaOp.queuePlay:
           if (cmd.trackIdx != null) {
             final nextIdx = cmd.trackIdx!;
-            // Without a real catalog the placeholder queue is sized
-            // to the highest trackIdx we've seen; if the host hops
-            // to a higher index, grow it so `_track` stays in range
-            // (Copilot review on PR #153).
-            if (nextIdx >= _lib.queue.length) {
-              _lib = _buildPlaceholderLib(source: _source, trackIdx: nextIdx);
+            final nextSource = cmd.source;
+            // Rebuild placeholder whenever source or index changes so the queue
+            // label and track list stay in sync with the host's selection.
+            if (nextSource != _source || nextIdx >= _lib.queue.length) {
+              _lib = _buildPlaceholderLib(source: nextSource, trackIdx: nextIdx);
             }
+            _source = nextSource;
             _trackIdx = nextIdx;
             _progress = 0;
             _playing = true;
@@ -676,7 +676,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                     NowPlayingCard(
                       track: _track,
                       source: source,
-                      isPodcast: _source == 'Podcasts',
+                      isPodcast: MediaSourceExtension.fromLabel(_source)?.isPodcast ?? false,
                       playing: _playing,
                       progress: _progress,
                       lastActionBy: _lastAction.by,
@@ -1155,6 +1155,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
 
   Future<void> _openSourceApp() async {
     final source = MediaSourceExtension.fromLabel(_source);
+    if (source == null) return;
     final launched = await launchSourceApp(source);
     if (!launched && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -21,6 +21,7 @@ import '../widgets/output_sheet.dart';
 import '../widgets/peer_drawer.dart';
 import '../widgets/peer_row.dart';
 import '../widgets/push_to_talk_button.dart';
+import '../widgets/media_source_sheet.dart';
 import '../widgets/queue_sheet.dart';
 
 /// Main "On air" room — voice + now playing.
@@ -1104,8 +1105,65 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           _playAt(i);
           Navigator.pop(ctx);
         },
+        onChangeSource: widget.isHost
+            ? () {
+                Navigator.pop(ctx);
+                _showSourceSheet();
+              }
+            : null,
+        onOpenInSource: widget.isHost
+            ? () {
+                Navigator.pop(ctx);
+                _openSourceApp();
+              }
+            : null,
       ),
     );
+  }
+
+  Future<void> _showSourceSheet() async {
+    final c = FrequencyTheme.of(context).colors;
+    final picked = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: c.bg,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => MediaSourceSheet(current: _source),
+    );
+    if (picked != null && mounted && picked != _source) {
+      _switchSource(picked);
+    }
+  }
+
+  void _switchSource(String newSource) {
+    final lib = _buildPlaceholderLib(source: newSource, trackIdx: 0);
+    setState(() {
+      _source = newSource;
+      _lib = lib;
+      _trackIdx = 0;
+      _progress = 0;
+      _playing = false;
+    });
+    context.read<FrequencySessionCubit>().sendMediaCommand(
+      op: MediaOp.queuePlay,
+      source: newSource,
+      trackIdx: 0,
+    );
+  }
+
+  Future<void> _openSourceApp() async {
+    final source = MediaSourceExtension.fromLabel(_source);
+    final launched = await launchSourceApp(source);
+    if (!launched && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Could not open ${source.label}'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
   }
 
   Future<void> _showInviteSheet() async {

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../theme/app_theme.dart';
+import 'frequency_atoms.dart';
+
+enum MediaSource {
+  youtubeMusic,
+  podcasts,
+  spotify,
+  pocketCasts,
+}
+
+extension MediaSourceExtension on MediaSource {
+  String get label => switch (this) {
+        MediaSource.youtubeMusic => 'YouTube Music',
+        MediaSource.podcasts => 'Podcasts',
+        MediaSource.spotify => 'Spotify',
+        MediaSource.pocketCasts => 'Pocket Casts',
+      };
+
+  IconData get icon => switch (this) {
+        MediaSource.youtubeMusic => Icons.music_note,
+        MediaSource.podcasts => Icons.podcasts,
+        MediaSource.spotify => Icons.queue_music,
+        MediaSource.pocketCasts => Icons.radio,
+      };
+
+  String get subtitle => switch (this) {
+        MediaSource.youtubeMusic => 'Music and playlists',
+        MediaSource.podcasts => 'Episodes and shows',
+        MediaSource.spotify => 'Music and podcasts',
+        MediaSource.pocketCasts => 'Podcast episodes',
+      };
+
+  /// Deep-link URI that opens the streaming app directly (App Links on
+  /// Android 12+). Falls through to the browser on devices where the app
+  /// isn't installed, which guides the host to install it.
+  Uri get appUri => switch (this) {
+        MediaSource.youtubeMusic => Uri.parse('https://music.youtube.com/'),
+        MediaSource.podcasts => Uri.parse('https://podcasts.google.com/'),
+        MediaSource.spotify => Uri.parse('https://open.spotify.com/'),
+        MediaSource.pocketCasts => Uri.parse('https://pca.st/'),
+      };
+
+  static MediaSource fromLabel(String label) {
+    for (final s in MediaSource.values) {
+      if (s.label == label) return s;
+    }
+    return MediaSource.youtubeMusic;
+  }
+}
+
+/// Attempts to launch [source]'s streaming app via its App Link URI.
+/// Returns true if the launch succeeded.
+Future<bool> launchSourceApp(MediaSource source) async {
+  final uri = source.appUri;
+  if (!await canLaunchUrl(uri)) return false;
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+/// Bottom sheet for changing the shared media source.
+class MediaSourceSheet extends StatelessWidget {
+  final String current;
+
+  const MediaSourceSheet({
+    super.key,
+    required this.current,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(top: 8, bottom: 14),
+              decoration: BoxDecoration(
+                color: c.line2,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+          ),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Choose source',
+                      style: TextStyle(
+                        fontFamily: 'Inter',
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        color: c.ink,
+                      ),
+                    ),
+                    Text(
+                      'Switch what everyone in the room hears',
+                      style: TextStyle(fontFamily: 'Inter', fontSize: 12, color: c.ink3),
+                    ),
+                  ],
+                ),
+              ),
+              Semantics(
+                button: true,
+                label: 'Close source picker',
+                child: GhostButton(
+                  icon: Icons.close,
+                  onPressed: () => Navigator.pop(context),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          FreqCard(
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              children: [
+                for (int i = 0; i < MediaSource.values.length; i++)
+                  _SourceRow(
+                    source: MediaSource.values[i],
+                    selected: MediaSource.values[i].label == current,
+                    first: i == 0,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SourceRow extends StatelessWidget {
+  final MediaSource source;
+  final bool selected;
+  final bool first;
+
+  const _SourceRow({
+    required this.source,
+    required this.selected,
+    required this.first,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: source.label,
+      hint: source.subtitle,
+      excludeSemantics: true,
+      child: Material(
+        color: selected ? c.surface2 : c.surface,
+        child: InkWell(
+          onTap: () => Navigator.pop(context, source.label),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+            decoration: BoxDecoration(
+              border: Border(
+                top: first ? BorderSide.none : BorderSide(color: c.line),
+              ),
+            ),
+            child: Row(
+              children: [
+                Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: selected ? c.accentSoft : c.surface2,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  alignment: Alignment.center,
+                  child: Icon(
+                    source.icon,
+                    size: 16,
+                    color: selected ? c.accentInk : c.ink2,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        source.label,
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                          color: c.ink,
+                        ),
+                      ),
+                      Text(
+                        source.subtitle,
+                        style: TextStyle(fontFamily: 'Inter', fontSize: 12, color: c.ink3),
+                      ),
+                    ],
+                  ),
+                ),
+                if (selected) Icon(Icons.check, size: 16, color: c.accent),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -33,9 +33,22 @@ extension MediaSourceExtension on MediaSource {
         MediaSource.pocketCasts => 'Podcast episodes',
       };
 
+  bool get isPodcast => switch (this) {
+        MediaSource.podcasts => true,
+        MediaSource.pocketCasts => true,
+        _ => false,
+      };
+
   /// Deep-link URI that opens the streaming app directly (App Links on
-  /// Android 12+). Falls through to the browser on devices where the app
-  /// isn't installed, which guides the host to install it.
+  /// Android 12+).
+  ///
+  /// On Android, [launchSourceApp] will attempt
+  /// [LaunchMode.externalNonBrowserApplication] first, which targets the
+  /// native app via App Links/universal links without browser fallback. If the
+  /// OS doesn't support that mode, it falls back to
+  /// [LaunchMode.externalApplication], which may open a browser if the app
+  /// isn't installed. Callers should not interpret the launch result as a
+  /// reliable "app is installed" signal on Android.
   Uri get appUri => switch (this) {
         MediaSource.youtubeMusic => Uri.parse('https://music.youtube.com/'),
         MediaSource.podcasts => Uri.parse('https://podcasts.google.com/'),
@@ -43,19 +56,31 @@ extension MediaSourceExtension on MediaSource {
         MediaSource.pocketCasts => Uri.parse('https://pca.st/'),
       };
 
-  static MediaSource fromLabel(String label) {
+  /// Returns null for unknown labels instead of silently defaulting to a
+  /// specific source, so callers must handle the unrecognised-source case.
+  static MediaSource? fromLabel(String label) {
     for (final s in MediaSource.values) {
       if (s.label == label) return s;
     }
-    return MediaSource.youtubeMusic;
+    return null;
   }
 }
 
-/// Attempts to launch [source]'s streaming app via its App Link URI.
-/// Returns true if the launch succeeded.
+/// Attempts to launch [source]'s streaming app.
+///
+/// Uses [LaunchMode.externalNonBrowserApplication] where supported (iOS 10+
+/// universal links, avoids browser); falls back to
+/// [LaunchMode.externalApplication] on platforms that don't support it.
+///
+/// Returns true if the OS accepted the launch; false if no handler was found.
+/// Note: on Android the fallback mode may still open a browser when the app is
+/// not installed — a `true` result does not guarantee the native app launched.
 Future<bool> launchSourceApp(MediaSource source) async {
   final uri = source.appUri;
   if (!await canLaunchUrl(uri)) return false;
+  if (await supportsLaunchMode(LaunchMode.externalNonBrowserApplication)) {
+    return launchUrl(uri, mode: LaunchMode.externalNonBrowserApplication);
+  }
   return launchUrl(uri, mode: LaunchMode.externalApplication);
 }
 

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -42,16 +42,19 @@ extension MediaSourceExtension on MediaSource {
   /// Deep-link URI that opens the streaming app directly (App Links on
   /// Android 12+).
   ///
-  /// On Android, [launchSourceApp] will attempt
-  /// [LaunchMode.externalNonBrowserApplication] first, which targets the
-  /// native app via App Links/universal links without browser fallback. If the
-  /// OS doesn't support that mode, it falls back to
-  /// [LaunchMode.externalApplication], which may open a browser if the app
-  /// isn't installed. Callers should not interpret the launch result as a
-  /// reliable "app is installed" signal on Android.
-  Uri get appUri => switch (this) {
+  /// Deep-link URI for opening the streaming app directly, or null when no
+  /// single canonical app exists for this source (e.g. the generic "Podcasts"
+  /// source — Google Podcasts is discontinued and there is no standard podcast
+  /// app URI on Android; use Pocket Casts explicitly for that app).
+  ///
+  /// On Android, [launchSourceApp] prefers
+  /// [LaunchMode.externalNonBrowserApplication] (avoids browser via App Links)
+  /// and falls back to [LaunchMode.externalApplication]. A true return does not
+  /// guarantee the native app launched on Android — a browser may open instead
+  /// if the app isn't installed.
+  Uri? get appUri => switch (this) {
         MediaSource.youtubeMusic => Uri.parse('https://music.youtube.com/'),
-        MediaSource.podcasts => Uri.parse('https://podcasts.google.com/'),
+        MediaSource.podcasts => null,
         MediaSource.spotify => Uri.parse('https://open.spotify.com/'),
         MediaSource.pocketCasts => Uri.parse('https://pca.st/'),
       };
@@ -77,6 +80,7 @@ extension MediaSourceExtension on MediaSource {
 /// not installed — a `true` result does not guarantee the native app launched.
 Future<bool> launchSourceApp(MediaSource source) async {
   final uri = source.appUri;
+  if (uri == null) return false;
   if (!await canLaunchUrl(uri)) return false;
   if (await supportsLaunchMode(LaunchMode.externalNonBrowserApplication)) {
     return launchUrl(uri, mode: LaunchMode.externalNonBrowserApplication);

--- a/lib/widgets/queue_sheet.dart
+++ b/lib/widgets/queue_sheet.dart
@@ -8,12 +8,18 @@ class QueueSheet extends StatelessWidget {
   final MediaSourceLib lib;
   final int currentIdx;
   final ValueChanged<int> onPlay;
+  /// Host-only: opens the source picker to switch the shared media source.
+  final VoidCallback? onChangeSource;
+  /// Host-only: launches the active streaming app so the host can pick music.
+  final VoidCallback? onOpenInSource;
 
   const QueueSheet({
     super.key,
     required this.lib,
     required this.currentIdx,
     required this.onPlay,
+    this.onChangeSource,
+    this.onOpenInSource,
   });
 
   @override
@@ -63,6 +69,15 @@ class QueueSheet extends StatelessWidget {
                       ],
                     ),
                   ),
+                  if (onChangeSource != null)
+                    Semantics(
+                      button: true,
+                      label: 'Change source',
+                      child: GhostButton(
+                        icon: Icons.swap_horiz,
+                        onPressed: onChangeSource,
+                      ),
+                    ),
                   Semantics(
                     button: true,
                     label: 'Close queue',
@@ -150,14 +165,16 @@ class QueueSheet extends StatelessWidget {
                   },
                 ),
               ),
-              const SizedBox(height: 10),
-              FreqButton(
-                icon: Icons.add,
-                label: 'Add from ${lib.name}',
-                block: true,
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                onPressed: () {},
-              ),
+              if (onOpenInSource != null) ...[
+                const SizedBox(height: 10),
+                FreqButton(
+                  icon: Icons.open_in_new,
+                  label: 'Open ${lib.name}',
+                  block: true,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  onPressed: onOpenInSource,
+                ),
+              ],
             ],
           ),
         );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1098,6 +1098,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   # UI/UX
   google_fonts: ^8.1.0
   package_info_plus: ^10.1.0
+  url_launcher: ^6.3.1
 
   # Crash Reporting (opt-in, privacy-first)
   sentry_flutter: ^9.0.0


### PR DESCRIPTION
Closes #228 (partial — addresses the source-picker and open-in-app sub-tasks; audio capture and real metadata sync are tracked as follow-up).

## What changed

### New: `lib/widgets/media_source_sheet.dart`
- `MediaSource` enum with `label`, `icon`, `subtitle`, and `appUri` (App Links to YouTube Music, Google Podcasts, Spotify, Pocket Casts)
- `launchSourceApp()` top-level helper wrapping `url_launcher`
- `MediaSourceSheet` bottom-sheet widget for picking the active source (host-only)

### Updated: `lib/widgets/queue_sheet.dart`
- Adds `onChangeSource` callback — renders a swap icon in the header (host-only) to open the source picker
- Adds `onOpenInSource` callback — renders an **"Open \<source\>"** button at the bottom (host-only) that launches the streaming app via App Link; guests see neither button
- Replaces the previous `onPressed: () {}` stub

### Updated: `lib/screens/frequency_room_screen.dart`
- Imports `media_source_sheet.dart`
- Wires `_showSourceSheet()` / `_switchSource()` / `_openSourceApp()` from the queue sheet callbacks
- Failed launch (app not installed) surfaces a `SnackBar`

### Updated: `pubspec.yaml` + `pubspec.lock`
- Adds `url_launcher: ^6.3.1`

### Updated: `android/app/src/main/AndroidManifest.xml`
- Adds `<queries>` entries for the four streaming app packages + `https` intent filter so `canLaunchUrl()` works correctly on Android 11+ (package visibility)

## Test plan
- [ ] Run `flutter analyze` — no issues
- [ ] Run `flutter test` — all 592 tests pass
- [ ] Manual: host opens queue sheet → "Open YouTube Music" button appears; tapping it launches YT Music
- [ ] Manual: host taps swap icon → source picker opens; selecting a different source updates the queue label and broadcasts `queuePlay`
- [ ] Manual: guest opens queue sheet → no buttons visible
- [ ] Manual: on device without YT Music installed → SnackBar shown with "Could not open YouTube Music"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosts can switch the shared media source from the queue and open the current source app directly.
  * Added a media source picker UI with per-source labels, icons and deep-link support.

* **Bug Fixes / Improvements**
  * External streaming/podcast links now resolve to source apps (YouTube Music, Spotify, Pocket Casts, Google Podcasts).
  * Prevent out-of-range queue jumps and show a brief notification if launching the source app fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->