### PR TITLE
docs(#252): update roadmap to reflect actual phase completion state

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ handles BLE radio, L2CAP sockets, mic capture, and Opus.
       and `deviceDiscovered` events drive the headset-routing manager.
       [audio_service.dart](lib/services/audio_service.dart) is the Dart
       side of that surface.
-    * Phase 2 (planned, see roadmap): the BLE control-plane bridge —
+    * Phase 2 ✅ done: the BLE control-plane bridge —
       Frequency-shaped methods like `startAdvertising`, `connectToHost`,
       and `setMuted`, plus events like `onPeerDiscovered` and
-      `onJoinAccepted`. Tracked under
+      `onJoinAccepted`. Implemented in
       [#44](https://github.com/ElodinLaarz/walkie-talkie/issues/44).
 4.  **Service Layer (Android Native — Kotlin):**
     * **Foreground Service**
@@ -68,9 +68,9 @@ handles BLE radio, L2CAP sockets, mic capture, and Opus.
     * **BT headset routing** today
       ([BluetoothLeAudioManager.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/BluetoothLeAudioManager.kt))
       — pairs the user's headset and routes phone audio to it.
-    * **BLE Connection Manager** (Phase 2) — LE advertise (host), scan
-      (guest), GATT server / client, L2CAP CoC server / client. Not yet
-      implemented; tracked in the Phase 2 issues below.
+    * **BLE Connection Manager** (Phase 2 ✅ done) — LE advertise (host),
+      scan (guest), GATT server / client, L2CAP CoC server / client.
+      Implemented across [#37–#45](https://github.com/ElodinLaarz/walkie-talkie/issues/37).
     * **Audio Engine** (Phase 3) — mic capture (Oboe), Opus encode/decode,
       mix-minus. Not yet implemented.
 5.  **Hardware Layer:** Bluetooth radio, microphone, audio output.
@@ -199,12 +199,11 @@ graph TD
 
 ### Android Native (Kotlin / C++)
 
-The libraries / APIs below are the planned native surface for Phases 2-3
-(see roadmap). Today's native code under `android/app/src/main/kotlin/`
-is the headset-routing manager
-([BluetoothLeAudioManager.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/BluetoothLeAudioManager.kt))
-plus the foreground service shell — none of the BLE control / L2CAP / Opus
-pieces are wired up yet.
+The libraries / APIs below are the native surface for Phases 2-3
+(see roadmap). Phase 2 (BLE control plane) is complete; Phase 3
+(voice pipeline) building blocks have landed but the session-level
+wiring is still owed (tracked in
+[#246](https://github.com/ElodinLaarz/walkie-talkie/issues/246)).
 
 1.  **AndroidX Bluetooth APIs** *(Phase 2)* — `BluetoothLeAdvertiser`,
     `BluetoothLeScanner`, `BluetoothGattServer` / `BluetoothGatt`, and

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ UI screens, onboarding + permissions, BLoC state, Hive persistence
 (`peerId` + display name), wire-protocol Dart stubs (framing,
 sequence filter, message envelope, voice-frame), foreground service shell.
 
-### Phase 2 — Native BLE control plane (in flight)
+### Phase 2 — Native BLE control plane ✅ done
 
 End-to-end host advertise → guest connect → JoinAccepted snapshot, all on
 real radios.
@@ -251,17 +251,20 @@ real radios.
 * [#39](https://github.com/ElodinLaarz/walkie-talkie/issues/39) Host-side session bootstrap (mint `sessionUuid`, self-seed `JoinAccepted`).
 * [#40](https://github.com/ElodinLaarz/walkie-talkie/issues/40) Replace mock roster + media in the room screen with cubit state.
 
-### Phase 3 — Voice plane
+### Phase 3 — Voice plane (bricks landed, session wiring pending)
 
-Real audio between two phones.
+Individual building blocks are all closed; the session-level wiring that
+makes audio flow end-to-end is tracked in
+[#246](https://github.com/ElodinLaarz/walkie-talkie/issues/246).
 
-* [#46](https://github.com/ElodinLaarz/walkie-talkie/issues/46) Native L2CAP CoC server (host) + client (guest).
-* [#47](https://github.com/ElodinLaarz/walkie-talkie/issues/47) Native libopus encoder + decoder.
-* [#48](https://github.com/ElodinLaarz/walkie-talkie/issues/48) Real mix-minus across multiple peers.
-* [#49](https://github.com/ElodinLaarz/walkie-talkie/issues/49) Per-peer voice-frame seq tracking with stuck-producer prune.
-* [#50](https://github.com/ElodinLaarz/walkie-talkie/issues/50) Voice-activity detection + outbound `TalkingState` messages.
+* [#46](https://github.com/ElodinLaarz/walkie-talkie/issues/46) ✅ Native L2CAP CoC server (host) + client (guest).
+* [#47](https://github.com/ElodinLaarz/walkie-talkie/issues/47) ✅ Native libopus encoder + decoder.
+* [#48](https://github.com/ElodinLaarz/walkie-talkie/issues/48) ✅ Real mix-minus across multiple peers.
+* [#49](https://github.com/ElodinLaarz/walkie-talkie/issues/49) ✅ Per-peer voice-frame seq tracking with stuck-producer prune.
+* [#50](https://github.com/ElodinLaarz/walkie-talkie/issues/50) ✅ Voice-activity detection + outbound `TalkingState` messages.
+* [#246](https://github.com/ElodinLaarz/walkie-talkie/issues/246) ⏳ Session-level wiring: mic→encode→send + receive→decode→playback.
 
-### Phase 4 — Reliability
+### Phase 4 — Reliability ✅ done
 
 * [#51](https://github.com/ElodinLaarz/walkie-talkie/issues/51) Heartbeats + dirty-disconnect detection.
 * [#53](https://github.com/ElodinLaarz/walkie-talkie/issues/53) `SignalReport` on a 10s timer (replaces the demo weak-signal toast).
@@ -269,7 +272,7 @@ Real audio between two phones.
 * [#56](https://github.com/ElodinLaarz/walkie-talkie/issues/56) Graceful auto-reconnect for transient drops (≤30s).
 * [#57](https://github.com/ElodinLaarz/walkie-talkie/issues/57) Permissions revocation handling (mic / BT revoked while in-room).
 
-### Phase 5 — Release polish
+### Phase 5 — Release polish ✅ done
 
 * [#34](https://github.com/ElodinLaarz/walkie-talkie/issues/34) Release signing config (replace debug-key fallback).
 * [#35](https://github.com/ElodinLaarz/walkie-talkie/issues/35) CI: build & run native `mixer_test` (and delete the checked-in binary).

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -224,18 +224,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     BitrateAdapter? bitrateAdapter,
     String Function()? mintSessionUuid,
     Duration joinAcceptedTimeout = defaultJoinAcceptedTimeout,
-  })  : _transport = transport,
-        _audio = audio,
-        _permissionWatcher = permissionWatcher,
-        _reconnectDelays = reconnectDelays,
-        _heartbeats = heartbeats ?? HeartbeatScheduler(),
-        _signalReporter = signalReporter ?? SignalReporter(),
-        _weakSignalDetector = weakSignalDetector ?? WeakSignalDetector(),
-        _linkQualityReporter = linkQualityReporter ?? LinkQualityReporter(),
-        _bitrateAdapter = bitrateAdapter ?? BitrateAdapter(),
-        _mintSessionUuid = mintSessionUuid ?? generateUuidV4,
-        _joinAcceptedTimeout = joinAcceptedTimeout,
-        super(const SessionBooting());
+  }) : _transport = transport,
+       _audio = audio,
+       _permissionWatcher = permissionWatcher,
+       _reconnectDelays = reconnectDelays,
+       _heartbeats = heartbeats ?? HeartbeatScheduler(),
+       _signalReporter = signalReporter ?? SignalReporter(),
+       _weakSignalDetector = weakSignalDetector ?? WeakSignalDetector(),
+       _linkQualityReporter = linkQualityReporter ?? LinkQualityReporter(),
+       _bitrateAdapter = bitrateAdapter ?? BitrateAdapter(),
+       _mintSessionUuid = mintSessionUuid ?? generateUuidV4,
+       _joinAcceptedTimeout = joinAcceptedTimeout,
+       super(const SessionBooting());
 
   /// Reads the persisted display name; routes the user to Discovery if one
   /// exists, otherwise into Onboarding. Always exits Booting — even if the
@@ -254,8 +254,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // crashing on the next AudioRecord / GATT call. The watcher emits an
     // initial snapshot on subscription, so a fresh launch with already-
     // revoked perms is handled too.
-    _permissionSubscription =
-        _permissionWatcher?.watch().listen(_onPermissionsChanged);
+    _permissionSubscription = _permissionWatcher?.watch().listen(
+      _onPermissionsChanged,
+    );
 
     // Cache peerId to avoid async resolution in hot path (voice activity)
     try {
@@ -269,7 +270,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     try {
       persisted = await identityStore.getDisplayName();
     } catch (error, stackTrace) {
-      if (kDebugMode) debugPrint('Failed to load persisted display name: $error');
+      if (kDebugMode) {
+        debugPrint('Failed to load persisted display name: $error');
+      }
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
     }
     if (isClosed) return;
@@ -278,10 +281,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     } else {
       final recent = await _loadRecentFrequencies();
       if (isClosed) return;
-      emit(SessionDiscovery(
-        myName: persisted,
-        recentHostedFrequencies: recent,
-      ));
+      emit(
+        SessionDiscovery(myName: persisted, recentHostedFrequencies: recent),
+      );
     }
     // Defensive replay of the latest permission state. The watcher's
     // initial sample is emitted before bootstrap finishes (cubit is still
@@ -330,8 +332,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         if (m.peerId == current.hostPeerId && !current.roomIsHost) {
           unawaited(leaveRoom());
         } else {
-          final updated =
-              current.roster.where((p) => p.peerId != m.peerId).toList();
+          final updated = current.roster
+              .where((p) => p.peerId != m.peerId)
+              .toList();
           emit(current.copyWith(roster: updated));
           _transport?.forgetPeer(m.peerId);
           _heartbeats.forgetPeer(m.peerId);
@@ -343,8 +346,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         // and clean up transport state, regardless of local role.
         final current = state;
         if (isClosed || current is! SessionRoom) return;
-        final updated =
-            current.roster.where((p) => p.peerId != m.target).toList();
+        final updated = current.roster
+            .where((p) => p.peerId != m.target)
+            .toList();
         emit(current.copyWith(roster: updated));
         _transport?.forgetPeer(m.target);
         _heartbeats.forgetPeer(m.target);
@@ -374,10 +378,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         if (m.newHostPeerId == _localPeerId) {
           unawaited(_promoteToHost(m.sessionUuid));
         } else {
-          emit(current.copyWith(
-            hostPeerId: m.newHostPeerId,
-            connectionPhase: ConnectionPhase.reconnecting,
-          ));
+          emit(
+            current.copyWith(
+              hostPeerId: m.newHostPeerId,
+              connectionPhase: ConnectionPhase.reconnecting,
+            ),
+          );
         }
       // These message types are handled by future issues
       // (voice-activity detection, join request flow). Silently drop.
@@ -420,9 +426,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       if (neighborId == current.hostPeerId) continue;
       final displayName = namesByPeerId[neighborId];
       if (displayName == null) continue;
-      _weakSignalEventsController.add(
-        (peerId: neighborId, displayName: displayName),
-      );
+      _weakSignalEventsController.add((
+        peerId: neighborId,
+        displayName: displayName,
+      ));
     }
   }
 
@@ -473,7 +480,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       try {
         peerId = await identityStore.getPeerId();
       } catch (error, stackTrace) {
-        if (kDebugMode) debugPrint('Failed to resolve peer id for signal report: $error');
+        if (kDebugMode) {
+          debugPrint('Failed to resolve peer id for signal report: $error');
+        }
         if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
         _seq++;
         return;
@@ -580,7 +589,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           peerId = await identityStore.getPeerId();
           _localPeerId = peerId;
         } catch (error, stackTrace) {
-          if (kDebugMode) debugPrint('Failed to resolve peer id for link quality: $error');
+          if (kDebugMode) {
+            debugPrint('Failed to resolve peer id for link quality: $error');
+          }
           if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
           return;
         }
@@ -702,7 +713,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         hostPeerId = await identityStore.getPeerId();
         _localPeerId = hostPeerId;
       } catch (error, stackTrace) {
-        if (kDebugMode) debugPrint('Failed to resolve peer id for bitrate hint: $error');
+        if (kDebugMode) {
+          debugPrint('Failed to resolve peer id for bitrate hint: $error');
+        }
         if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
         return;
       }
@@ -756,7 +769,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       try {
         peerId = await identityStore.getPeerId();
       } catch (error, stackTrace) {
-        if (kDebugMode) debugPrint('Failed to resolve peer id for heartbeat: $error');
+        if (kDebugMode) {
+          debugPrint('Failed to resolve peer id for heartbeat: $error');
+        }
         if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
         _seq++;
         return;
@@ -807,8 +822,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // production (we never receive our own messages back through the
       // wire), but the guard is cheap and removes the failure mode.
       if (peerId == current.hostPeerId) return;
-      final updated =
-          current.roster.where((p) => p.peerId != peerId).toList();
+      final updated = current.roster.where((p) => p.peerId != peerId).toList();
       if (updated.length == current.roster.length) return;
       emit(current.copyWith(roster: updated));
       _transport?.forgetPeer(peerId);
@@ -846,7 +860,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     try {
       peerId = await identityStore.getPeerId();
     } catch (error, stackTrace) {
-      if (kDebugMode) debugPrint('Failed to resolve peer id for roster update: $error');
+      if (kDebugMode) {
+        debugPrint('Failed to resolve peer id for roster update: $error');
+      }
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
       return;
     }
@@ -875,7 +891,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     try {
       peerId = _localPeerId ?? await identityStore.getPeerId();
     } catch (error, stackTrace) {
-      if (kDebugMode) debugPrint('Failed to resolve peerId for host transfer: $error');
+      if (kDebugMode) {
+        debugPrint('Failed to resolve peerId for host transfer: $error');
+      }
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
       return;
     }
@@ -929,25 +947,31 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         .where((p) => p.peerId != current.hostPeerId)
         .toList();
     if (!roster.any((p) => p.peerId == localPeerId)) {
-      roster.add(ProtocolPeer(peerId: localPeerId, displayName: current.myName));
+      roster.add(
+        ProtocolPeer(peerId: localPeerId, displayName: current.myName),
+      );
     }
     _sessionUuid = sessionUuid;
     _localPeerId = localPeerId;
-    emit(current.copyWith(
-      roomIsHost: true,
-      hostPeerId: localPeerId,
-      roster: roster,
-      macAddress: null,
-      sessionUuidLow8: null,
-      connectionPhase: ConnectionPhase.online,
-    ));
+    emit(
+      current.copyWith(
+        roomIsHost: true,
+        hostPeerId: localPeerId,
+        roster: roster,
+        macAddress: null,
+        sessionUuidLow8: null,
+        connectionPhase: ConnectionPhase.online,
+      ),
+    );
     // Start host BLE surfaces so remaining guests can reconnect.
     final audio = _audio;
     if (audio != null) {
-      unawaited(audio.startAdvertising(
-        sessionUuid: sessionUuid,
-        displayName: current.myName,
-      ));
+      unawaited(
+        audio.startAdvertising(
+          sessionUuid: sessionUuid,
+          displayName: current.myName,
+        ),
+      );
       unawaited(audio.startGattServer());
     }
   }
@@ -994,11 +1018,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // `catchError` swallows transport-level failures (e.g. a write that
     // throws on a closing GATT link) so an unawaited reject doesn't
     // bubble to the unhandled-async-error handler.
-    unawaited(t.send(msg).catchError((Object error, StackTrace stackTrace) {
-      if (kDebugMode) debugPrint('TalkingState send failed: $error');
-      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
-      return false;
-    }));
+    unawaited(
+      t.send(msg).catchError((Object error, StackTrace stackTrace) {
+        if (kDebugMode) debugPrint('TalkingState send failed: $error');
+        if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+        return false;
+      }),
+    );
   }
 
   /// Persists [name] and advances to Discovery. The state changes even if
@@ -1013,10 +1039,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
-    emit(SessionDiscovery(
-      myName: name,
-      recentHostedFrequencies: recent,
-    ));
+    emit(SessionDiscovery(myName: name, recentHostedFrequencies: recent));
   }
 
   /// Persists the new [name] without changing the current stage. Same
@@ -1038,10 +1061,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         // Preserve the loaded recent-frequencies list across renames —
         // re-reading would be a wasted disk hit and would briefly flicker
         // the Recent section if persistence is slow.
-        emit(SessionDiscovery(
-          myName: name,
-          recentHostedFrequencies: discovery.recentHostedFrequencies,
-        ));
+        emit(
+          SessionDiscovery(
+            myName: name,
+            recentHostedFrequencies: discovery.recentHostedFrequencies,
+          ),
+        );
       case final SessionRoom room:
         emit(room.copyWith(myName: name));
       case SessionBooting():
@@ -1126,7 +1151,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           hostPeerId = await identityStore.getPeerId();
           _localPeerId = hostPeerId;
         } catch (error, stackTrace) {
-          if (kDebugMode) debugPrint('Failed to load peerId for host bootstrap: $error');
+          if (kDebugMode) {
+            debugPrint('Failed to load peerId for host bootstrap: $error');
+          }
           if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
           return;
         }
@@ -1172,15 +1199,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // happens in [leaveRoom] and [close].
       final audio = _audio;
       if (audio != null) {
-        unawaited(audio.startAdvertising(
-          sessionUuid: sessionUuid,
-          displayName: myName,
-        ));
+        unawaited(
+          audio.startAdvertising(sessionUuid: sessionUuid, displayName: myName),
+        );
         unawaited(audio.startGattServer());
       }
     } else {
       if (freq == null) {
-        if (kDebugMode) debugPrint('joinRoom guest path requires a freq; refusing to enter the room.');
+        if (kDebugMode) {
+          debugPrint(
+            'joinRoom guest path requires a freq; refusing to enter the room.',
+          );
+        }
         return;
       }
       room = SessionRoom(
@@ -1212,17 +1242,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // skipped when audio or transport is absent, same rationale as the
     // heartbeat skip above.
     if (!isHost && _transport != null && _audio != null) {
-      _signalReporter.start(
-        onTick: () => unawaited(_sendSignalReport()),
-      );
+      _signalReporter.start(onTick: () => unawaited(_sendSignalReport()));
       // Begin the link-quality plane on the guest side. Same gating as
       // the signal reporter — needs a transport to write to and an
       // audio service to poll telemetry from. The host doesn't run the
       // reporter (it consumes incoming `LinkQuality` reports instead;
       // see [_onLinkQuality]).
-      _linkQualityReporter.start(
-        onTick: () => unawaited(_sendLinkQuality()),
-      );
+      _linkQualityReporter.start(onTick: () => unawaited(_sendLinkQuality()));
     }
   }
 
@@ -1296,10 +1322,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _sessionUuid = null;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
-    emit(SessionDiscovery(
-      myName: current.myName,
-      recentHostedFrequencies: recent,
-    ));
+    emit(
+      SessionDiscovery(myName: current.myName, recentHostedFrequencies: recent),
+    );
   }
 
   /// Reacts to a [PermissionWatcher] emission. Three cases:
@@ -1345,10 +1370,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Already showing the denied screen — just refresh the missing list
     // (e.g. mic was re-granted but bluetooth still off).
     if (current is SessionPermissionDenied) {
-      emit(SessionPermissionDenied(
-        missing: missing,
-        myName: current.myName,
-      ));
+      emit(SessionPermissionDenied(missing: missing, myName: current.myName));
       return;
     }
     // Discovery or Room — tear down audio/BLE and surface the denied screen.
@@ -1426,10 +1448,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
     if (!identical(state, current)) return;
-    emit(SessionDiscovery(
-      myName: myName,
-      recentHostedFrequencies: recent,
-    ));
+    emit(SessionDiscovery(myName: myName, recentHostedFrequencies: recent));
   }
 
   /// Asks the [PermissionWatcher] to re-sample now. Wired to the "Retry"
@@ -1489,10 +1508,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     final latest = state;
     if (latest is! SessionDiscovery) return;
-    emit(SessionDiscovery(
-      myName: latest.myName,
-      recentHostedFrequencies: refreshed,
-    ));
+    emit(
+      SessionDiscovery(
+        myName: latest.myName,
+        recentHostedFrequencies: refreshed,
+      ),
+    );
   }
 
   /// Removes [freq] from the persisted recents, then re-emits
@@ -1511,10 +1532,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     final latest = state;
     if (latest is! SessionDiscovery) return;
-    emit(SessionDiscovery(
-      myName: latest.myName,
-      recentHostedFrequencies: refreshed,
-    ));
+    emit(
+      SessionDiscovery(
+        myName: latest.myName,
+        recentHostedFrequencies: refreshed,
+      ),
+    );
   }
 
   /// Pins or unpins [freq] in the persisted recents, then re-emits
@@ -1534,10 +1557,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     if (isClosed) return;
     final latest = state;
     if (latest is! SessionDiscovery) return;
-    emit(SessionDiscovery(
-      myName: latest.myName,
-      recentHostedFrequencies: refreshed,
-    ));
+    emit(
+      SessionDiscovery(
+        myName: latest.myName,
+        recentHostedFrequencies: refreshed,
+      ),
+    );
   }
 
   /// Apply a `JoinAccepted` from the host. Replaces the room's snapshot
@@ -1560,12 +1585,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _reconnectController = null;
     _joinAcceptedWatchdog?.cancel();
     _joinAcceptedWatchdog = null;
-    emit(current.copyWith(
-      hostPeerId: msg.hostPeerId,
-      roster: msg.roster,
-      mediaState: msg.mediaState,
-      connectionPhase: ConnectionPhase.online,
-    ));
+    emit(
+      current.copyWith(
+        hostPeerId: msg.hostPeerId,
+        roster: msg.roster,
+        mediaState: msg.mediaState,
+        connectionPhase: ConnectionPhase.online,
+      ),
+    );
   }
 
   /// Called by heartbeat detection when the guest hasn't heard from the host
@@ -1663,7 +1690,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // Callers from the room screen fire-and-forget, so an exception
       // here would surface as an unhandled async error. Log and bail —
       // the user re-tapping is a fine recovery path.
-      if (kDebugMode) debugPrint('Failed to resolve peer id for media command: $error');
+      if (kDebugMode) {
+        debugPrint('Failed to resolve peer id for media command: $error');
+      }
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
       return;
     }
@@ -1733,7 +1762,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     try {
       peerId = await identityStore.getPeerId();
     } catch (error, stackTrace) {
-      if (kDebugMode) debugPrint('Failed to resolve peer id for mute broadcast: $error');
+      if (kDebugMode) {
+        debugPrint('Failed to resolve peer id for mute broadcast: $error');
+      }
       if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
       _seq++;
       return;

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -61,6 +61,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
 
   bool _meMuted = false;
   bool _holdingPtt = false;
+
   /// Per-peer playback volume, keyed by peerId. Populated lazily —
   /// only entries the user has explicitly adjusted exist; everything
   /// else reads through [_volumeFor] which falls back to
@@ -70,6 +71,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   final Map<String, double> _volumes = {};
   static const double _kDefaultPeerVolume = 0.7;
   double _volumeFor(String peerId) => _volumes[peerId] ?? _kDefaultPeerVolume;
+
   /// Mirrors the contents of [BlockedPeersStore] for the lifetime of
   /// this screen. Hydrated on initState (asynchronously — until the
   /// first read resolves the set is empty, which means a freshly-joined
@@ -85,8 +87,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   Timer? _progressTimer;
   StreamSubscription<MediaCommand>? _mediaSub;
   StreamSubscription<Map<String, dynamic>>? _audioEventsSub;
-  StreamSubscription<({String peerId, String displayName})>?
-      _weakSignalSub;
+  StreamSubscription<({String peerId, String displayName})>? _weakSignalSub;
 
   /// Local peer's stable id, resolved once asynchronously from the
   /// identity store. Until it lands, originator-vs-remote attribution
@@ -133,7 +134,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   void initState() {
     super.initState();
     final firstName = widget.myName.isEmpty ? 'You' : widget.myName;
-    final initials = (firstName.length >= 2 ? firstName.substring(0, 2) : firstName).toUpperCase();
+    final initials =
+        (firstName.length >= 2 ? firstName.substring(0, 2) : firstName)
+            .toUpperCase();
     _me = Person(
       id: 'me',
       name: firstName,
@@ -147,7 +150,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     );
     _meMuted = widget.pttMode;
 
-    _source = widget.mediaKind == MediaKind.podcast ? 'Podcasts' : 'YouTube Music';
+    _source = widget.mediaKind == MediaKind.podcast
+        ? 'Podcasts'
+        : 'YouTube Music';
     _lib = emptyMediaLib;
     _lastAction = const _LastAction(by: '', action: '', when: '');
 
@@ -193,7 +198,11 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       // device when _output is bluetooth), keep the UI selection but log it.
       final routed = await _audio.setAudioOutput(_output.name);
       if (!routed) {
-        if (kDebugMode) debugPrint('Failed to route to ${_output.name}, device may be unavailable');
+        if (kDebugMode) {
+          debugPrint(
+            'Failed to route to ${_output.name}, device may be unavailable',
+          );
+        }
       }
     }());
 
@@ -221,14 +230,18 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
               final btNameFromEvent = event['btName'] as String?;
               if (btNameFromEvent != null && btNameFromEvent.isNotEmpty) {
                 _me = Person(
-                  id: _me.id, name: _me.name,
-                  initials: _me.initials, hue: _me.hue,
+                  id: _me.id,
+                  name: _me.name,
+                  initials: _me.initials,
+                  hue: _me.hue,
                   btDevice: btNameFromEvent,
                 );
               } else if (_me.btDevice.isEmpty) {
                 _me = Person(
-                  id: _me.id, name: _me.name,
-                  initials: _me.initials, hue: _me.hue,
+                  id: _me.id,
+                  name: _me.name,
+                  initials: _me.initials,
+                  hue: _me.hue,
                   btDevice: 'Bluetooth',
                 );
               }
@@ -237,8 +250,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
               // switched by the system). Clear btDevice so the BT row in
               // the output picker is shown as disabled.
               _me = Person(
-                id: _me.id, name: _me.name,
-                initials: _me.initials, hue: _me.hue,
+                id: _me.id,
+                name: _me.name,
+                initials: _me.initials,
+                hue: _me.hue,
                 btDevice: '',
               );
             }
@@ -301,7 +316,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // production case). Skip the extra identity-store round-trip entirely.
     if (_myPeerId != null) return;
     try {
-      final peerId = await context.read<FrequencySessionCubit>().identityStore.getPeerId();
+      final peerId = await context
+          .read<FrequencySessionCubit>()
+          .identityStore
+          .getPeerId();
       if (!mounted) return;
       // setState triggers a re-render so the roster filter uses the
       // resolved id (only reached when bootstrap hadn't completed yet).
@@ -371,8 +389,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     int positionSec = 0,
   }) {
     final clampedIdx = trackIdx < 0 ? 0 : trackIdx;
-    final placeholderDurationSec =
-        positionSec * 2 < 60 ? 60 : positionSec * 2;
+    final placeholderDurationSec = positionSec * 2 < 60 ? 60 : positionSec * 2;
     // Use the human-readable display label for MediaSourceLib.name so UI
     // surfaces ("From Spotify", "Open Spotify") are user-facing rather than
     // showing raw wire keys like "spotify" or "pocket_casts". Unknown future
@@ -445,7 +462,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       // PTT ⇒ muted-until-held), so the engine needs the new state.
       final effectiveMuted = _meEffectivelyMuted;
       unawaited(_audio.setMuted(effectiveMuted));
-      unawaited(context.read<FrequencySessionCubit>().broadcastMute(effectiveMuted));
+      unawaited(
+        context.read<FrequencySessionCubit>().broadcastMute(effectiveMuted),
+      );
     }
   }
 
@@ -465,12 +484,14 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   /// production match without duplicating the spec.
   void _onWeakSignal(({String peerId, String displayName}) e) {
     if (!mounted) return;
-    FrequencyToastHost.of(context).push(FrequencyToastSpec(
-      tone: ToastTone.warn,
-      title: "${e.displayName}'s signal is weak",
-      description: 'Ask them to move closer',
-      autoDismiss: const Duration(milliseconds: 3600),
-    ));
+    FrequencyToastHost.of(context).push(
+      FrequencyToastSpec(
+        tone: ToastTone.warn,
+        title: "${e.displayName}'s signal is weak",
+        description: 'Ask them to move closer',
+        autoDismiss: const Duration(milliseconds: 3600),
+      ),
+    );
   }
 
   /// Open-mic mute toggle. Updates the local UI state and pushes the new
@@ -499,31 +520,52 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       switch (cmd.op) {
         case MediaOp.play:
           _playing = true;
-          _lastAction = _LastAction(by: senderName, action: 'resumed', when: 'just now');
+          _lastAction = _LastAction(
+            by: senderName,
+            action: 'resumed',
+            when: 'just now',
+          );
           break;
         case MediaOp.pause:
           _playing = false;
-          _lastAction = _LastAction(by: senderName, action: 'paused', when: 'just now');
+          _lastAction = _LastAction(
+            by: senderName,
+            action: 'paused',
+            when: 'just now',
+          );
           break;
         case MediaOp.skip:
           _trackIdx = (_trackIdx + 1) % _lib.queue.length;
           _progress = 0;
-          _lastAction = _LastAction(by: senderName, action: 'skipped', when: 'just now');
+          _lastAction = _LastAction(
+            by: senderName,
+            action: 'skipped',
+            when: 'just now',
+          );
           break;
         case MediaOp.prev:
           _trackIdx = (_trackIdx - 1 + _lib.queue.length) % _lib.queue.length;
           _progress = 0;
-          _lastAction = _LastAction(by: senderName, action: 'went back', when: 'just now');
+          _lastAction = _LastAction(
+            by: senderName,
+            action: 'went back',
+            when: 'just now',
+          );
           break;
         case MediaOp.seek:
           if (cmd.positionMs != null) {
             // Anchor scrub seeks to peer clocks
             final deltaMs = DateTime.now().millisecondsSinceEpoch - cmd.atMs;
             final effectiveMs = cmd.positionMs! + (deltaMs > 0 ? deltaMs : 0);
-            _progress = (effectiveMs / 1000)
-                .round()
-                .clamp(0, _track.durationSeconds);
-            _lastAction = _LastAction(by: senderName, action: 'scrubbed', when: 'just now');
+            _progress = (effectiveMs / 1000).round().clamp(
+              0,
+              _track.durationSeconds,
+            );
+            _lastAction = _LastAction(
+              by: senderName,
+              action: 'scrubbed',
+              when: 'just now',
+            );
           }
           break;
         case MediaOp.queuePlay:
@@ -535,12 +577,19 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
             // trackIdx exceeds the current queue length (Copilot review #153).
             if (nextSource != _source || nextIdx >= _lib.queue.length) {
               _source = nextSource;
-              _lib = _buildPlaceholderLib(source: nextSource, trackIdx: nextIdx);
+              _lib = _buildPlaceholderLib(
+                source: nextSource,
+                trackIdx: nextIdx,
+              );
             }
             _trackIdx = nextIdx;
             _progress = 0;
             _playing = true;
-            _lastAction = _LastAction(by: senderName, action: 'queued up track', when: 'just now');
+            _lastAction = _LastAction(
+              by: senderName,
+              action: 'queued up track',
+              when: 'just now',
+            );
           }
           break;
       }
@@ -618,10 +667,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   /// the same color across sessions.
   Person _protocolPeerToPerson(ProtocolPeer peer) {
     final displayName = peer.displayName.isEmpty ? 'Unknown' : peer.displayName;
-    final initials = (displayName.length >= 2
-            ? displayName.substring(0, 2)
-            : displayName)
-        .toUpperCase();
+    final initials =
+        (displayName.length >= 2 ? displayName.substring(0, 2) : displayName)
+            .toUpperCase();
     final hue = (peer.peerId.hashCode % 360).toDouble();
     return Person(
       id: peer.peerId,
@@ -688,7 +736,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                     NowPlayingCard(
                       track: _track,
                       source: source,
-                      isPodcast: MediaSourceExtension.fromWireKey(_source).isPodcast,
+                      isPodcast: MediaSourceExtension.fromWireKey(
+                        _source,
+                      ).isPodcast,
                       playing: _playing,
                       progress: _progress,
                       lastActionBy: _lastAction.by,
@@ -763,7 +813,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                                         key: ValueKey(peers[i].id),
                                         person: peers[i],
                                         first: i == 0,
-                                        talking: talkingIds.contains(peers[i].id) && !_peerMuted.contains(peers[i].id),
+                                        talking:
+                                            talkingIds.contains(peers[i].id) &&
+                                            !_peerMuted.contains(peers[i].id),
                                         muted: _peerMuted.contains(peers[i].id),
                                         volume: _volumeFor(peers[i].id),
                                         onTap: () => _showPeerDrawer(peers[i]),
@@ -781,7 +833,11 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                         widget.pttMode
                             ? 'Push-to-talk · hold the mic button to transmit'
                             : 'Open mic · everyone hears you when not muted',
-                        style: TextStyle(fontFamily: 'Inter', fontSize: 11, color: c.ink3),
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 11,
+                          color: c.ink3,
+                        ),
                       ),
                     ),
                   ],
@@ -864,13 +920,19 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                   ),
                 ),
                 if (phase == ConnectionPhase.online) ...[
-                  Text(' · ', style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 11,
-                    color: pillText,
-                    fontWeight: FontWeight.w500,
-                  )),
-                  Text(widget.freq, style: kMonoStyle.copyWith(fontSize: 11, color: pillText)),
+                  Text(
+                    ' · ',
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 11,
+                      color: pillText,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  Text(
+                    widget.freq,
+                    style: kMonoStyle.copyWith(fontSize: 11, color: pillText),
+                  ),
                 ],
               ],
             ),
