### PR TITLE
build(#268): uncomment vcsInfo block in bundle config

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -205,9 +205,9 @@ android {
         abi {
             enableSplit = true
         }
-        // vcsInfo {
-        //     include = true
-        // }
+        vcsInfo {
+            include = true
+        }
     }
 
     testOptions {


### PR DESCRIPTION
## Summary

Uncomments the `vcsInfo` block in [`android/app/build.gradle.kts`](android/app/build.gradle.kts) that was disabled without a recorded reason.

- **What:** Enables `bundle.vcsInfo.include = true` in the AGP bundle configuration.
- **Why:** The comment block above it (lines 194–197) already documents the intent — VCS metadata embeds the HEAD commit SHA and remote URL into the AAB so Play Console can deep-link crash stack traces back to the exact source revision. Without it, shipped builds can never have that deep-link retroactively added.
- **Risk:** None. The AGP version in this repo supports `vcsInfo` and `flutter analyze` + all tests remain clean.

Closes #268

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 612/612 passing
- [x] All C++ unit tests pass (mixer, jitter_buffer, resampler, talking_event_queue, ring_buffer, opus_codec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to enable version control system information inclusion in the app bundle metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->