### PR TITLE
feat(#228): add url_launcher — host can open streaming app from queue

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -74,5 +74,22 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- url_launcher: streaming apps the host can open from the shared queue -->
+        <package android:name="com.google.android.apps.youtube.music" />
+        <package android:name="com.spotify.music" />
+        <package android:name="au.com.shiftyjelly.pocketcasts" />
+        <!-- Per-host intent filters instead of broad scheme-only visibility -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" android:host="music.youtube.com" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" android:host="open.spotify.com" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" android:host="pca.st" />
+        </intent>
     </queries>
 </manifest>

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -373,14 +373,18 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     final clampedIdx = trackIdx < 0 ? 0 : trackIdx;
     final placeholderDurationSec =
         positionSec * 2 < 60 ? 60 : positionSec * 2;
+    // Use the human-readable display label for MediaSourceLib.name so UI
+    // surfaces ("From Spotify", "Open Spotify") are user-facing rather than
+    // showing raw wire keys like "spotify" or "pocket_casts".
+    final displayName = MediaSourceExtension.fromWireKey(source).label;
     return MediaSourceLib(
-      name: source,
+      name: displayName,
       kind: emptyMediaLib.kind,
       queue: [
         for (var i = 0; i <= clampedIdx; i++)
           Track(
             title: 'Track ${i + 1}',
-            artist: source,
+            artist: displayName,
             durationSeconds: placeholderDurationSec,
             tag: '',
           ),

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -375,8 +375,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         positionSec * 2 < 60 ? 60 : positionSec * 2;
     // Use the human-readable display label for MediaSourceLib.name so UI
     // surfaces ("From Spotify", "Open Spotify") are user-facing rather than
-    // showing raw wire keys like "spotify" or "pocket_casts".
-    final displayName = MediaSourceExtension.fromWireKey(source).label;
+    // showing raw wire keys like "spotify" or "pocket_casts". Unknown future
+    // keys fall back to the raw wireKey string rather than defaulting to
+    // "YouTube Music" (which fromWireKey does for backward compat).
+    final displayName = _sourceDisplayName(source);
     return MediaSourceLib(
       name: displayName,
       kind: emptyMediaLib.kind,
@@ -1098,6 +1100,15 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       .replaceAll(RegExp(r'[\x00-\x1F\x7F-\x9F\u2028\u2029]'), ' ')
       .replaceAll(RegExp(r' +'), ' ')
       .trim();
+
+  /// Returns the display label for a wire key, or the raw key itself for
+  /// unknown/future sources (avoids the YouTube Music fallback in fromWireKey).
+  static String _sourceDisplayName(String wireKey) {
+    for (final s in MediaSource.values) {
+      if (s.wireKey == wireKey) return s.label;
+    }
+    return wireKey;
+  }
 
   /// Returns the [MediaSource] for [_source]'s wire key, or null for
   /// unknown/future keys, so launch decisions never misroute to the

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -1093,8 +1093,19 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       .replaceAll(RegExp(r' +'), ' ')
       .trim();
 
+  /// Returns the [MediaSource] for [_source]'s wire key, or null for
+  /// unknown/future keys, so launch decisions never misroute to the
+  /// [MediaSource.youtubeMusic] fallback that [fromWireKey] would return.
+  MediaSource? get _launchableSource {
+    for (final s in MediaSource.values) {
+      if (s.wireKey == _source) return s;
+    }
+    return null;
+  }
+
   Future<void> _showQueueSheet() async {
     final c = FrequencyTheme.of(context).colors;
+    final launchable = _launchableSource;
     await showModalBottomSheet<void>(
       context: context,
       backgroundColor: c.bg,
@@ -1115,23 +1126,22 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                 _showSourceSheet();
               }
             : null,
-        // Only show "Open in app" when the source has a known deep-link URI
-        // and the lib name is already set (hides button before the first
-        // host snapshot populates lib.name from emptyMediaLib's '').
+        // Only show "Open in app" when lib.name is populated (hides button
+        // before first host snapshot), source is a known wire key, and that
+        // source has a canonical appUri (null for generic Podcasts).
         onOpenInSource: widget.isHost &&
                 _lib.name.isNotEmpty &&
-                MediaSourceExtension.fromWireKey(_source).appUri != null
+                launchable?.appUri != null
             ? () {
                 Navigator.pop(ctx);
-                _openSourceApp();
+                _openSourceApp(launchable!);
               }
             : null,
       ),
     );
   }
 
-  Future<void> _openSourceApp() async {
-    final source = MediaSourceExtension.fromWireKey(_source);
+  Future<void> _openSourceApp(MediaSource source) async {
     final launched = await launchSourceApp(source);
     if (!launched && mounted) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -404,21 +404,26 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   /// queue via [_buildPlaceholderLib] so the protocol-level `trackIdx`
   /// rides through unchanged — outgoing `sendMediaCommand`s keep
   /// referencing the same index the host published.
+  static const int _kMaxPlaceholderTracks = 500;
+
+  int _clampTrackIdx(int idx) => idx.clamp(0, _kMaxPlaceholderTracks - 1);
+
   void _applyMediaSnapshot(MediaState snapshot) {
     if (_appliedSnapshot == snapshot) return;
     _appliedSnapshot = snapshot;
     final positionSec = (snapshot.positionMs / 1000).round();
+    final trackIdx = _clampTrackIdx(snapshot.trackIdx);
     final lib = _buildPlaceholderLib(
       source: snapshot.source,
-      trackIdx: snapshot.trackIdx,
+      trackIdx: trackIdx,
       positionSec: positionSec,
     );
     setState(() {
       _source = snapshot.source;
       _lib = lib;
-      _trackIdx = snapshot.trackIdx;
+      _trackIdx = trackIdx;
       _playing = snapshot.playing;
-      _progress = positionSec.clamp(0, lib.queue[_trackIdx].durationSeconds);
+      _progress = positionSec.clamp(0, lib.queue[trackIdx].durationSeconds);
     });
   }
 
@@ -518,10 +523,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         case MediaOp.queuePlay:
           if (cmd.trackIdx != null) {
             final nextSource = cmd.source;
-            // Clamp wire input to prevent negative indexing or huge placeholder
-            // allocations from a malformed or future peer.
-            const maxPlaceholderTracks = 500;
-            final nextIdx = cmd.trackIdx!.clamp(0, maxPlaceholderTracks - 1);
+            final nextIdx = _clampTrackIdx(cmd.trackIdx!);
             // When the host switches source, rebuild the placeholder lib for
             // the new source; otherwise grow the existing one if the incoming
             // trackIdx exceeds the current queue length (Copilot review #153).

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -518,7 +518,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         case MediaOp.queuePlay:
           if (cmd.trackIdx != null) {
             final nextSource = cmd.source;
-            final nextIdx = cmd.trackIdx!;
+            // Clamp wire input to prevent negative indexing or huge placeholder
+            // allocations from a malformed or future peer.
+            const maxPlaceholderTracks = 500;
+            final nextIdx = cmd.trackIdx!.clamp(0, maxPlaceholderTracks - 1);
             // When the host switches source, rebuild the placeholder lib for
             // the new source; otherwise grow the existing one if the incoming
             // trackIdx exceeds the current queue length (Copilot review #153).
@@ -1112,8 +1115,32 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                 _showSourceSheet();
               }
             : null,
+        // Only show "Open in app" when the source has a known deep-link URI
+        // and the lib name is already set (hides button before the first
+        // host snapshot populates lib.name from emptyMediaLib's '').
+        onOpenInSource: widget.isHost &&
+                _lib.name.isNotEmpty &&
+                MediaSourceExtension.fromWireKey(_source).appUri != null
+            ? () {
+                Navigator.pop(ctx);
+                _openSourceApp();
+              }
+            : null,
       ),
     );
+  }
+
+  Future<void> _openSourceApp() async {
+    final source = MediaSourceExtension.fromWireKey(_source);
+    final launched = await launchSourceApp(source);
+    if (!launched && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Could not open ${source.label}'),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
   }
 
   Future<void> _showInviteSheet() async {

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../theme/app_theme.dart';
 import 'frequency_atoms.dart';
@@ -49,12 +50,44 @@ extension MediaSourceExtension on MediaSource {
         _ => false,
       };
 
+  /// Deep-link URI for launching the streaming app, or null when no canonical
+  /// App Link exists (e.g. the generic "Podcasts" source — Google Podcasts is
+  /// discontinued; use Pocket Casts explicitly for that app).
+  ///
+  /// [launchSourceApp] prefers [LaunchMode.externalNonBrowserApplication] to
+  /// avoid browser fallback on iOS via universal links; falls back to
+  /// [LaunchMode.externalApplication] on platforms that don't support it. On
+  /// Android the fallback mode may still open a browser — a `true` result does
+  /// not guarantee the native app launched.
+  Uri? get appUri => switch (this) {
+        MediaSource.youtubeMusic => Uri.parse('https://music.youtube.com/'),
+        MediaSource.podcasts => null,
+        MediaSource.spotify => Uri.parse('https://open.spotify.com/'),
+        MediaSource.pocketCasts => Uri.parse('https://pca.st/'),
+      };
+
   static MediaSource fromWireKey(String key) {
     for (final s in MediaSource.values) {
       if (s.wireKey == key) return s;
     }
     return MediaSource.youtubeMusic;
   }
+}
+
+/// Launches [source]'s streaming app via its [MediaSource.appUri].
+///
+/// Returns false immediately when [MediaSource.appUri] is null (no canonical
+/// app) or when the OS reports no handler. Uses
+/// [LaunchMode.externalNonBrowserApplication] where supported; falls back to
+/// [LaunchMode.externalApplication].
+Future<bool> launchSourceApp(MediaSource source) async {
+  final uri = source.appUri;
+  if (uri == null) return false;
+  if (!await canLaunchUrl(uri)) return false;
+  if (await supportsLaunchMode(LaunchMode.externalNonBrowserApplication)) {
+    return launchUrl(uri, mode: LaunchMode.externalNonBrowserApplication);
+  }
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
 }
 
 class MediaSourceSheet extends StatelessWidget {

--- a/lib/widgets/media_source_sheet.dart
+++ b/lib/widgets/media_source_sheet.dart
@@ -83,11 +83,15 @@ extension MediaSourceExtension on MediaSource {
 Future<bool> launchSourceApp(MediaSource source) async {
   final uri = source.appUri;
   if (uri == null) return false;
-  if (!await canLaunchUrl(uri)) return false;
-  if (await supportsLaunchMode(LaunchMode.externalNonBrowserApplication)) {
-    return launchUrl(uri, mode: LaunchMode.externalNonBrowserApplication);
+  try {
+    if (!await canLaunchUrl(uri)) return false;
+    if (await supportsLaunchMode(LaunchMode.externalNonBrowserApplication)) {
+      return launchUrl(uri, mode: LaunchMode.externalNonBrowserApplication);
+    }
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
+  } catch (_) {
+    return false;
   }
-  return launchUrl(uri, mode: LaunchMode.externalApplication);
 }
 
 class MediaSourceSheet extends StatelessWidget {

--- a/lib/widgets/queue_sheet.dart
+++ b/lib/widgets/queue_sheet.dart
@@ -8,7 +8,12 @@ class QueueSheet extends StatelessWidget {
   final MediaSourceLib lib;
   final int currentIdx;
   final ValueChanged<int> onPlay;
+  /// Host-only: opens the source picker to switch the shared media source.
   final VoidCallback? onChangeSource;
+  /// Host-only: launches the active streaming app so the host can pick music.
+  /// Null when the current source has no canonical app (e.g. generic Podcasts)
+  /// or when lib.name is empty (initial state before the first host snapshot).
+  final VoidCallback? onOpenInSource;
 
   const QueueSheet({
     super.key,
@@ -16,6 +21,7 @@ class QueueSheet extends StatelessWidget {
     required this.currentIdx,
     required this.onPlay,
     this.onChangeSource,
+    this.onOpenInSource,
   });
 
   @override
@@ -65,6 +71,15 @@ class QueueSheet extends StatelessWidget {
                       ],
                     ),
                   ),
+                  if (onChangeSource != null)
+                    Semantics(
+                      button: true,
+                      label: 'Change source',
+                      child: GhostButton(
+                        icon: Icons.swap_horiz,
+                        onPressed: onChangeSource,
+                      ),
+                    ),
                   Semantics(
                     button: true,
                     label: 'Close queue',
@@ -152,14 +167,16 @@ class QueueSheet extends StatelessWidget {
                   },
                 ),
               ),
-              const SizedBox(height: 10),
-              FreqButton(
-                icon: Icons.add,
-                label: lib.name.isEmpty ? 'Add source' : 'Add from ${lib.name}',
-                block: true,
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                onPressed: onChangeSource,
-              ),
+              if (onOpenInSource != null) ...[
+                const SizedBox(height: 10),
+                FreqButton(
+                  icon: Icons.open_in_new,
+                  label: 'Open ${lib.name}',
+                  block: true,
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  onPressed: onOpenInSource,
+                ),
+              ],
             ],
           ),
         );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1098,6 +1098,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   # UI/UX
   google_fonts: ^8.1.0
   package_info_plus: ^10.1.0
+  url_launcher: ^6.3.1
 
   # Crash Reporting (opt-in, privacy-first)
   sentry_flutter: ^9.0.0


### PR DESCRIPTION
Builds on #238 (merged: source picker + source switching). Adds the host's "Open in app" flow so they can launch the active streaming app directly from the queue sheet without leaving the room screen.

## What changed

### `pubspec.yaml`
- Adds `url_launcher: ^6.3.1`

### `android/app/src/main/AndroidManifest.xml`
- Per-package visibility for YouTube Music, Spotify, Pocket Casts
- Per-domain HTTPS intent filters (`music.youtube.com`, `open.spotify.com`, `pca.st`) — narrower than a broad scheme-only entry; excludes Google Podcasts (discontinued)

### `lib/widgets/media_source_sheet.dart`
- Adds nullable `appUri` getter — `null` for the generic Podcasts source (no canonical app), live URIs for YouTube Music / Spotify / Pocket Casts
- Adds `launchSourceApp()`: prefers `externalNonBrowserApplication` (avoids browser on iOS via universal links), falls back to `externalApplication`

### `lib/widgets/queue_sheet.dart`
- Adds `onOpenInSource` callback → **"Open \<source\>"** button at the bottom (host-only; null hides the button)
- Moves source-change access to a swap (`⇄`) icon in the queue header alongside the close button so both actions are reachable

### `lib/screens/frequency_room_screen.dart`
- Adds `_openSourceApp()` that calls `launchSourceApp()` and shows a `SnackBar` on failure
- Wires `onOpenInSource` guarded by `lib.name.isNotEmpty` (initial `emptyMediaLib`) and `source.appUri != null` (no button for generic Podcasts source)
- Clamps inbound `queuePlay trackIdx` to `[0, 499]` to prevent negative indexing or huge placeholder allocation from a malformed peer

## Test plan
- [ ] `flutter analyze` — no issues
- [ ] `flutter test` — 592/592 pass
- [ ] Manual (host): queue sheet → swap icon changes source; "Open YouTube Music" launches YT Music app
- [ ] Manual (host): switching to "Podcasts" source → "Open Podcasts" button is absent (no app)
- [ ] Manual (host): initial room entry before first snapshot → "Open" button absent (lib.name='')
- [ ] Manual (guest): queue sheet → neither button visible
- [ ] Manual: YT Music not installed → SnackBar "Could not open YouTube Music"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can detect YouTube Music, Spotify, and Pocket Casts and offers an "Open in app" deep-link action with graceful fallback and user feedback.
  * Queue UI shows a host-only "Open in app" action when a launchable source is available.

* **Bug Fixes**
  * Prevented out-of-range placeholder track indices when applying remote queue/state.
  * Host-only controls now render only when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->