### PR TITLE
fix(docs): use relative_url so index links respect baseurl

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,10 @@ anonymised diagnostic data if enabled in Settings.
 
 ### Documentation
 
-- **[Privacy Policy]({% link privacy-policy.md %})** — what data the app processes, what is
+- **[Privacy Policy]({{ '/privacy-policy/' | relative_url }})** — what data the app processes, what is
   stored locally, and how to delete it. Required reading for the Play Store
   Data Safety form.
-- **[Wire Protocol]({% link protocol.md %})** — the on-wire format for discovery
+- **[Wire Protocol]({{ '/protocol/' | relative_url }})** — the on-wire format for discovery
   advertisements, control messages, and audio framing.
-- **[Play Store Submission Guide]({% link play-store-submission-guide.md %})** — step-by-step
+- **[Play Store Submission Guide]({{ '/play-store-submission/' | relative_url }})** — step-by-step
   checklist for completing the Google Play Store listing and publishing the app.


### PR DESCRIPTION
## Summary

- The Pages site at `https://elodinlaarz.github.io/walkie-talkie/` had body links rendering as bare `/privacy-policy/`, `/protocol/`, `/play-store-submission/` — all 404s on the project site, which is served under `/walkie-talkie/`.
- Root cause: `{% link foo.md %}` resolves to the target's `permalink` without prepending `site.baseurl`. The minima theme's header nav uses `| relative_url` (which does prepend baseurl), so nav links worked while body links did not.
- Fix: switch the three index links to `{{ '/path/' | relative_url }}`, matching the theme's pattern.

## Test plan

- [ ] Pages workflow runs on merge to `main` (gated on `docs/**`).
- [ ] After deploy: `curl -s https://elodinlaarz.github.io/walkie-talkie/ | grep -E 'href="[^"]*(privacy|protocol|play-store)'` shows `/walkie-talkie/...` paths in body links, not bare `/...`.
- [ ] Click each of the three documentation links from the home page and confirm a 200, not a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation index page with improved navigation links for easier access to privacy policy, protocol information, and Play Store submission resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->