### PR TITLE
fix(#272): replace dead support@elodin.app with formalizedchaos.com addresses

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -6,7 +6,7 @@ permalink: /privacy-policy/
 
 # Frequency — Privacy Policy
 
-_Last updated: 2026-04-30_
+_Last updated: 2026-05-04_
 
 Frequency is an offline, peer-to-peer walkie-talkie app for Android. It runs
 entirely on the phones in the conversation — there is no Frequency server, no

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -116,6 +116,8 @@ in the project's GitHub repository.
 ## Contact
 
 Questions, concerns, or reports about Frequency's privacy practices can
-be filed as an issue on the project's GitHub repository:
+be filed as an issue on the project's GitHub repository or emailed to
+the maintainers:
 
 - <https://github.com/ElodinLaarz/walkie-talkie/issues>
+- <info@formalizedchaos.com>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -393,7 +393,7 @@
     "@privacyPolicyHeadline": {
         "description": "Headline of the privacy policy screen."
     },
-    "privacyPolicyLastUpdated": "Last updated 2026-04-30",
+    "privacyPolicyLastUpdated": "Last updated 2026-05-04",
     "@privacyPolicyLastUpdated": {
         "description": "Subhead under the privacy policy headline showing when the policy was last revised. Update this date when docs/privacy-policy.md is revised."
     },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -469,7 +469,7 @@
     "@privacyPolicySectionContactTitle": {
         "description": "Privacy policy section title — how to contact the maintainers."
     },
-    "privacyPolicySectionContactBody": "Questions, concerns, or reports about Frequency's privacy practices can be filed as an issue on the project's GitHub repository at https://github.com/ElodinLaarz/walkie-talkie/issues.",
+    "privacyPolicySectionContactBody": "Questions, concerns, or reports about Frequency's privacy practices can be filed as an issue on the project's GitHub repository at https://github.com/ElodinLaarz/walkie-talkie/issues or emailed to info@formalizedchaos.com.",
     "@privacyPolicySectionContactBody": {
         "description": "Privacy policy body — contact."
     },

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -22,6 +22,8 @@ import '../widgets/peer_drawer.dart';
 import '../widgets/peer_row.dart';
 import '../widgets/push_to_talk_button.dart';
 import '../widgets/media_source_sheet.dart';
+import 'package:url_launcher/url_launcher.dart';
+
 import '../widgets/queue_sheet.dart';
 
 /// Main "On air" room — voice + now playing.
@@ -1376,7 +1378,7 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'They have been muted and blocked. To report this incident to support, copy the report below and email it to support@elodin.app.',
+            'They have been muted and blocked. To report this incident to support, email the report below to support@formalizedchaos.com or copy it manually.',
           ),
           const SizedBox(height: 12),
           Container(
@@ -1397,6 +1399,21 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('Dismiss'),
+        ),
+        OutlinedButton.icon(
+          icon: const Icon(Icons.email_outlined),
+          label: const Text('Email report'),
+          onPressed: () async {
+            final uri = Uri(
+              scheme: 'mailto',
+              path: 'support@formalizedchaos.com',
+              queryParameters: {
+                'subject': 'Walkie Talkie abuse report',
+                'body': widget.reportText,
+              },
+            );
+            await launchUrl(uri);
+          },
         ),
         FilledButton.icon(
           icon: Icon(_copied ? Icons.check : Icons.copy),

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -1404,6 +1404,7 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
           icon: const Icon(Icons.email_outlined),
           label: const Text('Email report'),
           onPressed: () async {
+            final messenger = ScaffoldMessenger.of(context);
             final uri = Uri(
               scheme: 'mailto',
               path: 'support@formalizedchaos.com',
@@ -1412,7 +1413,19 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
                 'body': widget.reportText,
               },
             );
-            await launchUrl(uri);
+            try {
+              if (!await launchUrl(uri) && mounted) {
+                messenger.showSnackBar(
+                  SnackBar(content: Text('No email app available — use "Copy report" instead')),
+                );
+              }
+            } on PlatformException catch (_) {
+              if (mounted) {
+                messenger.showSnackBar(
+                  SnackBar(content: Text('Could not open email app — use "Copy report" instead')),
+                );
+              }
+            }
           },
         ),
         FilledButton.icon(

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -1032,6 +1032,45 @@ void main() {
 
       expect(find.text('Block & Report'), findsOneWidget);
     });
+    testWidgets('Block & Report dialog shows Email report button (#272)', (
+      tester,
+    ) async {
+      final cubit = _seededCubit();
+      addTearDown(cubit.close);
+      final store = _FakeBlockedPeersStore();
+
+      await tester.pumpWidget(_wrap(_room(), cubit: cubit, store: store));
+      await tester.pump();
+      await tester.pump();
+
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [ProtocolPeer(peerId: 'p-guest', displayName: 'Devon')],
+        ),
+      );
+      await tester.pump();
+
+      // Open Devon's drawer.
+      await tester.tap(find.text('Devon'));
+      await tester.pump(_settle);
+
+      // Drag the bottom sheet up so the off-screen Block & Report button is within
+      // the pointer-event bounds before tapping.
+      await tester.drag(find.byType(BottomSheet), const Offset(0, -600));
+      await tester.pump(_settle);
+
+      await tester.tap(find.text('Block & Report'));
+      // Let Navigator.pop + async block complete, then render dialog.
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Email report'), findsOneWidget);
+      expect(find.textContaining('support@formalizedchaos.com'), findsWidgets);
+    });
 
     testWidgets(
       'pttToggle in open-mic mode mutes (notification PTT button in open-mic)',


### PR DESCRIPTION
## Summary

- **Block & Report dialog**: Updates the email address from the dead `support@elodin.app` (no MX records) to `support@formalizedchaos.com`. Also adds an **"Email report" button** that opens a pre-filled `mailto:` URI so users don't have to manually copy the address into a mail client — `url_launcher` is already a dependency. The "Copy report" button is kept as a fallback for users without a mail client configured.
- **Privacy policy doc** (`docs/privacy-policy.md`): Extends the Contact section with `info@formalizedchaos.com` alongside the existing GitHub issues link.
- **In-app localization** (`lib/l10n/app_en.arb`): Mirrors the privacy policy change in `privacyPolicySectionContactBody` so the Settings → Privacy Policy screen stays in sync.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — all 612 tests pass
- [ ] Manual: trigger Block & Report on a peer, confirm the dialog shows the new address, the "Email report" button opens the system mail composer pre-filled, and the "Copy report" button still works.
- [ ] Manual: open Settings → Privacy Policy, scroll to Contact, confirm the email is shown.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Email report" button so users can send reports directly via their mail app to the support address; includes user-facing feedback if email cannot be launched.
* **Documentation**
  * Privacy policy updated (new last-updated date) and now lists an email contact alongside the existing issue-reporting option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->