@@ -932,7 +994,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                     const SizedBox(width: 4),
                     Flexible(
                       child: Text(
-                        _output == AudioOutput.bluetooth && _me.btDevice.isNotEmpty
+                        _output == AudioOutput.bluetooth &&
+                                _me.btDevice.isNotEmpty
                             ? _me.btDevice
                             : _output.label,
                         overflow: TextOverflow.ellipsis,
@@ -949,10 +1012,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
             ),
           ),
           if (widget.pttMode)
-            PushToTalkButton(
-              holding: _holdingPtt,
-              onChange: _setPttHolding,
-            )
+            PushToTalkButton(holding: _holdingPtt, onChange: _setPttHolding)
           else
             SizedBox(
               width: 102,
@@ -967,7 +1027,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                 child: FreqButton(
                   icon: _meMuted ? Icons.mic_off : Icons.mic,
                   label: _meMuted ? 'Unmute' : 'Mute',
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
                   fontSize: 13,
                   labelColor: _meMuted ? c.danger : null,
                   onPressed: () => _setOpenMicMuted(!_meMuted),
@@ -1018,10 +1081,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
               _removed.add(person.id);
             });
             Navigator.pop(ctx);
-            FrequencyToastHost.of(context).push(FrequencyToastSpec(
-              tone: ToastTone.leave,
-              title: '${person.name} was removed',
-            ));
+            FrequencyToastHost.of(context).push(
+              FrequencyToastSpec(
+                tone: ToastTone.leave,
+                title: '${person.name} was removed',
+              ),
+            );
           },
           onReport: () => _reportPeer(ctx, person),
         );
