### PR TITLE
fix(#273): host re-broadcast for TalkingState / MuteState / MediaCommand

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -385,11 +385,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           );
         }
       case TalkingState m:
-        _applyPeerStateUpdate(m.peerId, talking: m.talking);
-        _hostRebroadcast(m);
+        if (_applyPeerStateUpdate(m.peerId, talking: m.talking)) {
+          _hostRebroadcast(m);
+        }
       case MuteState m:
-        _applyPeerStateUpdate(m.peerId, muted: m.muted);
-        _hostRebroadcast(m);
+        if (_applyPeerStateUpdate(m.peerId, muted: m.muted)) {
+          _hostRebroadcast(m);
+        }
       // JoinRequest is host-only ingress (future host-side issue).
       // JoinDenied is reserved for the host-rejects-guest path.
       case JoinRequest():
@@ -400,21 +402,25 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
 
   /// Applies a single-peer flag mutation (talking or mute) from an inbound
   /// [TalkingState] / [MuteState] to the live roster, then emits the updated
-  /// [SessionRoom]. No-op when the cubit is closed, outside `SessionRoom`,
-  /// when the named peer isn't in the roster (stale message after
-  /// Leave / RemovePeer), or when the new flag matches the current value
-  /// (avoids redundant emits under flapping VAD).
-  void _applyPeerStateUpdate(String peerId, {bool? muted, bool? talking}) {
+  /// [SessionRoom]. Returns `true` when the named peer exists in the roster
+  /// (regardless of whether the value changed), `false` when the peer is
+  /// unknown, the state is wrong, or the cubit is closed.
+  ///
+  /// Callers use the return value to decide whether to fan-out the message:
+  /// a `false` result means the peer isn't in this room, so re-broadcasting
+  /// would leak a stale or spoofed peer ID to the rest of the room.
+  bool _applyPeerStateUpdate(String peerId, {bool? muted, bool? talking}) {
     final current = state;
-    if (isClosed || current is! SessionRoom) return;
+    if (isClosed || current is! SessionRoom) return false;
     final idx = current.roster.indexWhere((p) => p.peerId == peerId);
-    if (idx < 0) return;
+    if (idx < 0) return false;
     final existing = current.roster[idx];
     final updated = existing.copyWith(muted: muted, talking: talking);
-    if (existing == updated) return;
+    if (existing == updated) return true;
     final newRoster = [...current.roster];
     newRoster[idx] = updated;
     emit(current.copyWith(roster: newRoster));
+    return true;
   }
 
   /// Re-broadcasts [msg] to all peers when running as the host, excluding

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -318,6 +318,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         applyJoinAccepted(m);
       case MediaCommand m:
         applyHostMediaEcho(m);
+        _hostRebroadcast(m);
       case RosterUpdate m:
         final current = state;
         if (isClosed || current is! SessionRoom) return;
@@ -383,14 +384,54 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
             ),
           );
         }
-      // These message types are handled by future issues
-      // (voice-activity detection, join request flow). Silently drop.
-      case TalkingState():
-      case MuteState():
+      case TalkingState m:
+        _applyPeerStateUpdate(m.peerId, talking: m.talking);
+        _hostRebroadcast(m);
+      case MuteState m:
+        _applyPeerStateUpdate(m.peerId, muted: m.muted);
+        _hostRebroadcast(m);
+      // JoinRequest is host-only ingress (future host-side issue).
+      // JoinDenied is reserved for the host-rejects-guest path.
       case JoinRequest():
       case JoinDenied():
         break;
     }
