### PR TITLE
fix(#269): drop minSdk 33 → 31; update stale LE Audio comment

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,8 +24,10 @@ android {
 
     defaultConfig {
         applicationId = "com.elodin.walkie_talkie"
-        // Android 13+ required for Bluetooth LE Audio APIs
-        minSdk = 33
+        // API 31 (Android 12) is the real floor: BLUETOOTH_SCAN/CONNECT/ADVERTISE
+        // runtime permissions were introduced in Android 12. Going below 31 would
+        // require a parallel BLUETOOTH_ADMIN legacy-permission branch.
+        minSdk = 31
         targetSdk = 36
         // Resolve versionCode in this priority order. Play rejects duplicate
         // versionCodes, so the goal is "every CI build uploads with a unique,

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <!-- Bluetooth LE Audio Permissions (Android 13+) -->
-    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <!-- Bluetooth runtime permissions (API 31+); minSdk=31 so the legacy
+         BLUETOOTH/BLUETOOTH_ADMIN install-time pair is not needed. -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" 
         android:usesPermissionFlags="neverForLocation" />

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt
@@ -420,21 +420,12 @@ class WalkieTalkieService : Service() {
             .build()
     }
 
-    /**
-     * Check if Bluetooth permissions are granted. On Android 12+ we need
-     * BLUETOOTH_CONNECT to use FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE.
-     */
-    private fun hasBluetoothPermissions(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.BLUETOOTH_CONNECT
-            ) == PackageManager.PERMISSION_GRANTED
-        } else {
-            // On older APIs, BLUETOOTH permission is install-time, not runtime
-            true
-        }
-    }
+    /** BLUETOOTH_CONNECT is needed to attach FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE. */
+    private fun hasBluetoothPermissions(): Boolean =
+        ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.BLUETOOTH_CONNECT
+        ) == PackageManager.PERMISSION_GRANTED
 
     private fun startForegroundWithNotification(freq: String?) {
         val notification = buildNotification(freq)
@@ -451,14 +442,12 @@ class WalkieTalkieService : Service() {
                 notification,
                 serviceType,
             )
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        } else {
             startForeground(
                 NOTIFICATION_ID,
                 notification,
                 serviceType,
             )
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
         }
     }
 

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -59,7 +59,7 @@ One person hosts a Frequency room. Others nearby discover it automatically and j
 
 ── Requirements ──
 
-Android 13 (API 33) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.
+Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.
 ```
 
 Run `bash scripts/validate_store_metadata.sh` to see the current character count (max 4 000).

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -5,7 +5,7 @@ Manual end-to-end test procedure for verifying BLE/L2CAP/voice functionality acr
 ## Pre-flight
 
 ### Hardware Requirements
-- **Two Android 13+ devices** covering the OEM matrix:
+- **Two Android 12+ devices** covering the OEM matrix:
   - **Minimum**: One Pixel + one Samsung
   - **Ideal**: Add Xiaomi or OnePlus to catch aggressive battery-management failures
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -29,4 +29,4 @@ One person hosts a Frequency room. Others nearby discover it automatically and j
 
 ── Requirements ──
 
-Android 13 (API 33) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.
+Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.

--- a/lib/services/onboarding_permission_gateway.dart
+++ b/lib/services/onboarding_permission_gateway.dart
@@ -18,7 +18,7 @@ abstract class OnboardingPermissionGateway {
 
 /// Default implementation backed by the `permission_handler` package.
 ///
-/// Bluetooth on Android 13+ requires three runtime permissions; we ask for
+/// Bluetooth on Android 12+ requires three runtime permissions; we ask for
 /// all of them together and only report `granted` when every one is granted.
 class DefaultOnboardingPermissionGateway
     implements OnboardingPermissionGateway {


### PR DESCRIPTION
## Summary

Closes #269.

The `minSdk = 33` comment cited "Bluetooth LE Audio APIs" as the floor, but the voice plane was walked back to L2CAP CoC + Opus (see README note and `docs/protocol.md` § Voice plane). The _real_ floor is **API 31 (Android 12)**:

| Floor | Gate |
|---|---|
| API 29 | `createInsecureL2capChannel` |
| **API 31** | `BLUETOOTH_SCAN`/`CONNECT`/`ADVERTISE` runtime permission split — natural floor; below this requires a parallel `BLUETOOTH_ADMIN` branch |
| API 33 | `POST_NOTIFICATIONS` runtime ask, themed monochrome icon, `localesConfig` — all degrade gracefully |

Dropping to 31 expands device coverage from ~70–75 % (Android 13+) to ~85–90 % (Android 12+) without any parallel-permission branching.

### Changes

- **`android/app/build.gradle.kts`**: `minSdk = 33` → `minSdk = 31`; replace stale comment with the real reason.
- **`android/app/src/main/AndroidManifest.xml`**: Remove the `BLUETOOTH`/`BLUETOOTH_ADMIN` `maxSdkVersion="30"` declarations — dead code since no device below API 31 can install the app.
- **`android/app/src/main/kotlin/…/WalkieTalkieService.kt`**: Simplify `hasBluetoothPermissions()` (the `else` branch returning `true` for pre-S devices was unreachable); collapse the pre-Q `startForeground` fallback (also unreachable).

## Test plan

- [x] `dart format` clean
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 637/637 passed
- [x] Native C++ tests (mixer, jitter_buffer, resampler, talking_event_queue, ring_buffer, vad_detector, opus_codec, peer_audio_manager) — all passed
- [x] `scripts/presubmit.sh` green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Lowered minimum Android version from 13 to 12, expanding device compatibility.
  * Removed legacy install-time Bluetooth permission declarations and streamlined Bluetooth permission and foreground service handling for consistency.

* **Documentation**
  * Updated play store listing, testing guidance, metadata, and onboarding docs to reflect the new Android 12+ baseline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->