@@ -1064,23 +1129,22 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     if (!mounted) return;
 
     if (blocked) {
-      FrequencyToastHost.of(context).push(FrequencyToastSpec(
-        tone: ToastTone.warn,
-        title: '$safeName blocked',
-      ));
+      FrequencyToastHost.of(context).push(
+        FrequencyToastSpec(tone: ToastTone.warn, title: '$safeName blocked'),
+      );
       final report = _buildSanitizedReport(person);
       showDialog<void>(
         context: context,
-        builder: (ctx) => _ReportSentDialog(
-          peerName: safeName,
-          reportText: report,
-        ),
+        builder: (ctx) =>
+            _ReportSentDialog(peerName: safeName, reportText: report),
       );
     } else {
-      FrequencyToastHost.of(context).push(FrequencyToastSpec(
-        tone: ToastTone.warn,
-        title: 'Could not block $safeName — try again',
-      ));
+      FrequencyToastHost.of(context).push(
+        FrequencyToastSpec(
+          tone: ToastTone.warn,
+          title: 'Could not block $safeName — try again',
+        ),
+      );
     }
   }
 
@@ -1146,9 +1210,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         // Only show "Open in app" when lib.name is populated (hides button
         // before first host snapshot), source is a known wire key, and that
         // source has a canonical appUri (null for generic Podcasts).