+  }
+
+  /// Applies a single-peer flag mutation (talking or mute) from an inbound
+  /// [TalkingState] / [MuteState] to the live roster, then emits the updated
+  /// [SessionRoom]. No-op when the cubit is closed, outside `SessionRoom`,
+  /// when the named peer isn't in the roster (stale message after
+  /// Leave / RemovePeer), or when the new flag matches the current value
+  /// (avoids redundant emits under flapping VAD).
+  void _applyPeerStateUpdate(String peerId, {bool? muted, bool? talking}) {
+    final current = state;
+    if (isClosed || current is! SessionRoom) return;
+    final idx = current.roster.indexWhere((p) => p.peerId == peerId);
+    if (idx < 0) return;
+    final existing = current.roster[idx];
+    final updated = existing.copyWith(muted: muted, talking: talking);
+    if (existing == updated) return;
+    final newRoster = [...current.roster];
+    newRoster[idx] = updated;
+    emit(current.copyWith(roster: newRoster));
+  }
+
+  /// Re-broadcasts [msg] to all peers when running as the host, excluding
+  /// messages the host originated itself (originator guard prevents loopback).
+  /// No-op for guests or when no transport is wired.
+  void _hostRebroadcast(FrequencyMessage msg) {
+    final current = state;
+    if (isClosed || current is! SessionRoom || !current.roomIsHost) return;
+    if (msg.peerId == _localPeerId) return;
+    final t = _transport;
+    if (t == null) return;
+    unawaited(
+      t.send(msg).catchError((Object e) {
+        if (kDebugMode) debugPrint('Host re-broadcast failed: $e');
+        return false;
+      }),
+    );
   }
 
   /// Host-only ingress for `SignalReport`. Guests currently send
@@ -1727,9 +1768,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// queue (`MediaSourceLib.queue.length`), so it can't correctly
   /// resolve the trackIdx for `skip` / `prev`. The room screen owns
   /// queue-aware advancement; the cubit's `mediaState` is the
-  /// `JoinAccepted` bootstrap snapshot only. Host fan-out (so the host
-  /// tracks canonical mediaState and snapshots it into `JoinAccepted`
-  /// for guests) is still pending — tracked in issue #273.
+  /// `JoinAccepted` bootstrap snapshot only.
   ///
   /// No-op outside `SessionRoom`, or after the cubit is closed.
   void applyHostMediaEcho(MediaCommand cmd) {

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -3281,6 +3281,357 @@ void main() {
     });
   });
 
