### PR TITLE
fix(#293): host processes JoinRequest — admit or deny incoming guests

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -397,11 +397,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         }
       case JoinRequest m:
         _onJoinRequest(m);
-      // JoinDenied arrives at a guest that was rejected; the guest should
-      // disconnect on receipt. The cubit has no additional state to update
-      // here — the BLE layer handles the disconnection.
+      // JoinDenied arrives at a guest whose JoinRequest was rejected.
+      // Per the protocol, the guest must disconnect on receipt.
       case JoinDenied():
-        break;
+        if (!isClosed) unawaited(leaveRoom());
     }
   }
 
@@ -423,6 +422,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     final localPeerId = _localPeerId;
     if (localPeerId == null) return;
 
+    // Reject a spoofed JoinRequest that claims the host's own peerId.
+    if (m.peerId == localPeerId) return;
+
     final existingIdx = current.roster.indexWhere((p) => p.peerId == m.peerId);
     final bool isRejoin = existingIdx >= 0;
 
@@ -434,8 +436,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     final List<ProtocolPeer> newRoster;
     if (isRejoin) {
       final updated = [...current.roster];
-      updated[existingIdx] = ProtocolPeer(
-        peerId: m.peerId,
+      // Preserve live session flags (muted/talking) so a BLE reconnect
+      // doesn't silently clear the peer's in-room state.
+      updated[existingIdx] = current.roster[existingIdx].copyWith(
         displayName: m.displayName,
         btDevice: m.btDevice,
       );

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -50,7 +50,6 @@ import 'frequency_session_state.dart';
 ///     characteristic via the BLE transport.
 ///   * [applyHostMediaEcho] — host echo path. Forwards the host-approved
 ///     command onto [mediaCommands] so local listeners can react.
-///     Host fan-out (re-broadcasting to all peers) is pending #273.
 ///     This currently does **not** mutate `SessionRoom.mediaState`;
 ///     the cubit's room snapshot only changes when room state is
 ///     replaced (e.g. via [applyJoinAccepted]). The room screen owns
@@ -58,6 +57,10 @@ import 'frequency_session_state.dart';
 ///     [applyHostMediaEcho] for why mediaState advancement isn't in
 ///     the cubit.
 class FrequencySessionCubit extends Cubit<FrequencySessionState> {
+  /// Maximum number of peers in a single room (host + guests), per
+  /// [docs/protocol.md § Beyond 12 peers]. The host counts toward the cap.
+  static const int kMaxRoomPeers = 12;
+
   final IdentityStore identityStore;
   final RecentFrequenciesStore recentFrequenciesStore;
 
@@ -392,12 +395,111 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         if (_applyPeerStateUpdate(m.peerId, muted: m.muted)) {
           _hostRebroadcast(m);
         }
-      // JoinRequest is host-only ingress (future host-side issue).
-      // JoinDenied is reserved for the host-rejects-guest path.
-      case JoinRequest():
+      case JoinRequest m:
+        _onJoinRequest(m);
+      // JoinDenied arrives at a guest that was rejected; the guest should
+      // disconnect on receipt. The cubit has no additional state to update
+      // here — the BLE layer handles the disconnection.
       case JoinDenied():
         break;
     }
+  }
+
+  /// Host-only: processes an incoming [JoinRequest] from a guest.
+  ///
+  /// Admits the guest (up to [kMaxRoomPeers] total) by adding them to the
+  /// roster, emitting updated [SessionRoom] state, and broadcasting a
+  /// [JoinAccepted] with the new roster snapshot. Sends [JoinDenied] with
+  /// [JoinDenyReason.roomFull] when capacity is reached. No-op for guests or
+  /// when the cubit is not in [SessionRoom].
+  ///
+  /// **Re-joins**: if the requesting peer is already in the roster (e.g. after
+  /// a BLE link drop and reconnect), their entry is refreshed in-place with the
+  /// latest displayName / btDevice from the request and a fresh [JoinAccepted]
+  /// is broadcast. The re-join does not consume a roster slot.
+  void _onJoinRequest(JoinRequest m) {
+    final current = state;
+    if (isClosed || current is! SessionRoom || !current.roomIsHost) return;
+    final localPeerId = _localPeerId;
+    if (localPeerId == null) return;
+
+    final existingIdx = current.roster.indexWhere((p) => p.peerId == m.peerId);
+    final bool isRejoin = existingIdx >= 0;
+
+    if (!isRejoin && current.roster.length >= kMaxRoomPeers) {
+      unawaited(_sendJoinDenied(localPeerId, JoinDenyReason.roomFull));
+      return;
+    }
+
+    final List<ProtocolPeer> newRoster;
+    if (isRejoin) {
+      final updated = [...current.roster];
+      updated[existingIdx] = ProtocolPeer(
+        peerId: m.peerId,
+        displayName: m.displayName,
+        btDevice: m.btDevice,
+      );
+      newRoster = updated;
+    } else {
+      newRoster = [
+        ...current.roster,
+        ProtocolPeer(
+          peerId: m.peerId,
+          displayName: m.displayName,
+          btDevice: m.btDevice,
+        ),
+      ];
+    }
+
+    emit(current.copyWith(roster: newRoster));
+    unawaited(_sendJoinAccepted(current, localPeerId, newRoster));
+  }
+
+  /// Builds and sends a [JoinAccepted] carrying the supplied [roster] to the
+  /// control-plane transport. Best-effort: failures are logged and swallowed.
+  Future<void> _sendJoinAccepted(
+    SessionRoom room,
+    String localPeerId,
+    List<ProtocolPeer> roster,
+  ) async {
+    final t = _transport;
+    if (t == null) return;
+    final msg = JoinAccepted(
+      peerId: localPeerId,
+      seq: ++_seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+      hostPeerId: localPeerId,
+      roster: roster,
+      mediaState: room.mediaState,
+    );
+    unawaited(
+      t.send(msg).catchError((Object e) {
+        if (kDebugMode) debugPrint('JoinAccepted send failed: $e');
+        return false;
+      }),
+    );
+  }
+
+  /// Builds and sends a [JoinDenied] to the control-plane transport.
+  /// Best-effort: failures are logged and swallowed.
+  Future<void> _sendJoinDenied(
+    String localPeerId,
+    JoinDenyReason reason,
+  ) async {
+    final t = _transport;
+    if (t == null) return;
+    final msg = JoinDenied(
+      peerId: localPeerId,
+      seq: ++_seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+      reason: reason,
+    );
+    unawaited(
+      t.send(msg).catchError((Object e) {
+        if (kDebugMode) debugPrint('JoinDenied send failed: $e');
+        return false;
+      }),
+    );
   }
 
   /// Applies a single-peer flag mutation (talking or mute) from an inbound
@@ -1717,11 +1819,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   ///   3. Write it to the host's REQUEST characteristic via
   ///      `_transport?.send(cmd)`. The host validates and applies it;
   ///      [applyHostMediaEcho] delivers the canonical echo locally.
-  ///      Host fan-out to all peers (so others see the change) is
-  ///      still pending — tracked in issue #273.
   ///
   /// The BLE transport is wired — step 3 runs alongside the optimistic
-  /// apply. Cross-peer reconciliation depends on host fan-out (#273).
+  /// apply. The host re-broadcasts the echo to all peers via
+  /// [_hostRebroadcast] in [applyHostMediaEcho].
   Future<void> sendMediaCommand({
     required MediaOp op,
     required String source,

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -3861,7 +3861,7 @@ void main() {
       () async {
         final t = makeTestTransport();
         final cubit = await makeEmptyHostCubit(t.transport);
-        // Seed a guest already in the roster.
+        // Seed a guest already in the roster with non-default flags.
         cubit.applyJoinAccepted(
           JoinAccepted(
             peerId: kHostPeerId,
@@ -3870,7 +3870,12 @@ void main() {
             hostPeerId: kHostPeerId,
             roster: const [
               ProtocolPeer(peerId: kHostPeerId, displayName: 'Devon'),
-              ProtocolPeer(peerId: 'p-guest', displayName: 'OldName'),
+              ProtocolPeer(
+                peerId: 'p-guest',
+                displayName: 'OldName',
+                muted: true,
+                talking: false,
+              ),
             ],
           ),
         );
@@ -3891,10 +3896,13 @@ void main() {
         final room = cubit.state as SessionRoom;
         // Roster size must not grow on re-join.
         expect(room.roster.length, rosterSizeBefore);
-        expect(
-          room.roster.firstWhere((p) => p.peerId == 'p-guest').displayName,
-          'NewName',
+        final rejoinedPeer = room.roster.firstWhere(
+          (p) => p.peerId == 'p-guest',
         );
+        expect(rejoinedPeer.displayName, 'NewName');
+        // muted/talking flags must be preserved from the live session state.
+        expect(rejoinedPeer.muted, isTrue);
+        expect(rejoinedPeer.talking, isFalse);
 
         final sent = drainOutbox(t.outbox);
         expect(sent, hasLength(1));
@@ -3905,6 +3913,70 @@ void main() {
         t.transport.dispose();
       },
     );
+
+    test(
+      'host ignores JoinRequest that spoofs the host\'s own peerId',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeEmptyHostCubit(t.transport);
+        t.outbox.clear();
+        final stateBefore = cubit.state;
+
+        // A malicious guest claims to be the host.
+        final req = JoinRequest(
+          peerId: kHostPeerId,
+          seq: 1,
+          atMs: 1000,
+          displayName: 'Impersonator',
+        ).encode();
+        for (final frag in encodeFragments(req)) {
+          t.inbox.add((endpointId: 'EE:FF', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        expect(cubit.state, equals(stateBefore));
+        expect(t.outbox, isEmpty);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test('guest receives JoinDenied → leaves the room', () async {
+      final t = makeTestTransport();
+      final cubit = _makeCubit(
+        transport: t.transport,
+        heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      await cubit.joinRoom(
+        freq: '104.3',
+        isHost: false,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+        sessionUuidLow8: '0102030405060708',
+      );
+      expect(cubit.state, isA<SessionRoom>());
+
+      final denied = const JoinDenied(
+        peerId: kHostPeerId,
+        seq: 1,
+        atMs: 1000,
+        reason: JoinDenyReason.roomFull,
+      ).encode();
+      for (final frag in encodeFragments(denied)) {
+        t.inbox.add((endpointId: 'AA:BB:CC:DD:EE:FF', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      // After JoinDenied the cubit must exit the room and return to Discovery.
+      expect(cubit.state, isA<SessionDiscovery>());
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
   });
 
   // ── TalkingState (VAD outbound) ───────────────────────────────────────

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -3651,6 +3651,262 @@ void main() {
     );
   });
 
+  // ── JoinRequest (host-side admit / deny) ─────────────────────────────
+
+  group('JoinRequest', () {
+    setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+    ({
+      BleControlTransport transport,
+      List<Uint8List> outbox,
+      StreamController<({String endpointId, Uint8List bytes})> inbox,
+    })
+    makeTestTransport() {
+      final outbox = <Uint8List>[];
+      final inbox =
+          StreamController<({String endpointId, Uint8List bytes})>.broadcast();
+      final transport = BleControlTransport.forTest(
+        controlBytes: inbox.stream,
+        writeBytes: (bytes) async {
+          outbox.add(bytes);
+        },
+      );
+      return (transport: transport, outbox: outbox, inbox: inbox);
+    }
+
+    List<FrequencyMessage> drainOutbox(List<Uint8List> outbox) {
+      final reassembler = FragmentReassembler();
+      final messages = <FrequencyMessage>[];
+      for (final bytes in outbox) {
+        final json = reassembler.feed(bytes);
+        if (json != null) messages.add(FrequencyMessage.decode(json));
+      }
+      return messages;
+    }
+
+    const String kHostPeerId = 'fake-peer-id';
+
+    /// Host cubit with just the host on the roster (no guests yet).
+    Future<FrequencySessionCubit> makeEmptyHostCubit(
+      BleControlTransport transport,
+    ) async {
+      final cubit = _makeCubit(
+        transport: transport,
+        heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: kHostPeerId,
+          seq: 1,
+          atMs: 0,
+          hostPeerId: kHostPeerId,
+          roster: const [
+            ProtocolPeer(peerId: kHostPeerId, displayName: 'Devon'),
+          ],
+        ),
+      );
+      return cubit;
+    }
+
+    test(
+      'host admits a new guest: roster grows and JoinAccepted is sent',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeEmptyHostCubit(t.transport);
+        t.outbox.clear();
+
+        final req = const JoinRequest(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          displayName: 'Maya',
+          btDevice: 'AirPods Pro',
+        ).encode();
+        for (final frag in encodeFragments(req)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final room = cubit.state as SessionRoom;
+        expect(
+          room.roster.map((p) => p.peerId),
+          containsAll(['fake-peer-id', 'p-guest']),
+        );
+        expect(
+          room.roster.firstWhere((p) => p.peerId == 'p-guest').displayName,
+          'Maya',
+        );
+
+        final sent = drainOutbox(t.outbox);
+        expect(sent, hasLength(1));
+        expect(sent.single, isA<JoinAccepted>());
+        final ja = sent.single as JoinAccepted;
+        expect(ja.hostPeerId, kHostPeerId);
+        expect(
+          ja.roster.map((p) => p.peerId),
+          containsAll(['fake-peer-id', 'p-guest']),
+        );
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test('host sends JoinDenied when room is full', () async {
+      final t = makeTestTransport();
+      final cubit = _makeCubit(
+        transport: t.transport,
+        heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+
+      // Fill the room to kMaxRoomPeers (including the host).
+      final fullRoster = List<ProtocolPeer>.generate(
+        FrequencySessionCubit.kMaxRoomPeers,
+        (i) => ProtocolPeer(peerId: 'p-$i', displayName: 'Peer $i'),
+      );
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: kHostPeerId,
+          seq: 1,
+          atMs: 0,
+          hostPeerId: kHostPeerId,
+          roster: fullRoster,
+        ),
+      );
+      t.outbox.clear();
+      final stateBefore = cubit.state;
+
+      final req = const JoinRequest(
+        peerId: 'p-overflow',
+        seq: 1,
+        atMs: 2000,
+        displayName: 'Extra',
+      ).encode();
+      for (final frag in encodeFragments(req)) {
+        t.inbox.add((endpointId: 'CC:DD', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      // Roster must not have grown.
+      expect(cubit.state, equals(stateBefore));
+
+      final sent = drainOutbox(t.outbox);
+      expect(sent, hasLength(1));
+      expect(sent.single, isA<JoinDenied>());
+      expect((sent.single as JoinDenied).reason, JoinDenyReason.roomFull);
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test('guest role silently ignores incoming JoinRequest', () async {
+      final t = makeTestTransport();
+      final cubit = _makeCubit(
+        transport: t.transport,
+        heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      // Join as guest (isHost: false)
+      await cubit.joinRoom(
+        freq: '104.3',
+        isHost: false,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+        sessionUuidLow8: '0102030405060708',
+      );
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: kHostPeerId,
+          seq: 1,
+          atMs: 0,
+          hostPeerId: kHostPeerId,
+          roster: const [
+            ProtocolPeer(peerId: kHostPeerId, displayName: 'Devon'),
+            ProtocolPeer(peerId: 'fake-peer-id', displayName: 'Maya'),
+          ],
+        ),
+      );
+      t.outbox.clear();
+      final stateBefore = cubit.state;
+
+      final req = const JoinRequest(
+        peerId: 'p-other',
+        seq: 1,
+        atMs: 1000,
+        displayName: 'Other',
+      ).encode();
+      for (final frag in encodeFragments(req)) {
+        t.inbox.add((endpointId: 'BB:CC', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      expect(cubit.state, equals(stateBefore));
+      expect(t.outbox, isEmpty);
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test(
+      're-join from known peer refreshes entry and re-sends JoinAccepted',
+      () async {
+        final t = makeTestTransport();
+        final cubit = await makeEmptyHostCubit(t.transport);
+        // Seed a guest already in the roster.
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: kHostPeerId,
+            seq: 2,
+            atMs: 0,
+            hostPeerId: kHostPeerId,
+            roster: const [
+              ProtocolPeer(peerId: kHostPeerId, displayName: 'Devon'),
+              ProtocolPeer(peerId: 'p-guest', displayName: 'OldName'),
+            ],
+          ),
+        );
+        t.outbox.clear();
+        final rosterSizeBefore = (cubit.state as SessionRoom).roster.length;
+
+        final req = const JoinRequest(
+          peerId: 'p-guest',
+          seq: 2,
+          atMs: 2000,
+          displayName: 'NewName',
+        ).encode();
+        for (final frag in encodeFragments(req)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final room = cubit.state as SessionRoom;
+        // Roster size must not grow on re-join.
+        expect(room.roster.length, rosterSizeBefore);
+        expect(
+          room.roster.firstWhere((p) => p.peerId == 'p-guest').displayName,
+          'NewName',
+        );
+
+        final sent = drainOutbox(t.outbox);
+        expect(sent, hasLength(1));
+        expect(sent.single, isA<JoinAccepted>());
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+  });
+
   // ── TalkingState (VAD outbound) ───────────────────────────────────────
 
   group('TalkingState outbound', () {


### PR DESCRIPTION
## Summary

- Wires the host-side `JoinRequest` handler in `FrequencySessionCubit._onTransportMessage`. Previously the case was silently dropped with a comment saying *"future host-side issue"* — meaning no guest could ever join a frequency from the Dart control-plane.
- New `_onJoinRequest` method: checks room capacity (`kMaxRoomPeers = 12`), rejects latecomers with `JoinDenied(roomFull)`, otherwise appends the peer to the roster and broadcasts `JoinAccepted` with the updated snapshot.
- Re-joins (peer already on roster) refresh `displayName` / `btDevice` in-place without consuming a roster slot.
- Removes three stale `#273` references in doc-comments — host fan-out has been wired since PR #289.

## Test plan

- [x] `flutter analyze` clean
- [x] New cubit unit tests (4):
  - host admits new guest → roster grows, `JoinAccepted` in outbox
  - host rejects when room full → roster unchanged, `JoinDenied(roomFull)` in outbox
  - guest role silently ignores `JoinRequest` → no state change, empty outbox
  - re-join from known peer → roster size unchanged, display name updated, fresh `JoinAccepted` sent
- [x] Full `flutter test` green (641 tests, was 637)
- [x] `scripts/presubmit.sh` clean (formatting + analyze + Dart tests + C++ tests)

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-peer session join handling with a maximum room capacity of 12 peers.
  * Hosts can admit or deny guest join requests; roster updates are applied automatically.
  * Guests receive clear accept/deny responses; denied guests are returned to discovery.
  * Rejoining peers refresh their existing roster entry (e.g., display name) without consuming extra slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->