### PR TITLE
docs(#276): align README room description with actual linear-list UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ service UUID. Each row shows host name + cosmetic MHz dial reading. Tap
 *Tune in* to send a `JoinRequest`. Includes an identity chip that opens a
 rename sheet for changing your display name later.
 
-**Frequency Room** — central frequency dial, orbiting peer chips with
+**Frequency Room** — central frequency dial, a roster of peer chips with
 talking-rings, push-to-talk button, mute toggle, shared-media controls,
 and a *Leave* button. Joining is implicit — the host's `JoinAccepted`
 delivers the roster + current `mediaState` so the room renders fully

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -3449,7 +3449,9 @@ void main() {
         final t = makeTestTransport();
         final cubit = _makeCubit(
           transport: t.transport,
-          heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+          heartbeats: HeartbeatScheduler(
+            pingInterval: const Duration(hours: 1),
+          ),
         );
         await cubit.bootstrap();
         cubit.emit(const SessionDiscovery(myName: 'Maya'));


### PR DESCRIPTION
Fixes #276

## Summary

- Replaces "orbiting peer chips" with "a roster of peer chips" in the Frequency Room description in `README.md` so the copy matches what `lib/screens/frequency_room_screen.dart` actually renders (a `Column`-based vertical list, not an orbit layout).
- Normalizes CRLF → LF in `test/bloc/frequency_session_cubit_test.dart` and fixes a trailing-comma formatting issue in that file so `dart format --set-exit-if-changed` passes locally (pre-existing CI blocker unrelated to the README change).

## Test plan

- [x] `bash scripts/presubmit.sh` passes: formatting, `flutter analyze`, 637 Flutter tests, all C++ unit tests (mixer, jitter buffer, resampler, ring buffer, VAD, Opus, peer audio manager)
- [x] README wording confirmed: `grep "orbit\|roster" README.md` shows "a roster of peer chips" at line 131 and no "orbit" references in the UI-description prose

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Frequency Room description in the README for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->