### PR TITLE
feat(#248): extract VadDetector and add unit tests for VAD hysteresis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Enforce LF line endings for all text files regardless of platform.
+# Without this, Windows checkouts with core.autocrlf=true produce CRLF files
+# that cause `dart format --set-exit-if-changed` to fail in WSL/Linux CI.
+* text=auto eol=lf
+
+# Explicit binary patterns so git never attempts line-ending translation
+# on non-text assets.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.zip  binary
+*.aab  binary
+*.apk  binary
+*.so   binary
+*.a    binary
+*.jar  binary
+*.key  binary
+*.keystore binary

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -15,6 +15,7 @@
 #include "audio_mixer.h"
 #include "resampler.h"
 #include "talking_event_queue.h"
+#include "vad_detector.h"
 
 #define LOG_TAG "WalkieTalkieAudio"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
@@ -284,15 +285,8 @@ private:
 
     // Voice activity detection. RMS is computed at the playout rate so the
     // hysteresis threshold scales with the mic's actual sample count, not
-    // the codec's downsampled count.
-    static constexpr double kTalkingThreshold = 0.01;  // -40 dBFS
-    static constexpr int32_t kOnHysteresisMs = 100;
-    static constexpr int32_t kOffHysteresisMs = 300;
-    bool lastTalking = false;
-    int32_t aboveThresholdFrames = 0;
-    int32_t belowThresholdFrames = 0;
-    const int32_t onHysteresisFrames = (kSampleRate * kOnHysteresisMs) / 1000;
-    const int32_t offHysteresisFrames = (kSampleRate * kOffHysteresisMs) / 1000;
+    // the codec's downsampled count. State is owned by VadDetector.
+    VadDetector vad_{kSampleRate};
 
     // Resampler bridge between 48 kHz Oboe and the 16 kHz codec/mixer plane.
     // These are owned by the engine because their FIR history must persist
@@ -494,21 +488,8 @@ public:
         // VAD on the raw 48 kHz mic signal — pre-mute so the UI shows
         // "talking" feedback even when transmit is muted.
         const double rms = computeRms(inputData, numFrames);
-        const bool nowAboveThreshold = rms > kTalkingThreshold;
-        if (nowAboveThreshold) {
-            aboveThresholdFrames += numFrames;
-            belowThresholdFrames = 0;
-            if (!lastTalking && aboveThresholdFrames >= onHysteresisFrames) {
-                lastTalking = true;
-                emitTalkingEvent(true);
-            }
-        } else {
-            belowThresholdFrames += numFrames;
-            aboveThresholdFrames = 0;
-            if (lastTalking && belowThresholdFrames >= offHysteresisFrames) {
-                lastTalking = false;
-                emitTalkingEvent(false);
-            }
+        if (auto edge = vad_.update(rms > VadDetector::kDefaultThreshold, numFrames)) {
+            emitTalkingEvent(*edge);
         }
 
         // Mute zeros the mic signal before resampling so the wire path sees

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -376,10 +376,12 @@ public:
             return false;
         }
 
-        // Reset resampler history on every (re)start so the first samples
-        // don't carry transients from a previous session.
+        // Reset resampler history and VAD state on every (re)start so
+        // transients and stale hysteresis counts from a prior session
+        // don't carry over into the new one.
         micResampler_.reset();
         playbackResampler_.reset();
+        vad_.reset();
 
         // Bring the worker thread up before starting the streams so any
         // VAD edge from the very first callback finds a draining consumer.
@@ -488,7 +490,7 @@ public:
         // VAD on the raw 48 kHz mic signal — pre-mute so the UI shows
         // "talking" feedback even when transmit is muted.
         const double rms = computeRms(inputData, numFrames);
-        if (auto edge = vad_.update(rms > VadDetector::kDefaultThreshold, numFrames)) {
+        if (auto edge = vad_.update(rms > vad_.threshold(), numFrames)) {
             emitTalkingEvent(*edge);
         }
 

--- a/android/app/src/main/cpp/vad_detector.h
+++ b/android/app/src/main/cpp/vad_detector.h
@@ -1,0 +1,93 @@
+#ifndef VAD_DETECTOR_H
+#define VAD_DETECTOR_H
+
+#include <cstdint>
+#include <optional>
+
+// Voice-activity detector with two-sided hysteresis.
+//
+// The detector tracks "above threshold" and "below threshold" frame counts
+// and emits rising/falling edges only after the configured hold-off windows
+// have elapsed. This prevents rapid UI flicker at threshold boundaries.
+//
+// Typical usage (48 kHz, one Oboe callback per call):
+//
+//   VadDetector vad(48000);
+//   if (auto edge = vad.update(rms > kThreshold, numFrames)) {
+//       emitTalkingEvent(*edge);  // true = started talking, false = stopped
+//   }
+//
+// Thread safety: not thread-safe; must be called from a single audio thread.
+struct VadDetector {
+    // Default RMS threshold (-40 dBFS). Scales against normalised int16
+    // samples (divided by 32768).
+    static constexpr double kDefaultThreshold = 0.01;
+
+    // Hysteresis windows matching the original inline constants in
+    // audio_engine.cpp. Rise (on) is intentionally shorter than fall (off) so
+    // the UI responds quickly to speech but does not chatter on breath-pauses.
+    static constexpr int32_t kOnHysteresisMs  = 100;
+    static constexpr int32_t kOffHysteresisMs = 300;
+
+    // `sampleRate` is the rate of the audio stream feeding this detector
+    // (typically 48000 for Oboe). `threshold` is the RMS level above which
+    // a frame is considered "loud".
+    explicit VadDetector(int32_t sampleRate,
+                         double threshold = kDefaultThreshold)
+        : sampleRate_(sampleRate),
+          threshold_(threshold),
+          onFrames_((sampleRate * kOnHysteresisMs) / 1000),
+          offFrames_((sampleRate * kOffHysteresisMs) / 1000) {}
+
+    // Feed one audio callback's worth of signal. `aboveThreshold` is true
+    // when the RMS of this burst exceeds the threshold; `numFrames` is the
+    // sample count of the burst.
+    //
+    // Returns the new talking state if a VAD edge was crossed, or nullopt if
+    // the state did not change this burst.
+    std::optional<bool> update(bool aboveThreshold, int32_t numFrames) {
+        if (aboveThreshold) {
+            aboveFrames_ += numFrames;
+            belowFrames_ = 0;
+            if (!talking_ && aboveFrames_ >= onFrames_) {
+                talking_ = true;
+                return true;
+            }
+        } else {
+            belowFrames_ += numFrames;
+            aboveFrames_ = 0;
+            if (talking_ && belowFrames_ >= offFrames_) {
+                talking_ = false;
+                return false;
+            }
+        }
+        return std::nullopt;
+    }
+
+    // Current talking state (true after a rising edge, false after a falling
+    // edge or before the first rising edge).
+    bool talking() const { return talking_; }
+
+    // Returns the RMS threshold this detector was constructed with.
+    double threshold() const { return threshold_; }
+
+    // Reset state to silent as if the detector were freshly constructed.
+    // Useful for engine restarts so stale hysteresis counts do not carry over.
+    void reset() {
+        talking_     = false;
+        aboveFrames_ = 0;
+        belowFrames_ = 0;
+    }
+
+private:
+    const int32_t sampleRate_;
+    const double  threshold_;
+    const int32_t onFrames_;   // frames of above-threshold signal to confirm talking
+    const int32_t offFrames_;  // frames of below-threshold signal to confirm silence
+
+    bool    talking_     = false;
+    int32_t aboveFrames_ = 0;
+    int32_t belowFrames_ = 0;
+};
+
+#endif  // VAD_DETECTOR_H

--- a/android/app/src/main/cpp/vad_detector.h
+++ b/android/app/src/main/cpp/vad_detector.h
@@ -1,6 +1,7 @@
 #ifndef VAD_DETECTOR_H
 #define VAD_DETECTOR_H
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 
@@ -47,14 +48,17 @@ struct VadDetector {
     // the state did not change this burst.
     std::optional<bool> update(bool aboveThreshold, int32_t numFrames) {
         if (aboveThreshold) {
-            aboveFrames_ += numFrames;
+            // Clamp at onFrames_ so the counter never overflows int32_t on a
+            // long above-threshold run (overflow horizon: ~12 h at 48 kHz).
+            aboveFrames_ = std::min(aboveFrames_ + numFrames, onFrames_);
             belowFrames_ = 0;
             if (!talking_ && aboveFrames_ >= onFrames_) {
                 talking_ = true;
                 return true;
             }
         } else {
-            belowFrames_ += numFrames;
+            // Symmetric clamp for the off-hysteresis window.
+            belowFrames_ = std::min(belowFrames_ + numFrames, offFrames_);
             aboveFrames_ = 0;
             if (talking_ && belowFrames_ >= offFrames_) {
                 talking_ = false;

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -27,11 +27,13 @@ for required in \
     test/cpp/talking_event_queue_test.cpp \
     test/cpp/ring_buffer_test.cpp \
     test/cpp/opus_codec_test.cpp \
+    test/cpp/vad_detector_test.cpp \
     android/app/src/main/cpp/audio_mixer.cpp \
     android/app/src/main/cpp/talking_event_queue.h \
     android/app/src/main/cpp/ring_buffer.h \
     android/app/src/main/cpp/opus_codec.h \
-    android/app/src/main/cpp/opus_codec.cpp; do
+    android/app/src/main/cpp/opus_codec.cpp \
+    android/app/src/main/cpp/vad_detector.h; do
   if [ ! -f "$required" ]; then
     echo "$required missing — failing fast"
     exit 1
@@ -82,6 +84,15 @@ ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
     test/cpp/ring_buffer_test.cpp \
     -o build/cpp_test/ring_buffer_test
 build/cpp_test/ring_buffer_test
+
+# vad_detector_test exercises the two-sided hysteresis state machine extracted
+# from audio_engine.cpp. Header-only; no extra link deps beyond the STL.
+${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+    -I test/cpp \
+    -I android/app/src/main/cpp \
+    test/cpp/vad_detector_test.cpp \
+    -o build/cpp_test/vad_detector_test
+build/cpp_test/vad_detector_test
 
 # opus_codec_test exercises OpusEncoder/OpusDecoder from opus_codec.cpp.
 # Requires libopus and pkg-config. Without an explicit preflight, a missing

--- a/test/cpp/vad_detector_test.cpp
+++ b/test/cpp/vad_detector_test.cpp
@@ -1,0 +1,233 @@
+// Unit tests for VadDetector — the two-sided VAD hysteresis state machine
+// extracted from audio_engine.cpp.
+//
+// All tests run at 48 kHz with the default constants:
+//   - on  hysteresis: 100 ms = 4800 frames @ 48 kHz
+//   - off hysteresis: 300 ms = 14400 frames @ 48 kHz
+//
+// Tests exercise the acceptance criteria from issue #248:
+//   - Talking state is entered only after the on-hysteresis window.
+//   - Silence state is entered only after the off-hysteresis window.
+//   - Hysteresis does not flicker at threshold edges (brief blips are absorbed).
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <optional>
+
+#include "../../android/app/src/main/cpp/vad_detector.h"
+
+static constexpr int32_t kRate      = 48000;
+static constexpr int32_t kFrameSize = 960;  // 20 ms @ 48 kHz
+
+// Feed `durationMs` of above-threshold signal in kFrameSize bursts.
+// Returns the total number of VAD edges emitted.
+static int feedAbove(VadDetector& vad, int32_t durationMs) {
+    int edges = 0;
+    const int32_t totalFrames = (kRate * durationMs) / 1000;
+    for (int32_t fed = 0; fed < totalFrames; fed += kFrameSize) {
+        const int32_t n = std::min(kFrameSize, totalFrames - fed);
+        if (vad.update(true, n)) ++edges;
+    }
+    return edges;
+}
+
+// Feed `durationMs` of below-threshold signal in kFrameSize bursts.
+// Returns the total number of VAD edges emitted.
+static int feedBelow(VadDetector& vad, int32_t durationMs) {
+    int edges = 0;
+    const int32_t totalFrames = (kRate * durationMs) / 1000;
+    for (int32_t fed = 0; fed < totalFrames; fed += kFrameSize) {
+        const int32_t n = std::min(kFrameSize, totalFrames - fed);
+        if (vad.update(false, n)) ++edges;
+    }
+    return edges;
+}
+
+// ── On-hysteresis: rising edge fires only after 100 ms ──────────────────────
+
+// 80 ms of above-threshold is not enough to trigger talking.
+void testOnHysteresisUnder() {
+    VadDetector vad(kRate);
+    const int edges = feedAbove(vad, 80);
+    assert(!vad.talking());
+    assert(edges == 0);
+    std::cout << "testOnHysteresisUnder: PASSED" << std::endl;
+}
+
+// Exactly 100 ms triggers exactly one rising edge.
+void testOnHysteresisExact() {
+    VadDetector vad(kRate);
+    const int edges = feedAbove(vad, 100);
+    assert(vad.talking());
+    assert(edges == 1);
+    std::cout << "testOnHysteresisExact: PASSED" << std::endl;
+}
+
+// A brief dip resets the above-threshold accumulator — anti-flicker.
+// 80 ms above + 20 ms below + 80 ms above must not trigger talking.
+void testOnHysteresisResetByDip() {
+    VadDetector vad(kRate);
+    feedAbove(vad, 80);
+    assert(!vad.talking());
+    feedBelow(vad, 20);   // resets above-threshold accumulator
+    const int edges = feedAbove(vad, 80);
+    // Only 80 ms accumulated since the dip — still below the 100 ms window.
+    assert(!vad.talking());
+    assert(edges == 0);
+    std::cout << "testOnHysteresisResetByDip: PASSED" << std::endl;
+}
+
+// ── Off-hysteresis: falling edge fires only after 300 ms ────────────────────
+
+// After talking starts, 200 ms of silence is not enough to stop it.
+void testOffHysteresisUnder() {
+    VadDetector vad(kRate);
+    feedAbove(vad, 100);  // start talking
+    assert(vad.talking());
+    const int edges = feedBelow(vad, 200);
+    assert(vad.talking());
+    assert(edges == 0);
+    std::cout << "testOffHysteresisUnder: PASSED" << std::endl;
+}
+
+// Exactly 300 ms of silence after talking starts triggers exactly one falling edge.
+void testOffHysteresisExact() {
+    VadDetector vad(kRate);
+    feedAbove(vad, 100);  // start talking
+    const int edges = feedBelow(vad, 300);
+    assert(!vad.talking());
+    assert(edges == 1);
+    std::cout << "testOffHysteresisExact: PASSED" << std::endl;
+}
+
+// A brief blip during silence resets the below-threshold accumulator — anti-flicker.
+// 200 ms below + 20 ms above + 200 ms below must not trigger a falling edge.
+void testOffHysteresisResetByBlip() {
+    VadDetector vad(kRate);
+    feedAbove(vad, 100);  // start talking
+    feedBelow(vad, 200);
+    assert(vad.talking());
+    feedAbove(vad, 20);   // brief blip resets below-threshold accumulator
+    const int edges = feedBelow(vad, 200);
+    assert(vad.talking());
+    assert(edges == 0);
+    std::cout << "testOffHysteresisResetByBlip: PASSED" << std::endl;
+}
+
+// ── Full cycle ───────────────────────────────────────────────────────────────
+
+// Start silent → talk → stop → talk again. Each cycle must produce exactly
+// one rising and one falling edge.
+void testFullTalkSilenceCycle() {
+    VadDetector vad(kRate);
+    assert(!vad.talking());
+
+    int e = feedAbove(vad, 100);
+    assert(e == 1 && vad.talking());
+
+    e = feedBelow(vad, 300);
+    assert(e == 1 && !vad.talking());
+
+    // Second talk cycle.
+    e = feedAbove(vad, 100);
+    assert(e == 1 && vad.talking());
+
+    e = feedBelow(vad, 300);
+    assert(e == 1 && !vad.talking());
+
+    std::cout << "testFullTalkSilenceCycle: PASSED" << std::endl;
+}
+
+// ── reset() ─────────────────────────────────────────────────────────────────
+
+// reset() during accumulated-but-not-yet-triggered above-threshold signal
+// must zero the accumulator so the hysteresis window restarts from scratch.
+void testResetClearsAccumulator() {
+    VadDetector vad(kRate);
+    feedAbove(vad, 80);  // 80 ms — almost at threshold
+    assert(!vad.talking());
+    vad.reset();
+    // 80 ms more is not enough for the fresh accumulator.
+    const int edges = feedAbove(vad, 80);
+    assert(!vad.talking());
+    assert(edges == 0);
+    std::cout << "testResetClearsAccumulator: PASSED" << std::endl;
+}
+
+// reset() while talking must immediately drop talking() to false without
+// emitting a falling edge through update().
+void testResetWhileTalking() {
+    VadDetector vad(kRate);
+    feedAbove(vad, 100);
+    assert(vad.talking());
+    vad.reset();
+    assert(!vad.talking());
+    std::cout << "testResetWhileTalking: PASSED" << std::endl;
+}
+
+// ── Fine-grained frame-count boundary ───────────────────────────────────────
+
+// Feed exactly (onFrames - 1) frames, then one more: edge must fire on the
+// last call, not before. Exercises the >= boundary in the accumulator check.
+void testOnBoundaryFrameByFrame() {
+    VadDetector vad(kRate);
+    const int32_t onFrames = (kRate * VadDetector::kOnHysteresisMs) / 1000;
+
+    // Feed all but one frame.
+    std::optional<bool> edge;
+    for (int32_t i = 0; i < onFrames - 1; ++i) {
+        edge = vad.update(true, 1);
+        assert(!edge.has_value());
+    }
+    assert(!vad.talking());
+
+    // The final frame must cross the threshold.
+    edge = vad.update(true, 1);
+    assert(edge.has_value() && *edge == true);
+    assert(vad.talking());
+    std::cout << "testOnBoundaryFrameByFrame: PASSED" << std::endl;
+}
+
+// Same test for the off boundary.
+void testOffBoundaryFrameByFrame() {
+    VadDetector vad(kRate);
+    feedAbove(vad, 100);  // start talking
+    assert(vad.talking());
+
+    const int32_t offFrames = (kRate * VadDetector::kOffHysteresisMs) / 1000;
+
+    std::optional<bool> edge;
+    for (int32_t i = 0; i < offFrames - 1; ++i) {
+        edge = vad.update(false, 1);
+        assert(!edge.has_value());
+    }
+    assert(vad.talking());
+
+    edge = vad.update(false, 1);
+    assert(edge.has_value() && *edge == false);
+    assert(!vad.talking());
+    std::cout << "testOffBoundaryFrameByFrame: PASSED" << std::endl;
+}
+
+int main() {
+    try {
+        testOnHysteresisUnder();
+        testOnHysteresisExact();
+        testOnHysteresisResetByDip();
+        testOffHysteresisUnder();
+        testOffHysteresisExact();
+        testOffHysteresisResetByBlip();
+        testFullTalkSilenceCycle();
+        testResetClearsAccumulator();
+        testResetWhileTalking();
+        testOnBoundaryFrameByFrame();
+        testOffBoundaryFrameByFrame();
+        std::cout << "All VadDetector tests passed!" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "Test failed with exception: " << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/test/cpp/vad_detector_test.cpp
+++ b/test/cpp/vad_detector_test.cpp
@@ -10,6 +10,7 @@
 //   - Silence state is entered only after the off-hysteresis window.
 //   - Hysteresis does not flicker at threshold edges (brief blips are absorbed).
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <cstdio>


### PR DESCRIPTION
Closes #248

## Summary

Issue #248 identified that the VAD hysteresis state machine could not be exercised in isolation — it lived inside the private body of `AudioEngine`, which requires Oboe hardware to instantiate. This PR makes VAD testable.

- **`android/app/src/main/cpp/vad_detector.h`** (new): header-only `VadDetector` struct encapsulating the two-sided hysteresis state. The five inline member variables and twelve-line decision block from `AudioEngine` move here; callers get a single `update(aboveThreshold, numFrames)` method returning `optional<bool>` on a VAD edge.
- **`android/app/src/main/cpp/audio_engine.cpp`**: swap inline state for `VadDetector vad_{kSampleRate}` member. The VAD callback section shrinks from ~12 lines to 3.
- **`test/cpp/vad_detector_test.cpp`** (new): 11 tests exercising the acceptance criteria from #248 — on-hysteresis (100 ms), off-hysteresis (300 ms), anti-flicker (dip/blip absorbs before threshold), `reset()` semantics, and frame-by-frame boundary conditions at both thresholds.
- **`scripts/presubmit.sh`**: adds `vad_detector_test` to the required-file guard and build/run steps.
- **`.gitattributes`** (new): enforces `eol=lf` project-wide so Windows checkouts no longer produce CRLF files that fail `dart format --set-exit-if-changed` in WSL/Linux CI.

## Test plan

- [ ] `bash scripts/presubmit.sh` passes locally (all 11 `VadDetector` tests pass, plus the existing suite)
- [ ] `flutter analyze` — no new warnings
- [ ] `flutter test` — no regressions
- [ ] C++ `vad_detector_test` — all 11 tests pass (confirmed in CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced voice activity detection for more reliable, lower‑jitter voice start/stop detection.

* **Tests**
  * Added comprehensive native unit tests covering hysteresis, edge emission, reset behavior, and boundary cases for VAD.

* **Chores**
  * Enforced LF line endings and explicit binary asset classification; updated presubmit checks to include VAD native test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->