### PR TITLE
fix(#298): wire voice L2CAP lifecycle — startVoiceServer, connectVoiceClient, stopVoiceTransport

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1163,10 +1163,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       );
       unawaited(audio.startGattServer());
       // Close the guest-side voice client before opening the host server.
-      // Without this, the native layer reuses the existing transport (which
-      // was built as a client and has no peer-registration callback), so
+      // Awaited so the native layer tears down the client transport before
+      // startVoiceServer() runs; without this, the native code reuses the
+      // existing client-mode transport (no peer-registration callback) and
       // reconnecting guests would never be registered with registerVoicePeer.
-      unawaited(audio.stopVoiceTransport());
+      await audio.stopVoiceTransport();
+      if (isClosed) return;
+      final promoted = state;
+      if (promoted is! SessionRoom || !promoted.roomIsHost) return;
       // Open the voice L2CAP server. Store the future so _sendJoinAccepted
       // can await it if a guest reconnects before the native call returns.
       final gen = ++_voiceGeneration;

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -218,6 +218,18 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// dial. Cleared on room teardown alongside [_sessionUuid].
   int? _voicePsm;
 
+  /// In-flight [AudioService.startVoiceServer] future. Stored so
+  /// [_sendJoinAccepted] can await it when a guest arrives before the native
+  /// call resolves, preventing a null PSM in the first [JoinAccepted].
+  /// Nulled on every room teardown.
+  Future<int?>? _voiceServerStartup;
+
+  /// Incremented each time the host role starts a new voice server session.
+  /// Guards the `.then` callback in [_promoteToHost] / [joinRoom] so a late
+  /// completion from a torn-down session cannot overwrite the next session's
+  /// [_voicePsm].
+  int _voiceGeneration = 0;
+
   FrequencySessionCubit({
     required this.identityStore,
     required this.recentFrequenciesStore,
@@ -484,6 +496,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   ) async {
     final t = _transport;
     if (t == null) return;
+    // If startVoiceServer() hasn't resolved yet, wait for it so we never
+    // send JoinAccepted(voicePsm: null) to a guest just because the native
+    // call is still in flight.
+    final psm = _voicePsm ?? await _voiceServerStartup;
+    if (_voicePsm == null && psm != null) _voicePsm = psm;
     final msg = JoinAccepted(
       peerId: localPeerId,
       seq: ++_seq,
@@ -492,7 +509,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       roster: roster,
       mediaState: room.mediaState,
       recipientPeerId: joiningPeerId,
-      voicePsm: _voicePsm,
+      voicePsm: psm,
     );
     unawaited(
       t.send(msg).catchError((Object e) {
@@ -1142,11 +1159,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         ),
       );
       unawaited(audio.startGattServer());
-      // Open the voice L2CAP server. The PSM will be included in the next
-      // JoinAccepted sent to guests who re-connect after the host transfer.
+      // Open the voice L2CAP server. Store the future so _sendJoinAccepted
+      // can await it if a guest reconnects before the native call returns.
+      final gen = ++_voiceGeneration;
+      _voiceServerStartup = audio.startVoiceServer();
       unawaited(
-        audio.startVoiceServer().then((psm) {
-          if (!isClosed) _voicePsm = psm;
+        _voiceServerStartup!.then((psm) {
+          if (!isClosed && _voiceGeneration == gen) _voicePsm = psm;
         }),
       );
     }
@@ -1379,12 +1398,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           audio.startAdvertising(sessionUuid: sessionUuid, displayName: myName),
         );
         unawaited(audio.startGattServer());
-        // Open the L2CAP voice server and store the PSM. Fire-and-forget:
-        // discovery + GATT handshake latency means the first JoinRequest
-        // won't arrive before the native call returns.
+        // Open the L2CAP voice server. Store the future so _sendJoinAccepted
+        // can await it if a guest arrives before the native call returns.
+        final gen = ++_voiceGeneration;
+        _voiceServerStartup = audio.startVoiceServer();
         unawaited(
-          audio.startVoiceServer().then((psm) {
-            if (!isClosed) _voicePsm = psm;
+          _voiceServerStartup!.then((psm) {
+            if (!isClosed && _voiceGeneration == gen) _voicePsm = psm;
           }),
         );
       }
@@ -1509,6 +1529,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _seq = 0;
     _sessionUuid = null;
     _voicePsm = null;
+    _voiceServerStartup = null;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
     emit(
@@ -1592,6 +1613,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _transport?.forgetAllPeers();
     _seq = 0;
     _voicePsm = null;
+    _voiceServerStartup = null;
     // Best-effort native teardown — failures are already logged inside
     // AudioService and must not block the state transition.
     final audio = _audio;

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -501,6 +501,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // call is still in flight.
     final psm = _voicePsm ?? await _voiceServerStartup;
     if (_voicePsm == null && psm != null) _voicePsm = psm;
+    // Guard: the await above can suspend this method across a room teardown
+    // or role change. Re-check that we're still a live host before sending.
+    if (isClosed || state is! SessionRoom) return;
     final msg = JoinAccepted(
       peerId: localPeerId,
       seq: ++_seq,
@@ -1159,6 +1162,11 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         ),
       );
       unawaited(audio.startGattServer());
+      // Close the guest-side voice client before opening the host server.
+      // Without this, the native layer reuses the existing transport (which
+      // was built as a client and has no peer-registration callback), so
+      // reconnecting guests would never be registered with registerVoicePeer.
+      unawaited(audio.stopVoiceTransport());
       // Open the voice L2CAP server. Store the future so _sendJoinAccepted
       // can await it if a guest reconnects before the native call returns.
       final gen = ++_voiceGeneration;
@@ -1530,6 +1538,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _sessionUuid = null;
     _voicePsm = null;
     _voiceServerStartup = null;
+    ++_voiceGeneration; // invalidate any in-flight startVoiceServer callback
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
     emit(
@@ -1614,6 +1623,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _seq = 0;
     _voicePsm = null;
     _voiceServerStartup = null;
+    ++_voiceGeneration; // invalidate any in-flight startVoiceServer callback
     // Best-effort native teardown — failures are already logged inside
     // AudioService and must not block the state transition.
     final audio = _audio;

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -211,6 +211,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
   /// [_initiateHostTransfer] to tell the promoted peer what UUID to advertise.
   String? _sessionUuid;
 
+  /// PSM of the running voice L2CAP server (host path only). Set when
+  /// [joinRoom] or [_promoteToHost] succeeds in opening the native socket;
+  /// null when the native layer returned null (e.g. BT off) or on the guest
+  /// path. Threaded into every [JoinAccepted] so guests know which PSM to
+  /// dial. Cleared on room teardown alongside [_sessionUuid].
+  int? _voicePsm;
+
   FrequencySessionCubit({
     required this.identityStore,
     required this.recentFrequenciesStore,
@@ -485,6 +492,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       roster: roster,
       mediaState: room.mediaState,
       recipientPeerId: joiningPeerId,
+      voicePsm: _voicePsm,
     );
     unawaited(
       t.send(msg).catchError((Object e) {
@@ -1134,6 +1142,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         ),
       );
       unawaited(audio.startGattServer());
+      // Open the voice L2CAP server. The PSM will be included in the next
+      // JoinAccepted sent to guests who re-connect after the host transfer.
+      unawaited(
+        audio.startVoiceServer().then((psm) {
+          if (!isClosed) _voicePsm = psm;
+        }),
+      );
     }
   }
 
@@ -1364,6 +1379,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           audio.startAdvertising(sessionUuid: sessionUuid, displayName: myName),
         );
         unawaited(audio.startGattServer());
+        // Open the L2CAP voice server and store the PSM. Fire-and-forget:
+        // discovery + GATT handshake latency means the first JoinRequest
+        // won't arrive before the native call returns.
+        unawaited(
+          audio.startVoiceServer().then((psm) {
+            if (!isClosed) _voicePsm = psm;
+          }),
+        );
       }
     } else {
       if (freq == null) {
@@ -1450,6 +1473,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         unawaited(audio.stopGattServer());
       }
     }
+    // Tear down the voice L2CAP transport for both roles: closes the server
+    // socket on the host and the client channel on the guest. Safe to call
+    // when no voice channel is open (e.g. the native start failed).
+    unawaited(_audio?.stopVoiceTransport());
     // Stop any in-progress reconnect so BLE retries halt promptly when
     // the user manually leaves rather than waiting for the next delay tick.
     _reconnectController?.cancel();
@@ -1481,6 +1508,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _transport?.forgetAllPeers();
     _seq = 0;
     _sessionUuid = null;
+    _voicePsm = null;
     final recent = await _loadRecentFrequencies();
     if (isClosed) return;
     emit(
@@ -1563,6 +1591,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     _weakSignalDetector.clear();
     _transport?.forgetAllPeers();
     _seq = 0;
+    _voicePsm = null;
     // Best-effort native teardown — failures are already logged inside
     // AudioService and must not block the state transition.
     final audio = _audio;
@@ -1571,6 +1600,14 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         await audio.stopVoice();
       } catch (error, stackTrace) {
         debugPrint('stopVoice during permission revoke failed: $error');
+        debugPrintStack(stackTrace: stackTrace);
+      }
+      try {
+        await audio.stopVoiceTransport();
+      } catch (error, stackTrace) {
+        debugPrint(
+          'stopVoiceTransport during permission revoke failed: $error',
+        );
         debugPrintStack(stackTrace: stackTrace);
       }
       try {
@@ -1763,6 +1800,25 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         connectionPhase: ConnectionPhase.online,
       ),
     );
+    // Open the voice L2CAP channel when the host has advertised a PSM.
+    // Guest-only: the host never receives its own JoinAccepted and
+    // roomIsHost is always false on the guest path that reaches here.
+    // macAddress is required to dial the native CoC; we skip silently when
+    // it's absent (cosmetic / test-only entries that have no BLE device).
+    final voicePsm = msg.voicePsm;
+    final mac = current.macAddress;
+    final audio = _audio;
+    if (!current.roomIsHost &&
+        voicePsm != null &&
+        mac != null &&
+        audio != null) {
+      unawaited(
+        audio.connectVoiceClient(mac, voicePsm).catchError((Object e) {
+          if (kDebugMode) debugPrint('connectVoiceClient failed: $e');
+          return false;
+        }),
+      );
+    }
   }
 
   /// Called by heartbeat detection when the guest hasn't heard from the host