-        onOpenInSource: widget.isHost &&
-                _lib.name.isNotEmpty &&
-                launchable?.appUri != null
+        onOpenInSource:
+            widget.isHost && _lib.name.isNotEmpty && launchable?.appUri != null
             ? () {
                 Navigator.pop(ctx);
                 _openSourceApp(launchable!);
@@ -1202,7 +1265,11 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       if (success) {
         setState(() => _output = picked);
       } else {
-        if (kDebugMode) debugPrint('Failed to route audio to $outputStr, keeping current output');
+        if (kDebugMode) {
+          debugPrint(
+            'Failed to route audio to $outputStr, keeping current output',
+          );
+        }
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -1261,7 +1328,11 @@ class _LastAction {
   final String by;
   final String action;
   final String when;
-  const _LastAction({required this.by, required this.action, required this.when});
+  const _LastAction({
+    required this.by,
+    required this.action,
+    required this.when,
+  });
 }
 
 class _ReportSentDialog extends StatefulWidget {
@@ -1347,7 +1418,3 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
     );
   }
 }
-
-
-
-

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -43,12 +43,12 @@ class LinkTelemetrySnapshot {
 
   @override
   int get hashCode => Object.hash(
-        underrunCount,
-        lateFrameCount,
-        targetDepthFrames,
-        currentDepthFrames,
-        currentBitrateBps,
-      );
+    underrunCount,
+    lateFrameCount,
+    targetDepthFrames,
+    currentDepthFrames,
+    currentBitrateBps,
+  );
 }
 
 /// Service for communicating with native Android audio layer
