### PR TITLE
fix(bloc): apply inbound TalkingState/MuteState to roster

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -385,14 +385,43 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
             ),
           );
         }
-      // These message types are handled by future issues
-      // (voice-activity detection, join request flow). Silently drop.
-      case TalkingState():
-      case MuteState():
+      case TalkingState m:
+        _applyPeerStateUpdate(m.peerId, talking: m.talking);
+      case MuteState m:
+        _applyPeerStateUpdate(m.peerId, muted: m.muted);
+      // JoinRequest is host-only ingress (see future host-side issue).
+      // JoinDenied is reserved for the host-rejects-guest path.
       case JoinRequest():
       case JoinDenied():
         break;
     }
+  }
+
+  /// Applies a single-peer flag mutation (mute or talking) from an inbound
+  /// [TalkingState] / [MuteState] to the live roster, then emits the updated
+  /// [SessionRoom]. No-op outside `SessionRoom`, when the named peer isn't
+  /// in the roster, or when the new flag value matches the current value
+  /// (which avoids redundant emits under flapping VAD).
+  ///
+  /// Called from [_onTransportMessage]; the protocol contract is that a
+  /// peer may broadcast its own talking/mute state and other peers reflect
+  /// it. Cross-guest visibility additionally requires the host to fan out
+  /// these messages to other guests; that fan-out is tracked separately.
+  void _applyPeerStateUpdate(
+    String peerId, {
+    bool? muted,
+    bool? talking,
+  }) {
+    final current = state;
+    if (current is! SessionRoom) return;
+    final idx = current.roster.indexWhere((p) => p.peerId == peerId);
+    if (idx < 0) return;
+    final existing = current.roster[idx];
+    final updated = existing.copyWith(muted: muted, talking: talking);
+    if (existing == updated) return;
+    final newRoster = [...current.roster];
+    newRoster[idx] = updated;
+    emit(current.copyWith(roster: newRoster));
   }
 
   /// Host-only ingress for `SignalReport`. Guests currently send

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -399,9 +399,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
 
   /// Applies a single-peer flag mutation (mute or talking) from an inbound
   /// [TalkingState] / [MuteState] to the live roster, then emits the updated
-  /// [SessionRoom]. No-op outside `SessionRoom`, when the named peer isn't
-  /// in the roster, or when the new flag value matches the current value
-  /// (which avoids redundant emits under flapping VAD).
+  /// [SessionRoom]. No-op when the cubit is closed (a late transport
+  /// callback racing shutdown), outside `SessionRoom`, when the named peer
+  /// isn't in the roster, or when the new flag value matches the current
+  /// value (which avoids redundant emits under flapping VAD).
   ///
   /// Called from [_onTransportMessage]; the protocol contract is that a
   /// peer may broadcast its own talking/mute state and other peers reflect
