### PR TITLE
fix(#283): unify branding — rename Walkie Talkie → Frequency on all user-visible surfaces

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App label shown in launcher, app picker, recents, and Settings. -->
-    <string name="app_name">Walkie Talkie</string>
+    <string name="app_name">Frequency</string>
 
     <!-- Foreground service notification (channel name + per-notification copy
          shown while a session is active). Kept short so they fit in the
          compact notification body; the title doubles as the FGS channel
          identifier in Settings → Notifications. -->
-    <string name="fgs_channel_name">Walkie Talkie Service</string>
-    <string name="fgs_channel_description">Keeps the walkie-talkie connection active</string>
-    <string name="fgs_notification_title">Walkie Talkie Active</string>
+    <string name="fgs_channel_name">Frequency Service</string>
+    <string name="fgs_channel_description">Keeps the Frequency connection active</string>
+    <string name="fgs_notification_title">Frequency Active</string>
     <string name="fgs_notification_text_idle">Connected and ready to communicate</string>
     <!-- %1$s: frequency display string, e.g. "92.5 MHz" -->
     <string name="fgs_notification_text_on_freq">On %1$s · Tap to return</string>

--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -67,7 +67,7 @@ Exception: if the user explicitly opts in to crash reporting (Settings → Crash
 
 The app stores no user data on any server. To delete all local data:
 
-1. Open **Settings → Apps → Walkie Talkie → Storage**.
+1. Open **Settings → Apps → Frequency → Storage**.
 2. Tap **Clear Data**.
 
 Or simply uninstall the app.

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -8,10 +8,10 @@ All character limits are Play Store maxima; counts shown after each field.
 ## App name
 
 ```text
-Walkie Talkie
+Frequency: Walkie-Talkie
 ```
 
-13 characters (max 30).
+24 characters (max 30).
 
 ---
 

--- a/docs/play-store-permissions-rationale.md
+++ b/docs/play-store-permissions-rationale.md
@@ -8,12 +8,12 @@ them when responding to a policy review query.
 
 ## BLUETOOTH_SCAN
 
-> *"To discover other Walkie Talkie rooms broadcasting nearby over Bluetooth LE.
+> *"To discover other Frequency rooms broadcasting nearby over Bluetooth LE.
 > The `neverForLocation` flag is set — this scan cannot be used to derive the
 > user's location."*
 
 **Why needed:** The discovery screen lists nearby hosts that are advertising the
-Walkie Talkie service UUID. Without scan permission the list stays empty.
+Frequency service UUID. Without scan permission the list stays empty.
 
 **Privacy note:** `android:usesPermissionFlags="neverForLocation"` is set in the
 manifest, so Android does not require the user to grant location permission and
@@ -23,7 +23,7 @@ the OS enforces that scan results cannot be used to derive location.
 
 ## BLUETOOTH_CONNECT
 
-> *"To connect to a nearby Walkie Talkie host and exchange voice and control
+> *"To connect to a nearby Frequency host and exchange voice and control
 > messages over GATT and L2CAP CoC (Bluetooth LE connection-oriented channels)."*
 
 **Why needed:** Joining a room requires a GATT connection to the host for the
@@ -81,7 +81,7 @@ maintain the BLE connection while backgrounded.
 
 ## POST_NOTIFICATIONS
 
-> *"To display the persistent 'Walkie Talkie Active' foreground notification.
+> *"To display the persistent 'Frequency Active' foreground notification.
 > Android 13+ requires notification permission before a foreground service
 > notification can appear; this notification is the mandatory indicator that
 > the microphone foreground service is running."*

--- a/docs/play-store-submission-guide.md
+++ b/docs/play-store-submission-guide.md
@@ -6,7 +6,7 @@ permalink: /play-store-submission/
 
 # Play Store Submission Guide
 
-Step-by-step checklist for submitting the **Walkie Talkie** app to the Google
+Step-by-step checklist for submitting the **Frequency** app to the Google
 Play Store. Items marked ✅ are complete (all code and assets are committed);
 items marked ⏳ require action inside the Play Console.
 

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Walkie Talkie
+Frequency: Walkie-Talkie

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -1416,13 +1416,21 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
             try {
               if (!await launchUrl(uri) && mounted) {
                 messenger.showSnackBar(
-                  SnackBar(content: Text('No email app available — use "Copy report" instead')),
+                  SnackBar(
+                    content: Text(
+                      'No email app available — use "Copy report" instead',
+                    ),
+                  ),
                 );
               }
             } on PlatformException catch (_) {
               if (mounted) {
                 messenger.showSnackBar(
-                  SnackBar(content: Text('Could not open email app — use "Copy report" instead')),
+                  SnackBar(
+                    content: Text(
+                      'Could not open email app — use "Copy report" instead',
+                    ),
+                  ),
                 );
               }
             }

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -1160,7 +1160,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
 
   String _buildSanitizedReport(Person person) {
     final timestamp = DateTime.now().toUtc().toIso8601String();
-    return 'Walkie Talkie abuse report\n'
+    return 'Frequency abuse report\n'
         'Time (UTC): $timestamp\n'
         'Frequency: ${_sanitizeField(widget.freq)}\n'
         'Peer display name: ${_sanitizeField(person.name)}\n'
@@ -1409,7 +1409,7 @@ class _ReportSentDialogState extends State<_ReportSentDialog> {
               scheme: 'mailto',
               path: 'support@formalizedchaos.com',
               queryParameters: {
-                'subject': 'Walkie Talkie abuse report',
+                'subject': 'Frequency abuse report',
                 'body': widget.reportText,
               },
             );


### PR DESCRIPTION
Closes #283

## Summary

- **`android/app/src/main/res/values/strings.xml`** — `app_name`, `fgs_channel_name`, `fgs_channel_description`, `fgs_notification_title` all updated to `Frequency` / `Frequency Active` / `Frequency Service`
- **`fastlane/metadata/android/en-US/title.txt`** — `Walkie Talkie` → `Frequency: Walkie-Talkie` (24 chars, retains walkie-talkie keyword for Play Store search)
- **`docs/play-store-listing.md`** — app-name field updated (13 → 24 chars)
- **`docs/play-store-data-safety.md`** — Settings → Apps navigation path
- **`docs/play-store-permissions-rationale.md`** — four brand references in BLUETOOTH_SCAN, BLUETOOTH_CONNECT, POST_NOTIFICATIONS descriptions
- **`docs/play-store-submission-guide.md`** — heading reference
- **`lib/screens/frequency_room_screen.dart`** — abuse-report title and mailto subject line

Technical identifiers (`walkie_talkie` package, `com.elodin.walkie_talkie` applicationId, repo name) are **unchanged** — these are never user-visible and changing `applicationId` would require a fresh Play submission with no user migration path.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 613/613 pass
- [x] C++ native tests — all pass
- [x] `scripts/presubmit.sh` exits 0
- [x] `validate_store_metadata.sh` — title 24/30 chars ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application branding with new name across notifications, system services, and app metadata
  * Modified foreground service notification titles and descriptions
  * Refreshed Android app metadata, localized titles, Play Store documentation, permissions information, and data safety guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->