@@ -1961,6 +2017,8 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         unawaited(audio.stopGattServer());
       }
     }
+    // Stop the voice transport for both roles (safe when not running).
+    unawaited(_audio?.stopVoiceTransport());
     // Cancel an in-progress reconnect before closing so the attempt loop
     // won't call emit() or leaveRoom() after the cubit is disposed.
     _reconnectController?.cancel();

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -972,98 +972,107 @@ void main() {
       expect(calls.map((c) => c.method), contains('stopVoiceTransport'));
     });
 
-    test('_promoteToHost calls startVoiceServer and PSM appears in JoinAccepted',
-        () async {
-      TestWidgetsFlutterBinding.ensureInitialized();
-      const channel = MethodChannel('com.elodin.walkie_talkie/audio');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (call) async {
-            if (call.method == 'startVoiceServer') return 0x81;
-            return true;
-          });
-      addTearDown(() {
+    test(
+      '_promoteToHost calls startVoiceServer and PSM appears in JoinAccepted',
+      () async {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, null);
-      });
+            .setMockMethodCallHandler(channel, (call) async {
+              if (call.method == 'startVoiceServer') return 0x81;
+              return true;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
 
-      final outbox = <Uint8List>[];
-      final inbox =
-          StreamController<({String endpointId, Uint8List bytes})>.broadcast();
-      final transport = BleControlTransport.forTest(
-        controlBytes: inbox.stream,
-        writeBytes: (bytes) async => outbox.add(bytes),
-      );
-      final store = _FakeStore(initial: 'Devon');
-      store._peerId = 'peer-2';
-      final cubit = _makeCubit(
-        audio: AudioService(),
-        transport: transport,
-        identityStore: store,
-        heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
-      );
-      await cubit.bootstrap();
-      cubit.emit(
-        const SessionRoom(
-          myName: 'Devon',
-          roomFreq: '104.3',
-          roomIsHost: false,
-          hostPeerId: 'peer-1',
-          macAddress: 'AA:BB:CC:DD:EE:FF',
-          sessionUuidLow8: '0011223344556677',
-          roster: [
-            ProtocolPeer(peerId: 'peer-1', displayName: 'Maya'),
-            ProtocolPeer(peerId: 'peer-2', displayName: 'Devon'),
-          ],
-        ),
-      );
+        final outbox = <Uint8List>[];
+        final inbox =
+            StreamController<
+              ({String endpointId, Uint8List bytes})
+            >.broadcast();
+        final transport = BleControlTransport.forTest(
+          controlBytes: inbox.stream,
+          writeBytes: (bytes) async => outbox.add(bytes),
+        );
+        final store = _FakeStore(initial: 'Devon');
+        store._peerId = 'peer-2';
+        final cubit = _makeCubit(
+          audio: AudioService(),
+          transport: transport,
+          identityStore: store,
+          heartbeats: HeartbeatScheduler(
+            pingInterval: const Duration(hours: 1),
+          ),
+        );
+        await cubit.bootstrap();
+        cubit.emit(
+          const SessionRoom(
+            myName: 'Devon',
+            roomFreq: '104.3',
+            roomIsHost: false,
+            hostPeerId: 'peer-1',
+            macAddress: 'AA:BB:CC:DD:EE:FF',
+            sessionUuidLow8: '0011223344556677',
+            roster: [
+              ProtocolPeer(peerId: 'peer-1', displayName: 'Maya'),
+              ProtocolPeer(peerId: 'peer-2', displayName: 'Devon'),
+            ],
+          ),
+        );
 
-      // Inject a HostTransfer that promotes peer-2 (this cubit) to host.
-      for (final frag in encodeFragments(
-        const HostTransfer(
-          peerId: 'peer-1',
-          seq: 1,
-          atMs: 0,
-          newHostPeerId: 'peer-2',
-          sessionUuid: _testHostSessionUuid,
-        ).encode(),
-      )) {
-        inbox.add((endpointId: 'AA:BB', bytes: frag));
-      }
-      // Allow _promoteToHost and startVoiceServer to complete.
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-      outbox.clear();
+        // Inject a HostTransfer that promotes peer-2 (this cubit) to host.
+        for (final frag in encodeFragments(
+          const HostTransfer(
+            peerId: 'peer-1',
+            seq: 1,
+            atMs: 0,
+            newHostPeerId: 'peer-2',
+            sessionUuid: _testHostSessionUuid,
+          ).encode(),
+        )) {
+          inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        // Allow _promoteToHost and startVoiceServer to complete.
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        outbox.clear();
 
-      // Now send a JoinRequest — the host should reply with voicePsm set.
-      for (final frag in encodeFragments(
-        const JoinRequest(
-          peerId: 'peer-3',
-          seq: 1,
-          atMs: 1000,
-          displayName: 'Charlie',
-        ).encode(),
-      )) {
-        inbox.add((endpointId: 'CC:DD', bytes: frag));
-      }
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
+        // Now send a JoinRequest — the host should reply with voicePsm set.
+        for (final frag in encodeFragments(
+          const JoinRequest(
+            peerId: 'peer-3',
+            seq: 1,
+            atMs: 1000,
+            displayName: 'Charlie',
+          ).encode(),
+        )) {
+          inbox.add((endpointId: 'CC:DD', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
 
-      final reassembler = FragmentReassembler();
-      final messages = <FrequencyMessage>[];
-      for (final bytes in outbox) {
-        final json = reassembler.feed(bytes);
-        if (json != null) messages.add(FrequencyMessage.decode(json));
-      }
-      final ja = messages.whereType<JoinAccepted>().firstOrNull;
-      expect(ja, isNotNull, reason: 'promoted host should send JoinAccepted');
-      expect(ja!.voicePsm, 0x81,
-          reason: 'promoted host should include voice PSM in JoinAccepted');
+        final reassembler = FragmentReassembler();
+        final messages = <FrequencyMessage>[];
+        for (final bytes in outbox) {
+          final json = reassembler.feed(bytes);
+          if (json != null) messages.add(FrequencyMessage.decode(json));
+        }
+        final ja = messages.whereType<JoinAccepted>().firstOrNull;
+        expect(ja, isNotNull, reason: 'promoted host should send JoinAccepted');
+        expect(
+          ja!.voicePsm,
+          0x81,
+          reason: 'promoted host should include voice PSM in JoinAccepted',
+        );
 
-      await cubit.close();
-      await inbox.close();
-      transport.dispose();
-    });
+        await cubit.close();
+        await inbox.close();
+        transport.dispose();
+      },
+    );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'leaveRoom drops back to Discovery with the prior name',

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -972,6 +972,99 @@ void main() {
       expect(calls.map((c) => c.method), contains('stopVoiceTransport'));
     });
 
+    test('_promoteToHost calls startVoiceServer and PSM appears in JoinAccepted',
+        () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method == 'startVoiceServer') return 0x81;
+            return true;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final outbox = <Uint8List>[];
+      final inbox =
+          StreamController<({String endpointId, Uint8List bytes})>.broadcast();
+      final transport = BleControlTransport.forTest(
+        controlBytes: inbox.stream,
+        writeBytes: (bytes) async => outbox.add(bytes),
+      );
+      final store = _FakeStore(initial: 'Devon');
+      store._peerId = 'peer-2';
+      final cubit = _makeCubit(
+        audio: AudioService(),
+        transport: transport,
+        identityStore: store,
+        heartbeats: HeartbeatScheduler(pingInterval: const Duration(hours: 1)),
+      );
+      await cubit.bootstrap();
+      cubit.emit(
+        const SessionRoom(
+          myName: 'Devon',
+          roomFreq: '104.3',
+          roomIsHost: false,
+          hostPeerId: 'peer-1',
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+          sessionUuidLow8: '0011223344556677',
+          roster: [
+            ProtocolPeer(peerId: 'peer-1', displayName: 'Maya'),
+            ProtocolPeer(peerId: 'peer-2', displayName: 'Devon'),
+          ],
+        ),
+      );
+
+      // Inject a HostTransfer that promotes peer-2 (this cubit) to host.
+      for (final frag in encodeFragments(
+        const HostTransfer(
+          peerId: 'peer-1',
+          seq: 1,
+          atMs: 0,
+          newHostPeerId: 'peer-2',
+          sessionUuid: _testHostSessionUuid,
+        ).encode(),
+      )) {
+        inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      // Allow _promoteToHost and startVoiceServer to complete.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      outbox.clear();
+
+      // Now send a JoinRequest — the host should reply with voicePsm set.
+      for (final frag in encodeFragments(
+        const JoinRequest(
+          peerId: 'peer-3',
+          seq: 1,
+          atMs: 1000,
+          displayName: 'Charlie',
+        ).encode(),
+      )) {
+        inbox.add((endpointId: 'CC:DD', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final reassembler = FragmentReassembler();
+      final messages = <FrequencyMessage>[];
+      for (final bytes in outbox) {
+        final json = reassembler.feed(bytes);
+        if (json != null) messages.add(FrequencyMessage.decode(json));
+      }
+      final ja = messages.whereType<JoinAccepted>().firstOrNull;
+      expect(ja, isNotNull, reason: 'promoted host should send JoinAccepted');
+      expect(ja!.voicePsm, 0x81,
+          reason: 'promoted host should include voice PSM in JoinAccepted');
+
+      await cubit.close();
+      await inbox.close();
+      transport.dispose();
+    });
+
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'leaveRoom drops back to Discovery with the prior name',
       build: () => _makeCubit(),

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -700,6 +700,278 @@ void main() {
       );
     });
 
+    // ── Voice L2CAP lifecycle ──────────────────────────────────────────
+
+    test('joinRoom as host calls startVoiceServer', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            if (call.method == 'startVoiceServer') return 0x81;
+            return true;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final cubit = _makeCubit(audio: AudioService());
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      await cubit.joinRoom(isHost: true);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(calls.map((c) => c.method), contains('startVoiceServer'));
+      await cubit.close();
+    });
+
+    test(
+      'JoinAccepted sent to guest carries the voice PSM when server started',
+      () async {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              if (call.method == 'startVoiceServer') return 0x81;
+              return true;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        final outbox = <Uint8List>[];
+        final inbox =
+            StreamController<
+              ({String endpointId, Uint8List bytes})
+            >.broadcast();
+        final transport = BleControlTransport.forTest(
+          controlBytes: inbox.stream,
+          writeBytes: (bytes) async => outbox.add(bytes),
+        );
+        final cubit = _makeCubit(
+          audio: AudioService(),
+          transport: transport,
+          heartbeats: HeartbeatScheduler(
+            pingInterval: const Duration(hours: 1),
+          ),
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(isHost: true);
+        // Let startVoiceServer() complete and store _voicePsm.
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        outbox.clear();
+
+        final req = const JoinRequest(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 1000,
+          displayName: 'Maya',
+        ).encode();
+        for (final frag in encodeFragments(req)) {
+          inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        final reassembler = FragmentReassembler();
+        final messages = <FrequencyMessage>[];
+        for (final bytes in outbox) {
+          final json = reassembler.feed(bytes);
+          if (json != null) messages.add(FrequencyMessage.decode(json));
+        }
+        final ja = messages.whereType<JoinAccepted>().first;
+        expect(ja.voicePsm, 0x81);
+
+        await cubit.close();
+        await inbox.close();
+        transport.dispose();
+      },
+    );
+
+    test(
+      'applyJoinAccepted with voicePsm dials connectVoiceClient on guest',
+      () async {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              calls.add(call);
+              return true;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        final cubit = _makeCubit(audio: AudioService());
+        cubit.emit(
+          const SessionRoom(
+            myName: 'Maya',
+            roomFreq: '104.3',
+            roomIsHost: false,
+            macAddress: 'AA:BB:CC:DD:EE:FF',
+          ),
+        );
+
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [
+              ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ],
+            voicePsm: 0x81,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final connectCall = calls.firstWhere(
+          (c) => c.method == 'connectVoiceClient',
+          orElse: () => throw TestFailure('connectVoiceClient was not called'),
+        );
+        expect(connectCall.arguments['macAddress'], 'AA:BB:CC:DD:EE:FF');
+        expect(connectCall.arguments['psm'], 0x81);
+
+        await cubit.close();
+      },
+    );
+
+    test(
+      'applyJoinAccepted without voicePsm does not call connectVoiceClient',
+      () async {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              calls.add(call);
+              return true;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null);
+        });
+
+        final cubit = _makeCubit(audio: AudioService());
+        cubit.emit(
+          const SessionRoom(
+            myName: 'Maya',
+            roomFreq: '104.3',
+            roomIsHost: false,
+            macAddress: 'AA:BB:CC:DD:EE:FF',
+          ),
+        );
+
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [
+              ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ],
+            // no voicePsm
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          calls.map((c) => c.method),
+          isNot(contains('connectVoiceClient')),
+        );
+        await cubit.close();
+      },
+    );
+
+    test('leaveRoom calls stopVoiceTransport for host', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            if (call.method == 'startVoiceServer') return 0x81;
+            return true;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final cubit = _makeCubit(audio: AudioService());
+      cubit.emit(const SessionDiscovery(myName: 'Maya'));
+      await cubit.joinRoom(isHost: true);
+      await Future<void>.delayed(Duration.zero);
+      calls.clear();
+
+      await cubit.leaveRoom();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(calls.map((c) => c.method), contains('stopVoiceTransport'));
+      await cubit.close();
+    });
+
+    test('leaveRoom calls stopVoiceTransport for guest', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return true;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final cubit = _makeCubit(audio: AudioService());
+      cubit.emit(
+        const SessionRoom(myName: 'Maya', roomFreq: '104.3', roomIsHost: false),
+      );
+      calls.clear();
+
+      await cubit.leaveRoom();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(calls.map((c) => c.method), contains('stopVoiceTransport'));
+      await cubit.close();
+    });
+
+    test('close() calls stopVoiceTransport', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return true;
+          });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      final cubit = _makeCubit(audio: AudioService());
+      cubit.emit(
+        const SessionRoom(myName: 'Maya', roomFreq: '104.3', roomIsHost: true),
+      );
+      calls.clear();
+
+      await cubit.close();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(calls.map((c) => c.method), contains('stopVoiceTransport'));
+    });
+
     blocTest<FrequencySessionCubit, FrequencySessionState>(
       'leaveRoom drops back to Discovery with the prior name',
       build: () => _makeCubit(),
@@ -4898,4 +5170,7 @@ class _StubLocalTalkingAudio extends AudioService {
 
   @override
   Future<bool> stopGattServer() async => true;
+
+  @override
+  Future<bool> stopVoiceTransport() async => true;
 }


### PR DESCRIPTION
## Summary

Fixes [#298](https://github.com/ElodinLaarz/walkie-talkie/issues/298) — voice was permanently silent after joining a room because the L2CAP channel was never established.

- **Host `joinRoom`**: calls `audio.startVoiceServer()` and stores the PSM in `_voicePsm`
- **`_sendJoinAccepted`**: threads `_voicePsm` into every `JoinAccepted` so guests know which L2CAP PSM to dial
- **`applyJoinAccepted` (guest path)**: calls `audio.connectVoiceClient(macAddress, voicePsm)` when `voicePsm` is present
- **`_promoteToHost`**: starts the voice server so a promoted host can serve voice to reconnecting guests
- **Teardown** (`leaveRoom`, `_teardownForPermissionRevoke`, `close()`): calls `stopVoiceTransport()` on all exit paths

## Test plan

- [x] `flutter analyze` clean
- [x] New cubit tests (651/651 green):
  - `joinRoom as host calls startVoiceServer`
  - `JoinAccepted sent to guest carries the voice PSM when server started`
  - `applyJoinAccepted with voicePsm dials connectVoiceClient on guest`
  - `applyJoinAccepted without voicePsm does not call connectVoiceClient`
  - `leaveRoom calls stopVoiceTransport for host`
  - `leaveRoom calls stopVoiceTransport for guest`
  - `close() calls stopVoiceTransport`
- [x] Full `bash scripts/presubmit.sh` green (Dart + C++ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable voice session lifecycle: hosts start the native voice service during joins and promotions, host startup races are guarded so connection info isn’t overwritten, guests connect only when voice info and device address are available, and voice transport is consistently stopped and cleared on teardown.
* **Tests**
  * Added end-to-end tests for voice server startup, propagation of connection info, guest dialing behavior, host promotion, and teardown; test stubs updated to support voice transport teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->