### PR TITLE
fix(#295): propagate GATT service-setup failures to Flutter

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -292,6 +292,8 @@ class GattClientManager(
                         disconnect()
                     } else {
                         Log.e(TAG, "CCCD write failed with status $status")
+                        onError?.invoke("GATT_SETUP_FAILED")
+                        disconnect()
                     }
                 }
             }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -171,10 +171,17 @@ class GattClientManager(
             // Proceed to service discovery regardless of MTU result.
             // If the stack refuses the request, propagate the failure so Flutter
             // can react (the onServicesDiscovered callback will never fire).
-            val started = gatt.discoverServices()
-            if (!started) {
-                Log.e(TAG, "discoverServices() returned false — GATT stack busy or disconnected")
-                onError?.invoke("GATT_SETUP_FAILED")
+            // SecurityException is thrown if BLUETOOTH_CONNECT is revoked mid-session.
+            try {
+                val started = gatt.discoverServices()
+                if (!started) {
+                    Log.e(TAG, "discoverServices() returned false — GATT stack busy or disconnected")
+                    onError?.invoke("GATT_SETUP_FAILED")
+                    gatt.disconnect()
+                }
+            } catch (e: SecurityException) {
+                Log.e(TAG, "Missing Bluetooth permission for discoverServices()", e)
+                onError?.invoke("BLUETOOTH_PERMISSION_DENIED")
                 gatt.disconnect()
             }
         }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -189,7 +189,11 @@ class GattClientManager(
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "Service discovery failed with status $status")
-                onError?.invoke("GATT_SETUP_FAILED")
+                if (status in GattConstants.AUTHORIZATION_ERRORS) {
+                    onError?.invoke("GATT_AUTHORIZATION_DENIED")
+                } else {
+                    onError?.invoke("GATT_SETUP_FAILED")
+                }
                 gatt.disconnect()
                 return
             }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -168,19 +168,30 @@ class GattClientManager(
             } else {
                 Log.w(TAG, "MTU change failed with status $status")
             }
-            // Proceed to service discovery regardless of MTU result
-            gatt.discoverServices()
+            // Proceed to service discovery regardless of MTU result.
+            // If the stack refuses the request, propagate the failure so Flutter
+            // can react (the onServicesDiscovered callback will never fire).
+            val started = gatt.discoverServices()
+            if (!started) {
+                Log.e(TAG, "discoverServices() returned false — GATT stack busy or disconnected")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
+            }
         }
 
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 Log.e(TAG, "Service discovery failed with status $status")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
                 return
             }
 
             val service = gatt.getService(GattConstants.SERVICE_UUID)
             if (service == null) {
                 Log.e(TAG, "Walkie-talkie service not found on host")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
                 return
             }
 
@@ -188,6 +199,8 @@ class GattClientManager(
             requestCharacteristic = service.getCharacteristic(GattConstants.REQUEST_CHAR_UUID)
             if (requestCharacteristic == null) {
                 Log.e(TAG, "REQUEST characteristic not found")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
                 return
             }
 
@@ -195,6 +208,8 @@ class GattClientManager(
             responseCharacteristic = service.getCharacteristic(GattConstants.RESPONSE_CHAR_UUID)
             if (responseCharacteristic == null) {
                 Log.e(TAG, "RESPONSE characteristic not found")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
                 return
             }
 
@@ -202,6 +217,8 @@ class GattClientManager(
             val notifyEnabled = gatt.setCharacteristicNotification(responseCharacteristic, true)
             if (!notifyEnabled) {
                 Log.e(TAG, "Failed to enable characteristic notification")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
                 return
             }
 
@@ -209,6 +226,8 @@ class GattClientManager(
             val cccd = responseCharacteristic?.getDescriptor(GattConstants.CCCD_UUID)
             if (cccd == null) {
                 Log.e(TAG, "CCCD descriptor not found on RESPONSE characteristic")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
                 return
             }
 
@@ -221,6 +240,8 @@ class GattClientManager(
             )
             if (writeSuccess != BluetoothStatusCodes.SUCCESS) {
                 Log.e(TAG, "Failed to write CCCD descriptor: $writeSuccess")
+                onError?.invoke("GATT_SETUP_FAILED")
+                gatt.disconnect()
             } else {
                 Log.i(TAG, "GATT client setup complete, notifications enabled")
             }

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -285,6 +285,18 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         // SessionPermissionDenied without waiting for the 5-second poll
         // cycle in DefaultPermissionWatcher.
         unawaited(cubit.recheckPermissions());
+      } else if (type == 'gattError') {
+        // GATT client failure from GattClientManager — either a permission
+        // revocation (reason contains BLUETOOTH_PERMISSION_DENIED or
+        // GATT_AUTHORIZATION_DENIED) or a service-setup failure
+        // (GATT_SETUP_FAILED). Permission-related reasons get an immediate
+        // re-check; other reasons are left for the heartbeat watchdog to
+        // surface as a host-drop and trigger the reconnect flow.
+        final reason = event['reason'] as String? ?? '';
+        if (reason.contains('PERMISSION_DENIED') ||
+            reason.contains('AUTHORIZATION_DENIED')) {
+          unawaited(cubit.recheckPermissions());
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

- **Native (`GattClientManager.kt`)**: All failure paths in `onServicesDiscovered` (service not found, REQUEST/RESPONSE characteristic missing, `setCharacteristicNotification` fails, CCCD descriptor missing, CCCD write fails) now call `onError("GATT_SETUP_FAILED")` and `gatt.disconnect()`. Previously they returned silently, leaving the BT connection open-but-unusable with no event reaching Flutter.
- **Native**: `onMtuChanged` now checks the boolean return value of `gatt.discoverServices()`. If the stack refuses the request, `onError` is called and the GATT link is torn down so the heartbeat watchdog can react.
- **Dart (`FrequencyRoomScreen`)**: `audioEvents` listener adds a `gattError` branch. Permission-related reasons (`BLUETOOTH_PERMISSION_DENIED`, `GATT_AUTHORIZATION_DENIED`) call `cubit.recheckPermissions()` immediately — the same path used for `audioError` / `error` events. Other reasons (e.g. `GATT_SETUP_FAILED`, `GATT_DISCONNECTED`) are left for the heartbeat watchdog to surface as a host-drop and trigger the reconnect flow.

## Test plan

- [x] `dart format --set-exit-if-changed .` — no changes
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 643/643 passed
- [x] C++ native tests — all passed
- [ ] On-device: simulate GATT setup failure (connect to a device not advertising the Frequency service UUID) — expect `gattError` in Flutter logs and eventual reconnect / `SessionPermissionDenied` transition rather than hanging indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust Bluetooth setup: stricter validation of services/characteristics and notification enabling; clearer detection of setup failures and immediate graceful disconnection to avoid unstable states.
  * Descriptor (CCCD) write failures now fail setup and trigger disconnects.
  * App proactively rechecks permissions when native audio reports permission or authorization denials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->