### PR TITLE
fix(#270): resolve KEYSTORE_PATH relative to project root, not android/app/

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -119,7 +119,7 @@ android {
 
             when {
                 hasEnvConfig -> {
-                    storeFile = file(envKeystorePath)
+                    storeFile = rootProject.file(envKeystorePath)
                     storePassword = envKeystorePassword
                     keyAlias = envKeyAlias
                     keyPassword = envKeyPassword


### PR DESCRIPTION
## Summary

Fixes #270.

The `signingConfigs` block in [`android/app/build.gradle.kts`](android/app/build.gradle.kts) had an inconsistency in how it resolved the keystore path:

- **`key.properties` branch** used `rootProject.file(path)` → resolves relative to `android/` (project root)
- **env-var branch** used `file(envKeystorePath)` → resolves relative to `android/app/` (module dir)

Same relative path string, different base dirs. A contributor passing `KEYSTORE_PATH=keystore.jks` locally would get `android/app/keystore.jks` instead of `android/keystore.jks` (where the file likely lives per `SIGNING.md`). CI avoids this today because it uses an absolute temp path decoded from a base64 secret, but local release builds with relative paths silently fail.

**One-line fix:** `file(envKeystorePath)` → `rootProject.file(envKeystorePath)`, making both branches resolve identically.

## Test plan

- [x] Local CI passed (`scripts/presubmit.sh`): `flutter analyze` clean, all Flutter tests passing, all C++ tests passing
- [x] Change is a pure Gradle substitution; no behavioral change for absolute paths (CI), only fixes relative-path resolution for local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to improve keystore file path resolution when signing release binaries through continuous integration pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->