### PR TITLE
test(#295): add gattError event handler tests to FrequencyRoomScreen

### DIFF
--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -157,6 +157,43 @@ FrequencySessionCubit _seededCubit({bool isHost = false}) {
   return cubit;
 }
 
+/// Creates a [MockFrequencySessionCubit] pre-stubbed for audio-event /
+/// gattError tests that only need to verify [recheckPermissions] calls and
+/// do not emit any media-command or weak-signal events.
+///
+/// Uses [Stream.empty] for the streams that are subscribed but never
+/// fired, so no [StreamController] teardown is needed in the test.
+MockFrequencySessionCubit _mockCubitForPermTest() {
+  final cubit = MockFrequencySessionCubit();
+  final mockStore = MockIdentityStore();
+  when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
+  when(() => cubit.identityStore).thenReturn(mockStore);
+  when(() => cubit.localPeerId).thenReturn(null);
+  when(() => cubit.state).thenReturn(const SessionBooting());
+  when(
+    () => cubit.stream,
+  ).thenAnswer((_) => const Stream<FrequencySessionState>.empty());
+  when(
+    () => cubit.mediaCommands,
+  ).thenAnswer((_) => Stream<MediaCommand>.empty());
+  when(
+    () => cubit.weakSignalEvents,
+  ).thenAnswer(
+    (_) => Stream<({String peerId, String displayName})>.empty(),
+  );
+  when(
+    () => cubit.sendMediaCommand(
+      op: any(named: 'op'),
+      source: any(named: 'source'),
+      trackIdx: any(named: 'trackIdx'),
+      positionMs: any(named: 'positionMs'),
+    ),
+  ).thenAnswer((_) async {});
+  when(() => cubit.broadcastMute(any())).thenAnswer((_) async {});
+  when(() => cubit.recheckPermissions()).thenAnswer((_) async {});
+  return cubit;
+}
+
 void main() {
   /// Captures every audio MethodChannel call the room screen makes during a
   /// single test. Reset in `setUp` so cross-test bleed is impossible.
@@ -959,34 +996,7 @@ void main() {
         );
         addTearDown(eventEmitter.dispose);
 
-        final cubit = MockFrequencySessionCubit();
-        final mockStore = MockIdentityStore();
-        when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
-        when(() => cubit.identityStore).thenReturn(mockStore);
-        when(() => cubit.localPeerId).thenReturn(null);
-        when(() => cubit.state).thenReturn(const SessionBooting());
-        when(
-          () => cubit.stream,
-        ).thenAnswer((_) => const Stream<FrequencySessionState>.empty());
-        final mediaCtrl = StreamController<MediaCommand>.broadcast();
-        when(() => cubit.mediaCommands).thenAnswer((_) => mediaCtrl.stream);
-        final weakCtrl =
-            StreamController<({String peerId, String displayName})>.broadcast();
-        when(() => cubit.weakSignalEvents).thenAnswer((_) => weakCtrl.stream);
-        when(
-          () => cubit.sendMediaCommand(
-            op: any(named: 'op'),
-            source: any(named: 'source'),
-            trackIdx: any(named: 'trackIdx'),
-            positionMs: any(named: 'positionMs'),
-          ),
-        ).thenAnswer((_) async {});
-        when(() => cubit.broadcastMute(any())).thenAnswer((_) async {});
-        when(() => cubit.recheckPermissions()).thenAnswer((_) async {});
-        addTearDown(() {
-          mediaCtrl.close();
-          weakCtrl.close();
-        });
+        final cubit = _mockCubitForPermTest();
 
         await tester.pumpWidget(_wrap(_room(), cubit: cubit));
         await tester.pump();
@@ -1014,34 +1024,7 @@ void main() {
         );
         addTearDown(eventEmitter.dispose);
 
-        final cubit = MockFrequencySessionCubit();
-        final mockStore = MockIdentityStore();
-        when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
-        when(() => cubit.identityStore).thenReturn(mockStore);
-        when(() => cubit.localPeerId).thenReturn(null);
-        when(() => cubit.state).thenReturn(const SessionBooting());
-        when(
-          () => cubit.stream,
-        ).thenAnswer((_) => const Stream<FrequencySessionState>.empty());
-        final mediaCtrl = StreamController<MediaCommand>.broadcast();
-        when(() => cubit.mediaCommands).thenAnswer((_) => mediaCtrl.stream);
-        final weakCtrl =
-            StreamController<({String peerId, String displayName})>.broadcast();
-        when(() => cubit.weakSignalEvents).thenAnswer((_) => weakCtrl.stream);
-        when(
-          () => cubit.sendMediaCommand(
-            op: any(named: 'op'),
-            source: any(named: 'source'),
-            trackIdx: any(named: 'trackIdx'),
-            positionMs: any(named: 'positionMs'),
-          ),
-        ).thenAnswer((_) async {});
-        when(() => cubit.broadcastMute(any())).thenAnswer((_) async {});
-        when(() => cubit.recheckPermissions()).thenAnswer((_) async {});
-        addTearDown(() {
-          mediaCtrl.close();
-          weakCtrl.close();
-        });
+        final cubit = _mockCubitForPermTest();
 
         await tester.pumpWidget(_wrap(_room(), cubit: cubit));
         await tester.pump();
@@ -1072,34 +1055,7 @@ void main() {
         );
         addTearDown(eventEmitter.dispose);
 
-        final cubit = MockFrequencySessionCubit();
-        final mockStore = MockIdentityStore();
-        when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
-        when(() => cubit.identityStore).thenReturn(mockStore);
-        when(() => cubit.localPeerId).thenReturn(null);
-        when(() => cubit.state).thenReturn(const SessionBooting());
-        when(
-          () => cubit.stream,
-        ).thenAnswer((_) => const Stream<FrequencySessionState>.empty());
-        final mediaCtrl = StreamController<MediaCommand>.broadcast();
-        when(() => cubit.mediaCommands).thenAnswer((_) => mediaCtrl.stream);
-        final weakCtrl =
-            StreamController<({String peerId, String displayName})>.broadcast();
-        when(() => cubit.weakSignalEvents).thenAnswer((_) => weakCtrl.stream);
-        when(
-          () => cubit.sendMediaCommand(
-            op: any(named: 'op'),
-            source: any(named: 'source'),
-            trackIdx: any(named: 'trackIdx'),
-            positionMs: any(named: 'positionMs'),
-          ),
-        ).thenAnswer((_) async {});
-        when(() => cubit.broadcastMute(any())).thenAnswer((_) async {});
-        when(() => cubit.recheckPermissions()).thenAnswer((_) async {});
-        addTearDown(() {
-          mediaCtrl.close();
-          weakCtrl.close();
-        });
+        final cubit = _mockCubitForPermTest();
 
         await tester.pumpWidget(_wrap(_room(), cubit: cubit));
         await tester.pump();

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -1006,6 +1006,116 @@ void main() {
       },
     );
 
+    testWidgets(
+      'gattError with permission reason triggers immediate recheck (#295)',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        final cubit = MockFrequencySessionCubit();
+        final mockStore = MockIdentityStore();
+        when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
+        when(() => cubit.identityStore).thenReturn(mockStore);
+        when(() => cubit.localPeerId).thenReturn(null);
+        when(() => cubit.state).thenReturn(const SessionBooting());
+        when(
+          () => cubit.stream,
+        ).thenAnswer((_) => const Stream<FrequencySessionState>.empty());
+        final mediaCtrl = StreamController<MediaCommand>.broadcast();
+        when(() => cubit.mediaCommands).thenAnswer((_) => mediaCtrl.stream);
+        final weakCtrl =
+            StreamController<({String peerId, String displayName})>.broadcast();
+        when(() => cubit.weakSignalEvents).thenAnswer((_) => weakCtrl.stream);
+        when(
+          () => cubit.sendMediaCommand(
+            op: any(named: 'op'),
+            source: any(named: 'source'),
+            trackIdx: any(named: 'trackIdx'),
+            positionMs: any(named: 'positionMs'),
+          ),
+        ).thenAnswer((_) async {});
+        when(() => cubit.broadcastMute(any())).thenAnswer((_) async {});
+        when(() => cubit.recheckPermissions()).thenAnswer((_) async {});
+        addTearDown(() {
+          mediaCtrl.close();
+          weakCtrl.close();
+        });
+
+        await tester.pumpWidget(_wrap(_room(), cubit: cubit));
+        await tester.pump();
+
+        // BLUETOOTH_PERMISSION_DENIED reason → immediate recheckPermissions.
+        eventEmitter.emit({
+          'type': 'gattError',
+          'reason': 'BLUETOOTH_PERMISSION_DENIED',
+        });
+        await tester.pump();
+
+        // GATT_AUTHORIZATION_DENIED reason → same immediate recheck path.
+        eventEmitter.emit({
+          'type': 'gattError',
+          'reason': 'GATT_AUTHORIZATION_DENIED',
+        });
+        await tester.pump();
+
+        verify(() => cubit.recheckPermissions()).called(2);
+      },
+    );
+
+    testWidgets(
+      'gattError with GATT_SETUP_FAILED does not call recheckPermissions (#295)',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        final cubit = MockFrequencySessionCubit();
+        final mockStore = MockIdentityStore();
+        when(() => mockStore.getPeerId()).thenAnswer((_) async => 'me');
+        when(() => cubit.identityStore).thenReturn(mockStore);
+        when(() => cubit.localPeerId).thenReturn(null);
+        when(() => cubit.state).thenReturn(const SessionBooting());
+        when(
+          () => cubit.stream,
+        ).thenAnswer((_) => const Stream<FrequencySessionState>.empty());
+        final mediaCtrl = StreamController<MediaCommand>.broadcast();
+        when(() => cubit.mediaCommands).thenAnswer((_) => mediaCtrl.stream);
+        final weakCtrl =
+            StreamController<({String peerId, String displayName})>.broadcast();
+        when(() => cubit.weakSignalEvents).thenAnswer((_) => weakCtrl.stream);
+        when(
+          () => cubit.sendMediaCommand(
+            op: any(named: 'op'),
+            source: any(named: 'source'),
+            trackIdx: any(named: 'trackIdx'),
+            positionMs: any(named: 'positionMs'),
+          ),
+        ).thenAnswer((_) async {});
+        when(() => cubit.broadcastMute(any())).thenAnswer((_) async {});
+        when(() => cubit.recheckPermissions()).thenAnswer((_) async {});
+        addTearDown(() {
+          mediaCtrl.close();
+          weakCtrl.close();
+        });
+
+        await tester.pumpWidget(_wrap(_room(), cubit: cubit));
+        await tester.pump();
+
+        // Non-permission GATT setup failure → heartbeat watchdog handles it,
+        // recheckPermissions must NOT be called (that would navigate away).
+        eventEmitter.emit({
+          'type': 'gattError',
+          'reason': 'GATT_SETUP_FAILED',
+        });
+        await tester.pump();
+
+        verifyNever(() => cubit.recheckPermissions());
+      },
+    );
+
     testWidgets('peer drawer shows Block & Report button (#133)', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- Adds two widget tests for the `gattError` audio-event handler that PR #297 introduced in `FrequencyRoomScreen`
- Verifies that `BLUETOOTH_PERMISSION_DENIED` and `GATT_AUTHORIZATION_DENIED` reasons call `recheckPermissions()` immediately
- Verifies that `GATT_SETUP_FAILED` does **not** call `recheckPermissions()` (leaves the heartbeat watchdog to surface the drop and start the reconnect flow)

Closes #295

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] `flutter test test/screens/frequency_room_screen_test.dart` — all 42 tests pass, including the two new `gattError` tests
- [ ] `flutter test` — all 646 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored test setup for permission recheck scenarios to simplify stubbing and reuse.
  * Added tests covering GATT error cases: permission-denied errors now trigger repeated permission rechecks; setup-failed errors do not trigger rechecks.
  * Continued coverage of Bluetooth connectivity and initialization error handling in the frequency room screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->