@@ -262,15 +262,13 @@ class AudioService {
   ///
   /// Filters audioEvents for 'talkingPeers' events and extracts the peer list.
   Stream<Set<String>> get talkingPeers {
-    return audioEvents
-        .where((e) => e['type'] == 'talkingPeers')
-        .map((e) {
-          final raw = e['peers'];
-          if (raw is List) {
-            return Set<String>.from(raw.map((p) => p.toString()));
-          }
-          return <String>{};
-        });
+    return audioEvents.where((e) => e['type'] == 'talkingPeers').map((e) {
+      final raw = e['peers'];
+      if (raw is List) {
+        return Set<String>.from(raw.map((p) => p.toString()));
+      }
+      return <String>{};
+    });
   }
 
   /// Stream of local voice activity detection events.
@@ -380,8 +378,9 @@ class AudioService {
   /// surfacing a toast (see `_onSignalReport` in `FrequencySessionCubit`).
   Future<List<({String peerId, int rssi})>> getCurrentRssi() async {
     try {
-      final result =
-          await _methodChannel.invokeMethod<List<dynamic>>('getCurrentRssi');
+      final result = await _methodChannel.invokeMethod<List<dynamic>>(
+        'getCurrentRssi',
+      );
       if (result == null) return const [];
       return result
           .map((entry) {
@@ -453,7 +452,9 @@ class AudioService {
         currentBitrateBps: values[4]!,
       );
     } catch (e) {
-      if (kDebugMode) debugPrint('Error getting link telemetry for $macAddress: $e');
+      if (kDebugMode) {
+        debugPrint('Error getting link telemetry for $macAddress: $e');
+      }
       return null;
     }
   }
@@ -532,7 +533,9 @@ class AudioService {
       });
       return result == true;
     } catch (e) {
-      if (kDebugMode) debugPrint('Error writing notification to $deviceAddress: $e');
+      if (kDebugMode) {
+        debugPrint('Error writing notification to $deviceAddress: $e');
+      }
       return false;
     }
   }
@@ -578,7 +581,9 @@ class AudioService {
   /// Safe to call when the transport is not running.
   Future<bool> stopVoiceTransport() async {
     try {
-      final result = await _methodChannel.invokeMethod<bool>('stopVoiceTransport');
+      final result = await _methodChannel.invokeMethod<bool>(
+        'stopVoiceTransport',
+      );
       return result == true;
     } catch (e) {
       if (kDebugMode) debugPrint('Error stopping voice transport: $e');
@@ -603,7 +608,9 @@ class AudioService {
           return Map<String, dynamic>.from(event as Map);
         })
         .handleError((error) {
-          if (kDebugMode) debugPrint('Control bytes event stream error: $error');
+          if (kDebugMode) {
+            debugPrint('Control bytes event stream error: $error');
+          }
           return <String, dynamic>{};
         });
     return _controlBytesStream!
@@ -661,7 +668,9 @@ class AudioService {
   /// Safe to call when not connected (the native side resolves it as a no-op).
   Future<bool> disconnectFromHost() async {
     try {
-      final result = await _methodChannel.invokeMethod<bool>('disconnectFromHost');
+      final result = await _methodChannel.invokeMethod<bool>(
+        'disconnectFromHost',
+      );
       return result == true;
     } catch (e) {
       if (kDebugMode) debugPrint('Error disconnecting from host: $e');


### PR DESCRIPTION
Closes #252

## Summary

- **Phase 2** (`#37-#45`): all issues closed, BLE control plane is functioning — mark as ✅ done
- **Phase 3** (`#46-#50`): individual building-block issues all closed, but session-level wiring (`onVoiceFrame` callbacks, `audioEngineManager.start()`) is still pending in #246 — update heading and item list to reflect this
- **Phase 4** (`#51-#57`): all issues closed — mark as ✅ done
- **Phase 5** (`#34-#36, #52`): all issues closed — mark as ✅ done

Also fixes 16 pre-existing `curly_braces_in_flow_control_structures` lint violations (in `frequency_session_cubit.dart`, `frequency_room_screen.dart`, `audio_service.dart`) that were causing `flutter analyze` to exit 1 and fail the presubmit.

## Test plan

- [x] `scripts/presubmit.sh` passes locally (validate metadata, dart format, flutter analyze — no issues, flutter test — 592 passed, all C++ tests passed)
- [x] All issue numbers verified against GitHub API before updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the development roadmap to reflect project progress. Phase 2 is now marked as complete, indicating successful delivery of previous milestones. Phase 3 status has been clarified to show foundational components are in place, with session-level integration work identified as the next priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->