@@ -413,7 +414,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     bool? talking,
   }) {
     final current = state;
-    if (current is! SessionRoom) return;
+    if (isClosed || current is! SessionRoom) return;
     final idx = current.roster.indexWhere((p) => p.peerId == peerId);
     if (idx < 0) return;
     final existing = current.roster[idx];

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -2353,6 +2353,64 @@ void main() {
     );
 
     test(
+      'inbound TalkingState/MuteState arriving after close() is ignored without throwing',
+      () async {
+        // Race: a transport callback can fire after `close()` returns but
+        // before the inbox subscription is cancelled. The handler must not
+        // call `emit` on a closed cubit (would throw StateError) and must
+        // not mutate the roster post-close.
+        final t = makeTestTransport();
+        final cubit = _makeCubit(transport: t.transport);
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [
+              ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+              ProtocolPeer(peerId: 'p-guest', displayName: 'Maya'),
+            ],
+          ),
+        );
+        final preCloseRoster = (cubit.state as SessionRoom).roster;
+
+        await cubit.close();
+
+        final talking = const TalkingState(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        ).encode();
+        for (final frag in encodeFragments(talking)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        final mute = const MuteState(
+          peerId: 'p-guest',
+          seq: 2,
+          atMs: 2000,
+          muted: true,
+        ).encode();
+        for (final frag in encodeFragments(mute)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        // No emit should have run; the roster snapshot is what it was
+        // before close, and the cubit is still cleanly closed.
+        expect(cubit.isClosed, isTrue);
+        expect((cubit.state as SessionRoom).roster, equals(preCloseRoster));
+
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
       'host: peer-lost drops the peer from the roster and broadcasts RosterUpdate',
       () async {
         final t = makeTestTransport();

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -2169,6 +2169,190 @@ void main() {
     });
 
     test(
+      'inbound TalkingState flips the matching roster peer\'s talking flag',
+      () async {
+        // Host receives a guest's `TalkingState` after VAD fires on the
+        // guest. The dispatch handler must mutate the matching roster
+        // entry so the talking-ring lights up on the host's UI.
+        final t = makeTestTransport();
+        final cubit = _makeCubit(transport: t.transport);
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [
+              ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+              ProtocolPeer(peerId: 'p-guest', displayName: 'Maya'),
+            ],
+          ),
+        );
+
+        final talking = const TalkingState(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        ).encode();
+        for (final frag in encodeFragments(talking)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        var room = cubit.state as SessionRoom;
+        final guest = room.roster.firstWhere((p) => p.peerId == 'p-guest');
+        expect(guest.talking, isTrue);
+        // Host's own flag is untouched — the message named p-guest, not p-host.
+        final host = room.roster.firstWhere((p) => p.peerId == 'p-host');
+        expect(host.talking, isFalse);
+
+        // Flipping back to false must clear the flag.
+        final stopped = const TalkingState(
+          peerId: 'p-guest',
+          seq: 2,
+          atMs: 2000,
+          talking: false,
+        ).encode();
+        for (final frag in encodeFragments(stopped)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        room = cubit.state as SessionRoom;
+        expect(
+          room.roster.firstWhere((p) => p.peerId == 'p-guest').talking,
+          isFalse,
+        );
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test('inbound MuteState flips the matching roster peer\'s muted flag', () async {
+      // Same shape as the TalkingState test, for the mute path: a peer
+      // self-muting must surface on every other peer's roster so the
+      // mute icon renders correctly.
+      final t = makeTestTransport();
+      final cubit = _makeCubit(transport: t.transport);
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [
+            ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ProtocolPeer(peerId: 'p-guest', displayName: 'Maya'),
+          ],
+        ),
+      );
+
+      final mute = const MuteState(
+        peerId: 'p-guest',
+        seq: 1,
+        atMs: 1000,
+        muted: true,
+      ).encode();
+      for (final frag in encodeFragments(mute)) {
+        t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      var room = cubit.state as SessionRoom;
+      expect(
+        room.roster.firstWhere((p) => p.peerId == 'p-guest').muted,
+        isTrue,
+      );
+
+      final unmute = const MuteState(
+        peerId: 'p-guest',
+        seq: 2,
+        atMs: 2000,
+        muted: false,
+      ).encode();
+      for (final frag in encodeFragments(unmute)) {
+        t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      room = cubit.state as SessionRoom;
+      expect(
+        room.roster.firstWhere((p) => p.peerId == 'p-guest').muted,
+        isFalse,
+      );
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test(
+      'inbound TalkingState/MuteState about an unknown peer is silently ignored',
+      () async {
+        // Defensive: a stale message arriving after a peer has been
+        // dropped from the roster (Leave / RemovePeer / lost-peer prune)
+        // must not crash and must not resurrect the peer.
+        final t = makeTestTransport();
+        final cubit = _makeCubit(transport: t.transport);
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [
+              ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ],
+          ),
+        );
+        final initial = cubit.state as SessionRoom;
+
+        // Unknown peer in TalkingState — must be a no-op.
+        final talking = const TalkingState(
+          peerId: 'p-ghost',
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        ).encode();
+        for (final frag in encodeFragments(talking)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        // Same for MuteState.
+        final mute = const MuteState(
+          peerId: 'p-ghost',
+          seq: 2,
+          atMs: 2000,
+          muted: true,
+        ).encode();
+        for (final frag in encodeFragments(mute)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final after = cubit.state as SessionRoom;
+        expect(after.roster, equals(initial.roster));
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
       'host: peer-lost drops the peer from the roster and broadcasts RosterUpdate',
       () async {
         final t = makeTestTransport();


### PR DESCRIPTION
## Summary

- Per [`docs/protocol.md` § Voice control](docs/protocol.md), `talking` and `mute` are `peer → host → all` and drive the talking-ring + mute icon on every peer's screen. The dispatch handler in `FrequencySessionCubit._onTransportMessage` was silently dropping both kinds (the comment said "handled by future issues"), so a peer muting or VAD firing on device A never surfaced anywhere else.
- Wire both kinds into a small `_applyPeerStateUpdate` helper that finds the named peer in the live roster, `copyWith`s the changed flag, and re-emits `SessionRoom`. Unknown `peerId`s are silently ignored — defensive, so a stale message arriving after Leave / RemovePeer / lost-peer prune doesn't resurrect the peer. A flag that's already in the target value short-circuits to avoid redundant emits under flapping VAD.

## Scope note

This PR fixes the local apply only. Cross-guest visibility additionally requires the host to fan these messages out to other guests; that's a separate change. After this PR:

- ✅ host UI reflects guests' talking/mute
- ✅ guest UI reflects host's talking/mute (host's broadcast is already point-to-multipoint via GATT notifications)
- ❌ guest A's UI does not yet reflect guest B's talking/mute (needs host fan-out)

## Test plan

- [x] `flutter analyze` clean
- [x] New cubit tests:
  - `inbound TalkingState flips the matching roster peer's talking flag` (covers true → false flip too)
  - `inbound MuteState flips the matching roster peer's muted flag`
  - `inbound TalkingState/MuteState about an unknown peer is silently ignored`
- [x] Full `flutter test` green (615/615)
- [ ] On-device sanity: host phone + guest phone in a room, guest mutes → mute icon appears on host's UI; guest VAD-fires → talking ring lights on host's UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced real-time synchronization of peer talking and muting status during active sessions. Remote peer status updates are now properly reflected in the session roster, ensuring accurate and timely status indicators for all participants.

* **Tests**
  * Added comprehensive test coverage for peer state synchronization and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->