### PR TITLE
fix(#278): strip peerId from Sentry events to match data-safety promise

### DIFF
--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -50,7 +50,7 @@ All other data type rows should be answered **No**.
 
 All peer-to-peer voice and control traffic stays within local Bluetooth range and is never sent to any server. No data is shared with any third party by default.
 
-Exception: if the user explicitly opts in to crash reporting (Settings → Crash reporting, off by default), anonymised crash stack traces are sent to Sentry. These traces contain no audio, no display names, no peer IDs, and no location data — the sanitizer in `lib/services/sentry_event_sanitizer.dart` strips peer IDs from all event fields before transmission, so only Sentry's own per-install session ID is used for crash correlation. Users who keep crash reporting disabled have zero outbound network traffic.
+Exception: if the user explicitly opts in to crash reporting (Settings → Crash reporting, off by default), anonymised crash stack traces are sent to Sentry. These traces contain no audio, no display names, no peer IDs, and no location data — the sanitizer in `lib/services/sentry_event_sanitizer.dart` strips peer IDs from contexts, tags, and breadcrumbs (including nested values) before transmission, so only Sentry's own SDK-generated session identifiers are used for crash correlation. Users who keep crash reporting disabled send no outbound crash telemetry.
 
 ---
 

--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -50,7 +50,7 @@ All other data type rows should be answered **No**.
 
 All peer-to-peer voice and control traffic stays within local Bluetooth range and is never sent to any server. No data is shared with any third party by default.
 
-Exception: if the user explicitly opts in to crash reporting (Settings → Crash reporting, off by default), anonymised crash stack traces are sent to Sentry. These traces contain no audio, no display names, no peer IDs, and no location data. Users who keep crash reporting disabled have zero outbound network traffic.
+Exception: if the user explicitly opts in to crash reporting (Settings → Crash reporting, off by default), anonymised crash stack traces are sent to Sentry. These traces contain no audio, no display names, no peer IDs, and no location data — the sanitizer in `lib/services/sentry_event_sanitizer.dart` strips peer IDs from all event fields before transmission, so only Sentry's own per-install session ID is used for crash correlation. Users who keep crash reporting disabled have zero outbound network traffic.
 
 ---
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'services/onboarding_permission_gateway.dart';
 import 'services/permission_watcher.dart';
 import 'services/recent_frequencies_store.dart';
 import 'services/sentry_config.dart';
+import 'services/sentry_event_sanitizer.dart';
 import 'services/settings_store.dart';
 import 'services/storage_migration.dart';
 import 'theme/app_theme.dart';
@@ -67,7 +68,7 @@ void main() async {
           options.attachStacktrace = true;
           // Redact PII before sending
           options.beforeSend = (event, hint) {
-            return _sanitizeEvent(event);
+            return sanitizeSentryEvent(event);
           };
         },
         appRunner: () => runApp(WalkieTalkieApp(settingsStore: settingsStore)),
@@ -78,48 +79,6 @@ void main() async {
 
   // Opt-out path or missing DSN: run without Sentry
   runApp(WalkieTalkieApp(settingsStore: settingsStore));
-}
-
-// Matches any key/field containing a display-name identifier, regardless of
-// separator (camelCase, snake_case, or space-separated).
-final _piiKeyRegex = RegExp(r'display[_ ]?name', caseSensitive: false);
-// Matches "display_?name: <value>" in free-form text, capturing through the
-// next comma or semicolon so multi-word values are fully redacted.
-final _piiMessageRegex = RegExp(
-  r'display[_ ]?name[:\s]*[^,;]+',
-  caseSensitive: false,
-);
-
-/// Sanitizes Sentry events to remove PII.
-/// Redacts display names from contexts and breadcrumbs.
-/// Keeps peerId as it's documented as an anonymous identifier.
-SentryEvent? _sanitizeEvent(SentryEvent event) {
-  // Direct mutation — SentryContexts is mutable in sentry 9.x.
-  event.contexts.removeWhere((key, _) => _piiKeyRegex.hasMatch(key));
-
-  // Mutate breadcrumbs in-place — SentryBreadcrumb is mutable in sentry 9.x.
-  for (final crumb in event.breadcrumbs ?? const []) {
-    final msg = crumb.message;
-    if (msg != null && _piiMessageRegex.hasMatch(msg)) {
-      crumb.message = msg.replaceAll(
-        _piiMessageRegex,
-        'displayName: [REDACTED]',
-      );
-    }
-
-    final data = crumb.data;
-    if (data != null && data.keys.any(_piiKeyRegex.hasMatch)) {
-      crumb.data = Map.fromEntries(
-        data.entries.map((e) {
-          return _piiKeyRegex.hasMatch(e.key)
-              ? MapEntry(e.key, '[REDACTED]')
-              : e;
-        }),
-      );
-    }
-  }
-
-  return event;
 }
 
 class WalkieTalkieApp extends StatefulWidget {

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -1416,13 +1416,21 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
             try {
               if (!await launchUrl(uri) && mounted) {
                 messenger.showSnackBar(
-                  SnackBar(content: Text('No email app available — use "Copy report" instead')),
+                  SnackBar(
+                    content: Text(
+                      'No email app available — use "Copy report" instead',
+                    ),
+                  ),
                 );
               }
             } on PlatformException catch (_) {
               if (mounted) {
                 messenger.showSnackBar(
-                  SnackBar(content: Text('Could not open email app — use "Copy report" instead')),
+                  SnackBar(
+                    content: Text(
+                      'Could not open email app — use "Copy report" instead',
+                    ),
+                  ),
                 );
               }
             }

--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -1,32 +1,35 @@
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-// Matches any key/field containing a display-name identifier, regardless of
-// separator (camelCase, snake_case, or space-separated).
-final _piiKeyRegex = RegExp(r'display[_ ]?name', caseSensitive: false);
+// Matches any key/field that is a display-name identifier.
+final _displayNameKeyRegex = RegExp(r'display[_ ]?name', caseSensitive: false);
 
-// Matches "display_?name: <value>" in free-form text, capturing through the
-// next comma or semicolon so multi-word values are fully redacted.
-final _piiMessageRegex = RegExp(
-  r'display[_ ]?name[:\s]*[^,;]+',
+// Matches display-name assignments in free-form text: colon, equals, or
+// JSON-style ("key":"value") separators; optional surrounding quotes.
+final _displayNameMessageRegex = RegExp(
+  r'"?display[_ ]?name"?\s*[:=]\s*"?[^,;"{}]+',
   caseSensitive: false,
 );
 
-// Matches any key/field containing a peer-id identifier.
+// Matches any key/field that is a peer-id identifier.
 final _peerIdKeyRegex = RegExp(r'peer[_\s]?id', caseSensitive: false);
 
-// Matches "peer_?id: <value>" in free-form text.
+// Matches peer-id assignments in free-form text: colon, equals, or
+// JSON-style ("key":"value") separators; optional surrounding quotes.
 final _peerIdMessageRegex = RegExp(
-  r'peer[_\s]?id[:\s]*[^,;]+',
+  r'"?peer[_\s]?id"?\s*[:=]\s*"?[^,;"{}]+',
   caseSensitive: false,
 );
 
 bool _isPiiKey(String key) =>
-    _piiKeyRegex.hasMatch(key) || _peerIdKeyRegex.hasMatch(key);
+    _displayNameKeyRegex.hasMatch(key) || _peerIdKeyRegex.hasMatch(key);
 
 String _redactMessage(String msg) {
   var result = msg;
-  if (_piiMessageRegex.hasMatch(result)) {
-    result = result.replaceAll(_piiMessageRegex, 'displayName: [REDACTED]');
+  if (_displayNameMessageRegex.hasMatch(result)) {
+    result = result.replaceAll(
+      _displayNameMessageRegex,
+      'displayName: [REDACTED]',
+    );
   }
   if (_peerIdMessageRegex.hasMatch(result)) {
     result = result.replaceAll(_peerIdMessageRegex, 'peerId: [REDACTED]');
@@ -34,17 +37,45 @@ String _redactMessage(String msg) {
   return result;
 }
 
+// Recursively redacts PII from nested Map/List/String payloads so that values
+// like {'room': {'peerId': 'abc'}} are sanitized even when the outer key is
+// not itself a PII indicator.
+dynamic _redactDeep(dynamic value) {
+  if (value is Map) {
+    return <String, dynamic>{
+      for (final e in value.entries)
+        if (e.key is String)
+          (e.key as String): _isPiiKey(e.key as String)
+              ? '[REDACTED]'
+              : _redactDeep(e.value),
+    };
+  }
+  if (value is List) {
+    return [for (final item in value) _redactDeep(item)];
+  }
+  if (value is String) {
+    return _redactMessage(value);
+  }
+  return value;
+}
+
 /// Sanitizes Sentry events to remove PII before they are sent.
 ///
 /// Redacts display names and peer IDs from contexts, tags, and breadcrumbs.
 /// Peer IDs are intentionally stripped even though they are random UUIDs: the
 /// privacy-first stance (and the Play Store Data Safety declaration) promises
-/// no app-controlled identifiers reach Sentry. Sentry's own per-install
-/// session ID covers "this install crashed N times" diagnostics without
-/// exposing an app-level identifier.
+/// no app-controlled identifiers reach Sentry. Sentry's own SDK-generated
+/// session identifiers cover crash-frequency diagnostics without exposing an
+/// app-level identifier.
 SentryEvent? sanitizeSentryEvent(SentryEvent event) {
-  // Strip PII-keyed context entries (Contexts is mutable in sentry 9.x).
+  // Strip PII-keyed context entries; deep-scan remaining values for nested PII.
   event.contexts.removeWhere((key, _) => _isPiiKey(key));
+  for (final key in event.contexts.keys.toList()) {
+    final val = event.contexts[key];
+    if (val is Map || val is List || val is String) {
+      event.contexts[key] = _redactDeep(val);
+    }
+  }
 
   // Strip PII-keyed tags.
   final tags = event.tags;
@@ -56,15 +87,16 @@ SentryEvent? sanitizeSentryEvent(SentryEvent event) {
   for (final crumb in event.breadcrumbs ?? const []) {
     final msg = crumb.message;
     if (msg != null &&
-        (_piiMessageRegex.hasMatch(msg) || _peerIdMessageRegex.hasMatch(msg))) {
+        (_displayNameMessageRegex.hasMatch(msg) ||
+            _peerIdMessageRegex.hasMatch(msg))) {
       crumb.message = _redactMessage(msg);
     }
 
     final data = crumb.data;
-    if (data != null && data.keys.any(_isPiiKey)) {
+    if (data != null) {
       crumb.data = <String, dynamic>{
         for (final e in data.entries)
-          e.key: _isPiiKey(e.key) ? '[REDACTED]' : e.value,
+          e.key: _isPiiKey(e.key) ? '[REDACTED]' : _redactDeep(e.value),
       };
     }
   }

--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -1,0 +1,73 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+// Matches any key/field containing a display-name identifier, regardless of
+// separator (camelCase, snake_case, or space-separated).
+final _piiKeyRegex = RegExp(r'display[_ ]?name', caseSensitive: false);
+
+// Matches "display_?name: <value>" in free-form text, capturing through the
+// next comma or semicolon so multi-word values are fully redacted.
+final _piiMessageRegex = RegExp(
+  r'display[_ ]?name[:\s]*[^,;]+',
+  caseSensitive: false,
+);
+
+// Matches any key/field containing a peer-id identifier.
+final _peerIdKeyRegex = RegExp(r'peer[_\s]?id', caseSensitive: false);
+
+// Matches "peer_?id: <value>" in free-form text.
+final _peerIdMessageRegex = RegExp(
+  r'peer[_\s]?id[:\s]*[^,;]+',
+  caseSensitive: false,
+);
+
+bool _isPiiKey(String key) =>
+    _piiKeyRegex.hasMatch(key) || _peerIdKeyRegex.hasMatch(key);
+
+String _redactMessage(String msg) {
+  var result = msg;
+  if (_piiMessageRegex.hasMatch(result)) {
+    result = result.replaceAll(_piiMessageRegex, 'displayName: [REDACTED]');
+  }
+  if (_peerIdMessageRegex.hasMatch(result)) {
+    result = result.replaceAll(_peerIdMessageRegex, 'peerId: [REDACTED]');
+  }
+  return result;
+}
+
+/// Sanitizes Sentry events to remove PII before they are sent.
+///
+/// Redacts display names and peer IDs from contexts, tags, and breadcrumbs.
+/// Peer IDs are intentionally stripped even though they are random UUIDs: the
+/// privacy-first stance (and the Play Store Data Safety declaration) promises
+/// no app-controlled identifiers reach Sentry. Sentry's own per-install
+/// session ID covers "this install crashed N times" diagnostics without
+/// exposing an app-level identifier.
+SentryEvent? sanitizeSentryEvent(SentryEvent event) {
+  // Strip PII-keyed context entries (Contexts is mutable in sentry 9.x).
+  event.contexts.removeWhere((key, _) => _isPiiKey(key));
+
+  // Strip PII-keyed tags.
+  final tags = event.tags;
+  if (tags != null && tags.keys.any(_isPiiKey)) {
+    event.tags = Map.fromEntries(tags.entries.where((e) => !_isPiiKey(e.key)));
+  }
+
+  // Redact breadcrumbs in-place (Breadcrumb is mutable in sentry 9.x).
+  for (final crumb in event.breadcrumbs ?? const []) {
+    final msg = crumb.message;
+    if (msg != null &&
+        (_piiMessageRegex.hasMatch(msg) || _peerIdMessageRegex.hasMatch(msg))) {
+      crumb.message = _redactMessage(msg);
+    }
+
+    final data = crumb.data;
+    if (data != null && data.keys.any(_isPiiKey)) {
+      crumb.data = <String, dynamic>{
+        for (final e in data.entries)
+          e.key: _isPiiKey(e.key) ? '[REDACTED]' : e.value,
+      };
+    }
+  }
+
+  return event;
+}

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -3,7 +3,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:walkie_talkie/services/sentry_event_sanitizer.dart';
 
 void main() {
-  group('sanitizeSentryEvent — displayName redaction (existing behaviour)', () {
+  group('sanitizeSentryEvent — displayName redaction', () {
     test('removes displayName key from contexts', () {
       final event = SentryEvent(
         contexts: Contexts()..['displayName'] = {'value': 'Alice'},
@@ -12,11 +12,29 @@ void main() {
       expect(result.contexts['displayName'], isNull);
     });
 
-    test('redacts displayName in breadcrumb message', () {
+    test('redacts colon-separated displayName in breadcrumb message', () {
       final event = SentryEvent(
         breadcrumbs: [
           Breadcrumb(message: 'peer joined displayName: Alice, freq: 42'),
         ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
+      expect(result.breadcrumbs!.single.message, isNot(contains('Alice')));
+    });
+
+    test('redacts equals-separated displayName in breadcrumb message', () {
+      final event = SentryEvent(
+        breadcrumbs: [Breadcrumb(message: 'join displayName=Alice, code=0')],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
+      expect(result.breadcrumbs!.single.message, isNot(contains('Alice')));
+    });
+
+    test('redacts JSON-style displayName in breadcrumb message', () {
+      final event = SentryEvent(
+        breadcrumbs: [Breadcrumb(message: '"displayName":"Alice"')],
       );
       final result = sanitizeSentryEvent(event)!;
       expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
@@ -62,7 +80,7 @@ void main() {
       expect(result.breadcrumbs!.single.data!['event'], 'join');
     });
 
-    test('redacts peerId inline in breadcrumb message', () {
+    test('redacts colon-separated peerId in breadcrumb message', () {
       final event = SentryEvent(
         breadcrumbs: [
           Breadcrumb(message: 'transport error peerId: abc-123, code: 5'),
@@ -71,6 +89,53 @@ void main() {
       final result = sanitizeSentryEvent(event)!;
       expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
       expect(result.breadcrumbs!.single.message, isNot(contains('abc-123')));
+    });
+
+    test('redacts equals-separated peerId in breadcrumb message', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(message: 'disconnect peerId=abc-123, reason=timeout'),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
+      expect(result.breadcrumbs!.single.message, isNot(contains('abc-123')));
+    });
+
+    test('redacts JSON-style peerId in breadcrumb message', () {
+      final event = SentryEvent(
+        breadcrumbs: [Breadcrumb(message: '"peerId":"abc-123"')],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
+      expect(result.breadcrumbs!.single.message, isNot(contains('abc-123')));
+    });
+
+    test('redacts nested peerId inside a context value map', () {
+      final event = SentryEvent(
+        contexts: Contexts()..['room'] = {'peerId': 'abc-123', 'freq': 42},
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final roomCtx = result.contexts['room'] as Map<String, dynamic>;
+      expect(roomCtx['peerId'], '[REDACTED]');
+      expect(roomCtx['freq'], 42);
+    });
+
+    test('redacts nested peerId inside breadcrumb data value map', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(
+            data: {
+              'details': {'peerId': 'abc-123', 'rssi': -70},
+            },
+          ),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final details =
+          result.breadcrumbs!.single.data!['details'] as Map<String, dynamic>;
+      expect(details['peerId'], '[REDACTED]');
+      expect(details['rssi'], -70);
     });
 
     test('leaves unrelated tags and data intact', () {

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:walkie_talkie/services/sentry_event_sanitizer.dart';
+
+void main() {
+  group('sanitizeSentryEvent — displayName redaction (existing behaviour)', () {
+    test('removes displayName key from contexts', () {
+      final event = SentryEvent(
+        contexts: Contexts()..['displayName'] = {'value': 'Alice'},
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.contexts['displayName'], isNull);
+    });
+
+    test('redacts displayName in breadcrumb message', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(message: 'peer joined displayName: Alice, freq: 42'),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
+      expect(result.breadcrumbs!.single.message, isNot(contains('Alice')));
+    });
+
+    test('redacts displayName key in breadcrumb data', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(data: {'displayName': 'Alice', 'freq': 42}),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.data!['displayName'], '[REDACTED]');
+      expect(result.breadcrumbs!.single.data!['freq'], 42);
+    });
+  });
+
+  group('sanitizeSentryEvent — peerId redaction', () {
+    test('removes peerId key from contexts', () {
+      final event = SentryEvent(
+        contexts: Contexts()..['peerId'] = {'value': 'abc-123'},
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.contexts['peerId'], isNull);
+    });
+
+    test('removes peerId from event tags', () {
+      final event = SentryEvent(tags: {'peerId': 'abc-123', 'version': '1.0'});
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.tags!.containsKey('peerId'), isFalse);
+      expect(result.tags!['version'], '1.0');
+    });
+
+    test('redacts peerId key in breadcrumb data', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(data: {'peerId': 'abc-123', 'event': 'join'}),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.data!['peerId'], '[REDACTED]');
+      expect(result.breadcrumbs!.single.data!['event'], 'join');
+    });
+
+    test('redacts peerId inline in breadcrumb message', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(message: 'transport error peerId: abc-123, code: 5'),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[REDACTED]'));
+      expect(result.breadcrumbs!.single.message, isNot(contains('abc-123')));
+    });
+
+    test('leaves unrelated tags and data intact', () {
+      final event = SentryEvent(
+        tags: {'version': '1.2.3', 'platform': 'android'},
+        breadcrumbs: [
+          Breadcrumb(data: {'frequency': 42, 'rssi': -70}),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.tags, {'version': '1.2.3', 'platform': 'android'});
+      expect(result.breadcrumbs!.single.data, {'frequency': 42, 'rssi': -70});
+    });
+
+    test('handles null tags and breadcrumbs without error', () {
+      final event = SentryEvent();
+      expect(() => sanitizeSentryEvent(event), returnsNormally);
+    });
+
+    test(
+      'simultaneous displayName and peerId in breadcrumb data are both redacted',
+      () {
+        final event = SentryEvent(
+          breadcrumbs: [
+            Breadcrumb(
+              data: {'displayName': 'Alice', 'peerId': 'abc-123', 'freq': 7},
+            ),
+          ],
+        );
+        final result = sanitizeSentryEvent(event)!;
+        final data = result.breadcrumbs!.single.data!;
+        expect(data['displayName'], '[REDACTED]');
+        expect(data['peerId'], '[REDACTED]');
+        expect(data['freq'], 7);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #278

## Summary

- The Play Store Data Safety doc claimed crash traces contain "no peer IDs", but `_sanitizeEvent` in `main.dart` was explicitly **keeping** peerId as an "anonymous identifier" — a contradiction caught while filling out the Play Console Data Safety form.
- Implements **Option B** from the issue: extend the sanitizer to redact peerId from all Sentry event fields so the doc claim becomes accurate.
- Extracts the sanitizer into `lib/services/sentry_event_sanitizer.dart` so it can be unit-tested.

## Changes

- **`lib/services/sentry_event_sanitizer.dart`** (new): `sanitizeSentryEvent()` with `_peerIdKeyRegex` / `_peerIdMessageRegex` alongside the existing displayName patterns; a shared `_isPiiKey()` covers both. Redacts contexts, tags, breadcrumb data keys, and breadcrumb message text.
- **`lib/main.dart`**: delegates `beforeSend` to `sanitizeSentryEvent()`; removes inlined sanitizer code.
- **`docs/play-store-data-safety.md`**: notes that the sanitizer strips peer IDs before transmission, making the "no peer IDs" claim accurate.
- **`test/services/sentry_event_sanitizer_test.dart`** (new): 10 unit tests — displayName regression coverage + peerId redaction across all field types (contexts, tags, breadcrumb data, breadcrumb messages).

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 630/630 pass (10 new sanitizer tests)
- [x] C++ native tests — all pass
- [x] `scripts/presubmit.sh` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Play Console data-safety wording: opt-in crash reports are anonymized and sent without audio/display names/location; “crash reporting disabled” now states it “sends no outbound crash telemetry.”

* **New Features**
  * Added runtime sanitization that redacts/removes sensitive identity fields from crash events before transmission.

* **Style**
  * Improved error message/snackbar formatting in the report dialog.

* **Tests**
  * Added tests validating the sanitizer’s redaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->