+  // ── Host re-broadcast (issue #273) ───────────────────────────────────
+
+  group('Host re-broadcast', () {
+    setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+    ({
+      BleControlTransport transport,
+      List<Uint8List> outbox,
+      StreamController<({String endpointId, Uint8List bytes})> inbox,
+    })
+    makeTestTransport() {
+      final outbox = <Uint8List>[];
+      final inbox =
+          StreamController<({String endpointId, Uint8List bytes})>.broadcast();
+      final transport = BleControlTransport.forTest(
+        controlBytes: inbox.stream,
+        writeBytes: (bytes) async {
+          outbox.add(bytes);
+        },
+      );
+      return (transport: transport, outbox: outbox, inbox: inbox);
+    }
+
+    List<FrequencyMessage> drainOutbox(List<Uint8List> outbox) {
+      final reassembler = FragmentReassembler();
+      final messages = <FrequencyMessage>[];
+      for (final bytes in outbox) {
+        final json = reassembler.feed(bytes);
+        if (json != null) messages.add(FrequencyMessage.decode(json));
+      }
+      return messages;
+    }
+
+    // The default _FakeStore.getPeerId() returns 'fake-peer-id'; bootstrap()
+    // caches this as _localPeerId, so the originator guard checks against it.
+    const String kHostPeerId = 'fake-peer-id';
+
+    /// Builds a host cubit with two roster entries: the host and 'p-guest'.
+    Future<FrequencySessionCubit> makeHostCubit(
+      BleControlTransport transport,
+    ) async {
+      final cubit = _makeCubit(
+        transport: transport,
+        heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: kHostPeerId,
+          seq: 1,
+          atMs: 0,
+          hostPeerId: kHostPeerId,
+          roster: const [
+            ProtocolPeer(peerId: kHostPeerId, displayName: 'Devon'),
+            ProtocolPeer(peerId: 'p-guest', displayName: 'Maya'),
+          ],
+        ),
+      );
+      return cubit;
+    }
+
+    test(
+      'host receives TalkingState from guest → re-broadcasts to all peers',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeHostCubit(t.transport);
+
+        final msg = const TalkingState(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        );
+        t.outbox.clear(); // discard any join-phase sends
+        for (final frag in encodeFragments(msg.encode())) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final sent = drainOutbox(t.outbox);
+        expect(sent, hasLength(1));
+        expect(sent.single, isA<TalkingState>());
+        expect((sent.single as TalkingState).peerId, 'p-guest');
+        expect((sent.single as TalkingState).talking, isTrue);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'host receives MuteState from guest → re-broadcasts to all peers',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeHostCubit(t.transport);
+
+        final msg = const MuteState(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          muted: true,
+        );
+        t.outbox.clear();
+        for (final frag in encodeFragments(msg.encode())) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final sent = drainOutbox(t.outbox);
+        expect(sent, hasLength(1));
+        expect(sent.single, isA<MuteState>());
+        expect((sent.single as MuteState).peerId, 'p-guest');
+        expect((sent.single as MuteState).muted, isTrue);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'host receives MediaCommand from guest → applies locally and re-broadcasts',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeHostCubit(t.transport);
+
+        final emissions = <MediaCommand>[];
+        final sub = cubit.mediaCommands.listen(emissions.add);
+
+        final msg = const MediaCommand(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          op: MediaOp.play,
+          source: 'YouTube Music',
+        );
+        t.outbox.clear();
+        for (final frag in encodeFragments(msg.encode())) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        // Applied locally (mediaCommands stream)
+        expect(emissions, hasLength(1));
+        expect(emissions.single.op, MediaOp.play);
+
+        // Re-broadcast over the wire
+        final sent = drainOutbox(t.outbox);
+        expect(sent, hasLength(1));
+        expect(sent.single, isA<MediaCommand>());
+        expect((sent.single as MediaCommand).peerId, 'p-guest');
+
+        await sub.cancel();
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'guest role: receives TalkingState → applies locally, does NOT re-broadcast',
+      () async {
+        final t = makeTestTransport();
+        final cubit = _makeCubit(
+          transport: t.transport,
+          heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Maya'));
+        await cubit.joinRoom(freq: '104.3', isHost: false);
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [
+              ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+              ProtocolPeer(peerId: 'p-peer', displayName: 'Someone'),
+            ],
+          ),
+        );
+
+        t.outbox.clear();
+        final msg = const TalkingState(
+          peerId: 'p-peer',
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        );
+        for (final frag in encodeFragments(msg.encode())) {
+          t.inbox.add((endpointId: 'p-host', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        // Applied locally (roster updated)
+        final room = cubit.state as SessionRoom;
+        expect(
+          room.roster.firstWhere((p) => p.peerId == 'p-peer').talking,
+          isTrue,
+        );
+        // No re-broadcast — not the host
+        expect(t.outbox, isEmpty);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'host receives message from itself → no re-broadcast (originator guard)',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeHostCubit(t.transport);
+
+        t.outbox.clear();
+        // A TalkingState bearing the host's own peerId — should not loop back.
+        final msg = const TalkingState(
+          peerId: kHostPeerId,
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        );
+        for (final frag in encodeFragments(msg.encode())) {
+          t.inbox.add((endpointId: 'p-host', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        expect(t.outbox, isEmpty);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'inbound TalkingState flips the matching roster peer\'s talking flag',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeHostCubit(t.transport);
+
+        final talking = const TalkingState(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        ).encode();
+        for (final frag in encodeFragments(talking)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        var room = cubit.state as SessionRoom;
+        expect(
+          room.roster.firstWhere((p) => p.peerId == 'p-guest').talking,
+          isTrue,
+        );
+        expect(
+          room.roster.firstWhere((p) => p.peerId == kHostPeerId).talking,
+          isFalse,
+        );
+
+        final stopped = const TalkingState(
+          peerId: 'p-guest',
+          seq: 2,
+          atMs: 2000,
+          talking: false,
+        ).encode();
+        for (final frag in encodeFragments(stopped)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        room = cubit.state as SessionRoom;
+        expect(
+          room.roster.firstWhere((p) => p.peerId == 'p-guest').talking,
+          isFalse,
+        );
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'inbound MuteState flips the matching roster peer\'s muted flag',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeHostCubit(t.transport);
+
+        final muted = const MuteState(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          muted: true,
+        ).encode();
+        for (final frag in encodeFragments(muted)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final room = cubit.state as SessionRoom;
+        expect(
+          room.roster.firstWhere((p) => p.peerId == 'p-guest').muted,
+          isTrue,
+        );
+        expect(
+          room.roster.firstWhere((p) => p.peerId == kHostPeerId).muted,
+          isFalse,
+        );
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test(
+      'inbound TalkingState/MuteState about an unknown peer is silently ignored',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeHostCubit(t.transport);
+        final stateBefore = cubit.state;
+
+        final msg = const TalkingState(
+          peerId: 'p-unknown',
+          seq: 1,
+          atMs: 1000,
+          talking: true,
+        ).encode();
+        for (final frag in encodeFragments(msg)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        // State unchanged — unknown peer not in roster
+        expect(cubit.state, equals(stateBefore));
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+  });
+
   // ── TalkingState (VAD outbound) ───────────────────────────────────────
 
   group('TalkingState outbound', () {

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -3610,20 +3610,37 @@ void main() {
         final t = makeTestTransport();
         final cubit = await makeHostCubit(t.transport);
         final stateBefore = cubit.state;
+        t.outbox.clear();
 
-        final msg = const TalkingState(
+        final talkingMsg = const TalkingState(
           peerId: 'p-unknown',
           seq: 1,
           atMs: 1000,
           talking: true,
         ).encode();
-        for (final frag in encodeFragments(msg)) {
+        for (final frag in encodeFragments(talkingMsg)) {
           t.inbox.add((endpointId: 'AA:BB', bytes: frag));
         }
         await Future<void>.delayed(Duration.zero);
 
         // State unchanged — unknown peer not in roster
         expect(cubit.state, equals(stateBefore));
+        // Must not fan out stale/unknown peer IDs to the room
+        expect(t.outbox, isEmpty);
+
+        final muteMsg = const MuteState(
+          peerId: 'p-unknown',
+          seq: 2,
+          atMs: 2000,
+          muted: true,
+        ).encode();
+        for (final frag in encodeFragments(muteMsg)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        expect(cubit.state, equals(stateBefore));
+        expect(t.outbox, isEmpty);
 
         await cubit.close();
         await t.inbox.close();


### PR DESCRIPTION
## Summary

Closes #273.

With three peers A/B/C and host H: if A toggles mute or VAD fires, A's UI updates locally, H receives the message — but B and C never saw it. This PR wires the host fan-out so all three message kinds propagate to every peer.

- **`_applyPeerStateUpdate`** — new helper that finds the named peer in the live roster and `copyWith`s the changed `talking`/`muted` flag, then re-emits `SessionRoom`. Silently ignores unknown `peerId`s (stale messages after Leave / RemovePeer) and no-ops when the flag is already the target value (avoids redundant emits under flapping VAD).
- **`_hostRebroadcast`** — new helper that re-sends the inbound message to all peers when `roomIsHost` is true. Originator guard (`msg.peerId == _localPeerId`) prevents the host from looping its own messages back to itself. No-op for guests.
- **`_onTransportMessage`** — `TalkingState` and `MuteState` now call `_applyPeerStateUpdate` + `_hostRebroadcast` instead of silently dropping. `MediaCommand` now additionally calls `_hostRebroadcast` after the existing `applyHostMediaEcho`.

## Test plan

New `Host re-broadcast` group (8 tests, all pass):

- [x] Host receives `TalkingState` from guest → outbox contains re-encoded `TalkingState` with originator's `peerId`
- [x] Host receives `MuteState` from guest → outbox contains re-encoded `MuteState`
- [x] Host receives `MediaCommand` from guest → applies locally (mediaCommands stream) + re-broadcasts on wire
- [x] Guest role: receives `TalkingState` → applies locally, outbox stays empty (no fan-out)
- [x] Host receives message from itself → no re-broadcast (originator guard)
- [x] Inbound `TalkingState` flips the matching roster peer's `talking` flag (and clears on false)
- [x] Inbound `MuteState` flips the matching roster peer's `muted` flag
- [x] Unknown `peerId` → silently ignored, state unchanged

- [x] `flutter analyze` — clean (no issues)
- [x] `flutter test` — 637/637 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inbound talking and muted state messages are now applied to session rosters instead of being dropped; hosts will forward peer state updates to other participants (excluding messages from the local peer).
  * Unknown peer state messages are safely ignored.

* **Tests**
  * Added coverage validating host re-broadcast behavior, originator guards, guest/no-rebroadcast cases, and state-update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->