### PR TITLE
refactor(#271): regroup sentry gradle upload settings + fix DSN comment

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -215,8 +215,9 @@ android {
     }
 }
 
-// Sentry configuration for crash reporting
-// Only enabled when user opts in via Settings (defaults to disabled)
+// Sentry Gradle plugin — build-time symbol/mapping upload pipeline.
+// Runtime SDK init is gated separately by the user's Settings → Privacy toggle
+// (handled by sentry_flutter; see autoInstallation block below).
 sentry {
     // Build-time uploads for crash deobfuscation:
     //   - native sources + symbols → C++ stacks (Oboe / Opus)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -218,27 +218,25 @@ android {
 // Sentry configuration for crash reporting
 // Only enabled when user opts in via Settings (defaults to disabled)
 sentry {
-    // Upload debug symbols for native crashes (C++ Oboe/Opus code)
+    // Build-time uploads for crash deobfuscation:
+    //   - native sources + symbols → C++ stacks (Oboe / Opus)
+    //   - ProGuard/R8 mapping → Java/Kotlin stacks
+    //   - source context → resolves to source line in the Sentry UI
     includeNativeSources = true
-
-    // Auto-upload ProGuard/R8 mapping files for deobfuscated Java/Kotlin stacks
-    autoUploadProguardMapping = true
-
-    // Controlled by SENTRY_DSN environment variable
-    // If not set, Sentry is disabled (respects opt-out default)
     autoUploadNativeSymbols = true
-
-    // Include source context in stack traces
+    autoUploadProguardMapping = true
     includeSourceContext = true
 
-    // Prevent duplicate initialization (sentry_flutter handles SDK init)
+    // Runtime SDK init is handled by sentry_flutter (driven by the
+    // SENTRY_DSN dart-define + the user's Settings → Privacy toggle).
+    // Disable the plugin's auto-install so we don't double-init.
     autoInstallation {
         enabled = false
     }
 
-    // Trace instrumentation for performance monitoring (opt-in only)
+    // Off by default — privacy posture, not a Sentry-side concern.
     tracingInstrumentation {
-        enabled = false // Disabled by default for privacy
+        enabled = false
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #271

Fixes misleading structure in the `sentry {}` block in `android/app/build.gradle.kts`:

- **Regroups the four build-time upload settings** (`includeNativeSources`, `autoUploadNativeSymbols`, `autoUploadProguardMapping`, `includeSourceContext`) under a single descriptive comment — they all control the Sentry Gradle plugin's deobfuscation pipeline and belong together.
- **Removes the misplaced DSN comment** that sat next to `autoUploadNativeSymbols`, which incorrectly implied the DSN env var controlled the symbol upload behavior.
- **Updates `autoInstallation` comment** to accurately explain the runtime-vs-build separation: `sentry_flutter` handles SDK init via `SENTRY_DSN` dart-define + the user's privacy toggle; the plugin's auto-install is disabled to prevent double-init.
- **No behavior change** — ordering of keys within a Kotlin DSL block is irrelevant to semantics; all values remain `true`/`false` as before.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests passing
- [x] All C++ unit tests pass (mixer, jitter_buffer, resampler, talking_event_queue, ring_buffer, opus_codec, peer_audio_manager)
- [x] Play Store metadata validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Clarified and reorganized Sentry build configuration documentation to separate build-time upload concerns from runtime SDK initialization; configuration values and runtime behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->