### PR TITLE
fix(#304): expand Sentry sanitizer PII coverage

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -322,8 +322,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
           if (isClosed) return;
           _onPermissionsChanged(missing);
         } catch (error, stackTrace) {
-          debugPrint('Initial permission check failed: $error');
-          debugPrintStack(stackTrace: stackTrace);
+          if (kDebugMode) {
+            debugPrint('Initial permission check failed: $error');
+            debugPrintStack(stackTrace: stackTrace);
+          }
         }
       }());
     }
@@ -1667,22 +1669,28 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       try {
         await audio.stopVoice();
       } catch (error, stackTrace) {
-        debugPrint('stopVoice during permission revoke failed: $error');
-        debugPrintStack(stackTrace: stackTrace);
+        if (kDebugMode) {
+          debugPrint('stopVoice during permission revoke failed: $error');
+          debugPrintStack(stackTrace: stackTrace);
+        }
       }
       try {
         await audio.stopVoiceTransport();
       } catch (error, stackTrace) {
-        debugPrint(
-          'stopVoiceTransport during permission revoke failed: $error',
-        );
-        debugPrintStack(stackTrace: stackTrace);
+        if (kDebugMode) {
+          debugPrint(
+            'stopVoiceTransport during permission revoke failed: $error',
+          );
+          debugPrintStack(stackTrace: stackTrace);
+        }
       }
       try {
         await audio.stopService();
       } catch (error, stackTrace) {
-        debugPrint('stopService during permission revoke failed: $error');
-        debugPrintStack(stackTrace: stackTrace);
+        if (kDebugMode) {
+          debugPrint('stopService during permission revoke failed: $error');
+          debugPrintStack(stackTrace: stackTrace);
+        }
       }
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,6 +66,12 @@ void main() async {
           options.sampleRate = 1.0;
           // Attach stack traces to messages
           options.attachStacktrace = true;
+          // Belt-and-braces: refuse Sentry's server-side enrichment that
+          // would otherwise resolve `user.ipAddress = "{{auto}}"` to the
+          // device's public IP. The sanitizer also drops the user block,
+          // but this prevents the auto-resolution from happening in the
+          // first place.
+          options.sendDefaultPii = false;
           // Redact PII before sending
           options.beforeSend = (event, hint) {
             return sanitizeSentryEvent(event);

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -502,7 +502,13 @@ class AudioService {
         'endpointId': endpointId,
       });
     } catch (e) {
-      debugPrint('Error getting negotiated MTU for $endpointId: $e');
+      // Gate logging that interpolates `endpointId` (a BT MAC) so the MAC
+      // can't reach Sentry via auto-captured release-build breadcrumbs.
+      // The sanitizer also strips MACs from event payloads, but skipping
+      // the print outright in release is the cheaper defense.
+      if (kDebugMode) {
+        debugPrint('Error getting negotiated MTU for $endpointId: $e');
+      }
       return null;
     }
   }

--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -71,22 +71,6 @@ dynamic _redactDeep(dynamic value) {
   return value;
 }
 
-// Drop every PII-bearing field on a SentryUser. Sentry's server-side
-// enrichment can resolve `ipAddress = "{{auto}}"` to the device's public IP,
-// so even an apparently-empty user object is risky to forward.
-void _scrubUser(SentryUser user) {
-  user.id = null;
-  user.username = null;
-  user.email = null;
-  user.ipAddress = null;
-  user.name = null;
-  user.geo = null;
-  final data = user.data;
-  if (data != null) {
-    user.data = (_redactDeep(data) as Map<String, dynamic>);
-  }
-}
-
 // Rebuild a stack frame with PII-redacted `vars`. SentryStackFrame exposes
 // `vars` as an unmodifiable view (no setter) in sentry 9.x, so we have to
 // reconstruct the frame to update them. Filenames / line numbers / function
@@ -257,11 +241,14 @@ SentryEvent? sanitizeSentryEvent(SentryEvent event) {
     _scrubThread(t);
   }
 
-  // User PII. Sentry's server can resolve `ipAddress = "{{auto}}"` to the
-  // device's public IP. Always drop the user block — the app does not have
-  // accounts, and SDK-generated session IDs cover crash-frequency.
-  final user = event.user;
-  if (user != null) _scrubUser(user);
+  // User PII. Drop the entire SentryUser block — the app has no accounts,
+  // and Sentry's server can resolve `ipAddress = "{{auto}}"` to the device's
+  // public IP. Field-by-field scrubbing leaks anything we forgot to enumerate
+  // (arbitrary `data` keys, future SDK fields), so null the whole thing.
+  // SDK-generated session identifiers still cover crash-frequency.
+  if (event.user != null) {
+    event.user = null;
+  }
 
   // Request — irrelevant in this app today (no HTTP), but defensive against
   // future code that uses `Sentry.configureScope((s) => s.setRequest(...))`.

--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -1,3 +1,9 @@
+// Sanitizer reads + rewrites SentryEvent.extra to redact PII. Sentry deprecated
+// the `extra` API in favor of structured contexts, but the field still ships
+// in serialized events from upstream code paths we don't own — so we have to
+// continue to walk it.
+// ignore_for_file: deprecated_member_use
+
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 // Matches any key/field that is a display-name identifier.
@@ -168,9 +174,10 @@ SentryRequest _scrubRequest(SentryRequest r) {
     };
   }
   // r.data is final in sentry 9.x. Use copyWith so every shape (Map, List,
-  // String, primitive) flows through _redactDeep — mutating in place via
-  // clear()/addAll() would skip non-Map payloads entirely and throw on an
-  // immutable Map.
+  // String, primitive) flows through _redactDeep — mutating a Map via
+  // clear()/addAll() would skip non-Map shapes and throw on an immutable Map.
+  // The deprecation note tells callers to assign directly, but this field has
+  // no setter; copyWith remains the only path.
   final data = r.data;
   if (data != null) {
     return r.copyWith(data: _redactDeep(data));

--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -122,7 +122,23 @@ SentryStackFrame _scrubFrame(SentryStackFrame f) {
 SentryStackTrace? _scrubStackTrace(SentryStackTrace? st) {
   if (st == null) return null;
   final scrubbed = [for (final f in st.frames) _scrubFrame(f)];
-  return SentryStackTrace(frames: scrubbed);
+  // `registers` is a Map<String, String> CPU register snapshot used for
+  // native (NDK) crashes. Empty for Dart-only crashes, but on native it can
+  // contain memory addresses or stringified pointers that match our MAC
+  // regex by coincidence; scrub each value through the message redactor.
+  final registers = st.registers;
+  final scrubbedRegisters = registers.isEmpty
+      ? null
+      : <String, String>{
+          for (final e in registers.entries)
+            e.key: _isPiiKey(e.key) ? '[REDACTED]' : _redactMessage(e.value),
+        };
+  return SentryStackTrace(
+    frames: scrubbed,
+    registers: scrubbedRegisters,
+    lang: st.lang,
+    snapshot: st.snapshot,
+  );
 }
 
 void _scrubException(SentryException ex) {
@@ -143,10 +159,11 @@ void _scrubMessage(SentryMessage m) {
   if (template != null) m.template = _redactMessage(template);
   final params = m.params;
   if (params != null) {
-    final redacted = [
-      for (final p in params) p is String ? _redactMessage(p) : p,
-    ];
-    m.params = redacted;
+    // Use the deep redactor so structured params (Map / List) are scrubbed,
+    // not just String values. Sentry coerces non-strings to strings on
+    // serialization, so a Map<String, dynamic> with a peerId key would
+    // otherwise be stringified verbatim before reaching beforeSend's reach.
+    m.params = [for (final p in params) _redactDeep(p)];
   }
 }
 

--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -167,7 +167,7 @@ void _scrubMessage(SentryMessage m) {
   }
 }
 
-void _scrubRequest(SentryRequest r) {
+SentryRequest _scrubRequest(SentryRequest r) {
   final url = r.url;
   if (url != null) r.url = _redactMessage(url);
   final qs = r.queryString;
@@ -183,17 +183,15 @@ void _scrubRequest(SentryRequest r) {
         e.key: _isPiiKey(e.key) ? '[REDACTED]' : _redactMessage(e.value),
     };
   }
-  // r.data is final in sentry 9.x; if a future Sentry integration sets it
-  // and it's a mutable Map, we redact in place. For other shapes (primitive,
-  // immutable List, etc.) the field is left untouched — the app does not
-  // populate it today, so the surface area is small.
+  // r.data is final in sentry 9.x. Use copyWith so every shape (Map, List,
+  // String, primitive) flows through _redactDeep — mutating in place via
+  // clear()/addAll() would skip non-Map payloads entirely and throw on an
+  // immutable Map.
   final data = r.data;
-  if (data is Map) {
-    final redacted = _redactDeep(data) as Map<String, dynamic>;
-    data
-      ..clear()
-      ..addAll(redacted);
+  if (data != null) {
+    return r.copyWith(data: _redactDeep(data));
   }
+  return r;
 }
 
 /// Sanitizes Sentry events to remove PII before they are sent.
@@ -201,7 +199,7 @@ void _scrubRequest(SentryRequest r) {
 /// Redacts display names, peer IDs, and Bluetooth MAC addresses from every
 /// load-bearing field of the event: contexts, tags, breadcrumbs, top-level
 /// `message`, `exceptions` (including stack-frame `vars`), `threads`, `user`,
-/// `request`, `fingerprint`, and `transaction`.
+/// `request`, `extra`, `fingerprint`, and `transaction`.
 ///
 /// Peer IDs are intentionally stripped even though they are random UUIDs:
 /// the privacy-first stance (and the Play Store Data Safety declaration)
@@ -268,7 +266,20 @@ SentryEvent? sanitizeSentryEvent(SentryEvent event) {
   // Request — irrelevant in this app today (no HTTP), but defensive against
   // future code that uses `Sentry.configureScope((s) => s.setRequest(...))`.
   final request = event.request;
-  if (request != null) _scrubRequest(request);
+  if (request != null) event.request = _scrubRequest(request);
+
+  // Extra — arbitrary key/value attached via Sentry.captureEvent / scopes.
+  // setExtra is deprecated in favor of structured contexts but the field is
+  // still serialized, so a peerId / displayName nested in extra would
+  // otherwise bypass every other gate. Strip PII keys outright; deep-redact
+  // remaining values.
+  final extra = event.extra;
+  if (extra != null && extra.isNotEmpty) {
+    event.extra = <String, dynamic>{
+      for (final e in extra.entries)
+        e.key: _isPiiKey(e.key) ? '[REDACTED]' : _redactDeep(e.value),
+    };
+  }
 
   // Fingerprint is a list of user-controlled strings; we don't set it
   // ourselves but Sentry SDK / integrations can. Scrub each entry.

--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -20,6 +20,15 @@ final _peerIdMessageRegex = RegExp(
   caseSensitive: false,
 );
 
+// Matches a Bluetooth MAC address (six colon- or hyphen-separated hex pairs).
+// The control plane and audio service interpolate `$endpointId` (a BT MAC)
+// into log messages, exception strings, and breadcrumb data. A MAC is a
+// stable per-device identifier and must not reach Sentry.
+final _macAddressRegex = RegExp(
+  r'\b[0-9A-F]{2}([:-][0-9A-F]{2}){5}\b',
+  caseSensitive: false,
+);
+
 bool _isPiiKey(String key) =>
     _displayNameKeyRegex.hasMatch(key) || _peerIdKeyRegex.hasMatch(key);
 
@@ -33,6 +42,9 @@ String _redactMessage(String msg) {
   }
   if (_peerIdMessageRegex.hasMatch(result)) {
     result = result.replaceAll(_peerIdMessageRegex, 'peerId: [REDACTED]');
+  }
+  if (_macAddressRegex.hasMatch(result)) {
+    result = result.replaceAll(_macAddressRegex, '[MAC_REDACTED]');
   }
   return result;
 }
@@ -59,14 +71,126 @@ dynamic _redactDeep(dynamic value) {
   return value;
 }
 
+// Drop every PII-bearing field on a SentryUser. Sentry's server-side
+// enrichment can resolve `ipAddress = "{{auto}}"` to the device's public IP,
+// so even an apparently-empty user object is risky to forward.
+void _scrubUser(SentryUser user) {
+  user.id = null;
+  user.username = null;
+  user.email = null;
+  user.ipAddress = null;
+  user.name = null;
+  user.geo = null;
+  final data = user.data;
+  if (data != null) {
+    user.data = (_redactDeep(data) as Map<String, dynamic>);
+  }
+}
+
+// Rebuild a stack frame with PII-redacted `vars`. SentryStackFrame exposes
+// `vars` as an unmodifiable view (no setter) in sentry 9.x, so we have to
+// reconstruct the frame to update them. Filenames / line numbers / function
+// names / etc. are copied through verbatim.
+SentryStackFrame _scrubFrame(SentryStackFrame f) {
+  if (f.vars.isEmpty) return f;
+  final redacted = _redactDeep(f.vars) as Map<String, dynamic>;
+  return SentryStackFrame(
+    absPath: f.absPath,
+    fileName: f.fileName,
+    function: f.function,
+    module: f.module,
+    lineNo: f.lineNo,
+    colNo: f.colNo,
+    contextLine: f.contextLine,
+    inApp: f.inApp,
+    package: f.package,
+    native: f.native,
+    platform: f.platform,
+    imageAddr: f.imageAddr,
+    symbolAddr: f.symbolAddr,
+    instructionAddr: f.instructionAddr,
+    rawFunction: f.rawFunction,
+    stackStart: f.stackStart,
+    symbol: f.symbol,
+    framesOmitted: f.framesOmitted,
+    preContext: f.preContext,
+    postContext: f.postContext,
+    vars: redacted,
+  );
+}
+
+SentryStackTrace? _scrubStackTrace(SentryStackTrace? st) {
+  if (st == null) return null;
+  final scrubbed = [for (final f in st.frames) _scrubFrame(f)];
+  return SentryStackTrace(frames: scrubbed);
+}
+
+void _scrubException(SentryException ex) {
+  final value = ex.value;
+  if (value != null) ex.value = _redactMessage(value);
+  ex.stackTrace = _scrubStackTrace(ex.stackTrace);
+}
+
+void _scrubThread(SentryThread t) {
+  t.stacktrace = _scrubStackTrace(t.stacktrace);
+}
+
+void _scrubMessage(SentryMessage m) {
+  // In sentry 9.x, `formatted` is non-nullable on SentryMessage and
+  // `template` is the nullable raw form supplied to captureMessage.
+  m.formatted = _redactMessage(m.formatted);
+  final template = m.template;
+  if (template != null) m.template = _redactMessage(template);
+  final params = m.params;
+  if (params != null) {
+    final redacted = [
+      for (final p in params) p is String ? _redactMessage(p) : p,
+    ];
+    m.params = redacted;
+  }
+}
+
+void _scrubRequest(SentryRequest r) {
+  final url = r.url;
+  if (url != null) r.url = _redactMessage(url);
+  final qs = r.queryString;
+  if (qs != null) r.queryString = _redactMessage(qs);
+  final cookies = r.cookies;
+  if (cookies != null) r.cookies = _redactMessage(cookies);
+  // headers is exposed as an unmodifiable view; assign through the setter
+  // to replace the underlying map with the redacted version.
+  final headers = r.headers;
+  if (headers.isNotEmpty) {
+    r.headers = <String, String>{
+      for (final e in headers.entries)
+        e.key: _isPiiKey(e.key) ? '[REDACTED]' : _redactMessage(e.value),
+    };
+  }
+  // r.data is final in sentry 9.x; if a future Sentry integration sets it
+  // and it's a mutable Map, we redact in place. For other shapes (primitive,
+  // immutable List, etc.) the field is left untouched — the app does not
+  // populate it today, so the surface area is small.
+  final data = r.data;
+  if (data is Map) {
+    final redacted = _redactDeep(data) as Map<String, dynamic>;
+    data
+      ..clear()
+      ..addAll(redacted);
+  }
+}
+
 /// Sanitizes Sentry events to remove PII before they are sent.
 ///
-/// Redacts display names and peer IDs from contexts, tags, and breadcrumbs.
-/// Peer IDs are intentionally stripped even though they are random UUIDs: the
-/// privacy-first stance (and the Play Store Data Safety declaration) promises
-/// no app-controlled identifiers reach Sentry. Sentry's own SDK-generated
-/// session identifiers cover crash-frequency diagnostics without exposing an
-/// app-level identifier.
+/// Redacts display names, peer IDs, and Bluetooth MAC addresses from every
+/// load-bearing field of the event: contexts, tags, breadcrumbs, top-level
+/// `message`, `exceptions` (including stack-frame `vars`), `threads`, `user`,
+/// `request`, `fingerprint`, and `transaction`.
+///
+/// Peer IDs are intentionally stripped even though they are random UUIDs:
+/// the privacy-first stance (and the Play Store Data Safety declaration)
+/// promises no app-controlled identifiers reach Sentry. Sentry's own
+/// SDK-generated session identifiers cover crash-frequency diagnostics
+/// without exposing an app-level identifier.
 SentryEvent? sanitizeSentryEvent(SentryEvent event) {
   // Strip PII-keyed context entries; deep-scan remaining values for nested PII.
   event.contexts.removeWhere((key, _) => _isPiiKey(key));
@@ -86,10 +210,9 @@ SentryEvent? sanitizeSentryEvent(SentryEvent event) {
   // Redact breadcrumbs in-place (Breadcrumb is mutable in sentry 9.x).
   for (final crumb in event.breadcrumbs ?? const []) {
     final msg = crumb.message;
-    if (msg != null &&
-        (_displayNameMessageRegex.hasMatch(msg) ||
-            _peerIdMessageRegex.hasMatch(msg))) {
-      crumb.message = _redactMessage(msg);
+    if (msg != null) {
+      final redacted = _redactMessage(msg);
+      if (redacted != msg) crumb.message = redacted;
     }
 
     final data = crumb.data;
@@ -99,6 +222,49 @@ SentryEvent? sanitizeSentryEvent(SentryEvent event) {
           e.key: _isPiiKey(e.key) ? '[REDACTED]' : _redactDeep(e.value),
       };
     }
+  }
+
+  // Top-level message — captureMessage payloads land here. Without this,
+  // any free-form Sentry.captureMessage with interpolated identifiers
+  // bypasses the breadcrumb redactor entirely.
+  final message = event.message;
+  if (message != null) _scrubMessage(message);
+
+  // Exception messages and stack-frame locals can both carry interpolated
+  // identifiers. Without scrubbing here, a thrown
+  // `Exception('Failed for ${displayName}')` would be transmitted verbatim.
+  for (final ex in event.exceptions ?? const <SentryException>[]) {
+    _scrubException(ex);
+  }
+
+  // Thread stack frames carry the same risk as exception frames.
+  for (final t in event.threads ?? const <SentryThread>[]) {
+    _scrubThread(t);
+  }
+
+  // User PII. Sentry's server can resolve `ipAddress = "{{auto}}"` to the
+  // device's public IP. Always drop the user block — the app does not have
+  // accounts, and SDK-generated session IDs cover crash-frequency.
+  final user = event.user;
+  if (user != null) _scrubUser(user);
+
+  // Request — irrelevant in this app today (no HTTP), but defensive against
+  // future code that uses `Sentry.configureScope((s) => s.setRequest(...))`.
+  final request = event.request;
+  if (request != null) _scrubRequest(request);
+
+  // Fingerprint is a list of user-controlled strings; we don't set it
+  // ourselves but Sentry SDK / integrations can. Scrub each entry.
+  final fingerprint = event.fingerprint;
+  if (fingerprint != null) {
+    final redacted = [for (final f in fingerprint) _redactMessage(f)];
+    event.fingerprint = redacted;
+  }
+
+  // Transaction name can carry path-style identifiers (e.g. /room/<peerId>).
+  final transaction = event.transaction;
+  if (transaction != null) {
+    event.transaction = _redactMessage(transaction);
   }
 
   return event;

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -173,4 +173,241 @@ void main() {
       },
     );
   });
+
+  group('sanitizeSentryEvent — MAC address redaction', () {
+    test('redacts MAC addresses from breadcrumb messages', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(message: 'Error getting MTU for AA:BB:CC:DD:EE:FF: timeout'),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[MAC_REDACTED]'));
+      expect(
+        result.breadcrumbs!.single.message,
+        isNot(contains('AA:BB:CC:DD:EE:FF')),
+      );
+    });
+
+    test('redacts hyphen-separated MAC addresses', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(message: 'connect to aa-bb-cc-dd-ee-ff failed'),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.breadcrumbs!.single.message, contains('[MAC_REDACTED]'));
+      expect(
+        result.breadcrumbs!.single.message,
+        isNot(contains('aa-bb-cc-dd-ee-ff')),
+      );
+    });
+
+    test('redacts MAC addresses inside nested breadcrumb data', () {
+      final event = SentryEvent(
+        breadcrumbs: [
+          Breadcrumb(data: {'endpoint': '11:22:33:44:55:66', 'rssi': -70}),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final data = result.breadcrumbs!.single.data!;
+      expect(data['endpoint'], '[MAC_REDACTED]');
+      expect(data['rssi'], -70);
+    });
+
+    test('does not over-match short hex sequences', () {
+      final event = SentryEvent(
+        breadcrumbs: [Breadcrumb(message: 'opcode 0xAB:0xCD failed')],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(
+        result.breadcrumbs!.single.message,
+        equals('opcode 0xAB:0xCD failed'),
+      );
+    });
+  });
+
+  group('sanitizeSentryEvent — top-level message', () {
+    test('redacts peerId in formatted message', () {
+      final event = SentryEvent(
+        message: SentryMessage('host bootstrap failed peerId=abc-123'),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.message!.formatted, contains('[REDACTED]'));
+      expect(result.message!.formatted, isNot(contains('abc-123')));
+    });
+
+    test('redacts displayName in template', () {
+      final event = SentryEvent(
+        message: SentryMessage(
+          'join attempt for displayName: Alice',
+          template: 'join attempt for displayName: %s',
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      // Template was the literal "%s" placeholder so it stays intact, but the
+      // "displayName:" key still triggers the message redactor.
+      expect(result.message!.template, contains('[REDACTED]'));
+    });
+
+    test('redacts MAC in message params', () {
+      final event = SentryEvent(
+        message: SentryMessage(
+          'failed for AA:BB:CC:DD:EE:FF',
+          params: ['AA:BB:CC:DD:EE:FF'],
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.message!.params!.single, '[MAC_REDACTED]');
+      expect(result.message!.formatted, contains('[MAC_REDACTED]'));
+    });
+  });
+
+  group('sanitizeSentryEvent — exceptions', () {
+    test('redacts peerId from exception value', () {
+      final event = SentryEvent(
+        exceptions: [
+          SentryException(
+            type: 'StateError',
+            value: 'JoinAccepted send failed peerId=abc-123',
+          ),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.exceptions!.single.value, contains('[REDACTED]'));
+      expect(result.exceptions!.single.value, isNot(contains('abc-123')));
+    });
+
+    test('redacts MAC from exception value', () {
+      final event = SentryEvent(
+        exceptions: [
+          SentryException(
+            type: 'PlatformException',
+            value: 'Error getting MTU for AA:BB:CC:DD:EE:FF',
+          ),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.exceptions!.single.value, contains('[MAC_REDACTED]'));
+      expect(
+        result.exceptions!.single.value,
+        isNot(contains('AA:BB:CC:DD:EE:FF')),
+      );
+    });
+
+    test('redacts displayName in stack frame vars', () {
+      final event = SentryEvent(
+        exceptions: [
+          SentryException(
+            type: 'Exception',
+            value: 'oops',
+            stackTrace: SentryStackTrace(
+              frames: [
+                SentryStackFrame(
+                  function: 'doThing',
+                  fileName: 'foo.dart',
+                  lineNo: 42,
+                  vars: {'displayName': 'Alice', 'count': 3},
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final frame = result.exceptions!.single.stackTrace!.frames.single;
+      expect(frame.vars['displayName'], '[REDACTED]');
+      expect(frame.vars['count'], 3);
+      expect(frame.fileName, 'foo.dart');
+      expect(frame.lineNo, 42);
+    });
+  });
+
+  group('sanitizeSentryEvent — user', () {
+    test('drops every PII field from event.user', () {
+      final event = SentryEvent(
+        user: SentryUser(
+          id: 'abc-123',
+          username: 'alice',
+          email: 'alice@example.com',
+          ipAddress: '203.0.113.7',
+          name: 'Alice',
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final user = result.user!;
+      expect(user.id, isNull);
+      expect(user.username, isNull);
+      expect(user.email, isNull);
+      expect(user.ipAddress, isNull);
+      expect(user.name, isNull);
+    });
+
+    test('redacts PII keys inside user.data', () {
+      // SentryUser asserts that at least one identifier is set at construction
+      // time, so we satisfy the assertion with a placeholder id; the scrubber
+      // is expected to clear it as part of the redact pass.
+      final event = SentryEvent(
+        user: SentryUser(
+          id: 'placeholder',
+          data: {'displayName': 'Alice', 'peerId': 'abc-123', 'role': 'host'},
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final user = result.user!;
+      expect(user.id, isNull);
+      final data = user.data!;
+      expect(data['displayName'], '[REDACTED]');
+      expect(data['peerId'], '[REDACTED]');
+      expect(data['role'], 'host');
+    });
+  });
+
+  group('sanitizeSentryEvent — fingerprint and transaction', () {
+    test('redacts MAC in fingerprint entries', () {
+      final event = SentryEvent(
+        fingerprint: ['ble-error', 'AA:BB:CC:DD:EE:FF'],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.fingerprint, ['ble-error', '[MAC_REDACTED]']);
+    });
+
+    test('redacts peerId in transaction name', () {
+      final event = SentryEvent(transaction: '/room/peerId=abc-123/voice');
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.transaction, contains('[REDACTED]'));
+      expect(result.transaction, isNot(contains('abc-123')));
+    });
+  });
+
+  group('sanitizeSentryEvent — request', () {
+    test('redacts MAC in request URL', () {
+      final event = SentryEvent(
+        request: SentryRequest(url: 'https://api.example/peer/AA:BB:CC:DD:EE:FF'),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.request!.url, contains('[MAC_REDACTED]'));
+      expect(result.request!.url, isNot(contains('AA:BB:CC:DD:EE:FF')));
+    });
+
+    test('redacts peerId in request query string', () {
+      final event = SentryEvent(
+        request: SentryRequest(queryString: 'peerId=abc-123&v=1'),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.request!.queryString, contains('[REDACTED]'));
+      expect(result.request!.queryString, isNot(contains('abc-123')));
+    });
+
+    test('redacts PII-keyed headers', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          headers: {'X-PeerId': 'abc-123', 'X-Version': '1.0'},
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.request!.headers['X-PeerId'], '[REDACTED]');
+      expect(result.request!.headers['X-Version'], '1.0');
+    });
+  });
 }

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -1,3 +1,7 @@
+// Tests cover redaction of SentryEvent.extra, which Sentry deprecated in favor
+// of structured contexts but still serializes — see the sanitizer for context.
+// ignore_for_file: deprecated_member_use
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:walkie_talkie/services/sentry_event_sanitizer.dart';
@@ -384,6 +388,34 @@ void main() {
         '0xAABBCCDDEEFF',
       ); // 12-hex-digit literal — not a MAC shape
       expect(regs['pc'], '0x1234');
+    });
+  });
+
+  group('sanitizeSentryEvent — threads', () {
+    test('redacts peerId in thread stack frame vars', () {
+      final event = SentryEvent(
+        threads: [
+          SentryThread(
+            id: 1,
+            name: 'main',
+            stacktrace: SentryStackTrace(
+              frames: [
+                SentryStackFrame(
+                  function: 'tick',
+                  fileName: 'engine.dart',
+                  lineNo: 99,
+                  vars: {'peerId': 'abc-123', 'depth': 4},
+                ),
+              ],
+            ),
+          ),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final frame = result.threads!.single.stacktrace!.frames.single;
+      expect(frame.vars['peerId'], '[REDACTED]');
+      expect(frame.vars['depth'], 4);
+      expect(frame.fileName, 'engine.dart');
     });
   });
 

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -475,5 +475,61 @@ void main() {
       expect(result.request!.headers['X-PeerId'], '[REDACTED]');
       expect(result.request!.headers['X-Version'], '1.0');
     });
+
+    test('redacts PII inside Map request data', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          data: {'peerId': 'abc-123', 'displayName': 'Alice', 'kind': 'join'},
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final redacted = result.request!.data as Map;
+      expect(redacted['peerId'], '[REDACTED]');
+      expect(redacted['displayName'], '[REDACTED]');
+      expect(redacted['kind'], 'join');
+    });
+
+    test('redacts PII inside String request data', () {
+      final event = SentryEvent(
+        request: SentryRequest(data: 'peerId=abc-123 join AA:BB:CC:DD:EE:FF'),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final redacted = result.request!.data as String;
+      expect(redacted, isNot(contains('abc-123')));
+      expect(redacted, isNot(contains('AA:BB:CC:DD:EE:FF')));
+    });
+
+    test('redacts PII inside immutable Map request data', () {
+      final event = SentryEvent(
+        request: SentryRequest(
+          data: Map.unmodifiable({'peerId': 'abc-123', 'kind': 'join'}),
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final redacted = result.request!.data as Map;
+      expect(redacted['peerId'], '[REDACTED]');
+      expect(redacted['kind'], 'join');
+    });
+  });
+
+  group('sanitizeSentryEvent — extra', () {
+    test('redacts PII-keyed extra entries outright', () {
+      final event = SentryEvent()..extra = {'peerId': 'abc-123', 'op': 'send'};
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.extra!['peerId'], '[REDACTED]');
+      expect(result.extra!['op'], 'send');
+    });
+
+    test('deep-redacts PII nested inside extra values', () {
+      final event = SentryEvent()
+        ..extra = {
+          'context': 'peer AA:BB:CC:DD:EE:FF joined as Alice',
+          'roster': ['Alice', 'Bob'],
+        };
+      final result = sanitizeSentryEvent(event)!;
+      final ctx = result.extra!['context'] as String;
+      expect(ctx, isNot(contains('AA:BB:CC:DD:EE:FF')));
+      expect(ctx, contains('[MAC_REDACTED]'));
+    });
   });
 }

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -388,7 +388,7 @@ void main() {
   });
 
   group('sanitizeSentryEvent — user', () {
-    test('drops every PII field from event.user', () {
+    test('drops the entire user block', () {
       final event = SentryEvent(
         user: SentryUser(
           id: 'abc-123',
@@ -396,34 +396,11 @@ void main() {
           email: 'alice@example.com',
           ipAddress: '203.0.113.7',
           name: 'Alice',
+          data: {'role': 'host'},
         ),
       );
       final result = sanitizeSentryEvent(event)!;
-      final user = result.user!;
-      expect(user.id, isNull);
-      expect(user.username, isNull);
-      expect(user.email, isNull);
-      expect(user.ipAddress, isNull);
-      expect(user.name, isNull);
-    });
-
-    test('redacts PII keys inside user.data', () {
-      // SentryUser asserts that at least one identifier is set at construction
-      // time, so we satisfy the assertion with a placeholder id; the scrubber
-      // is expected to clear it as part of the redact pass.
-      final event = SentryEvent(
-        user: SentryUser(
-          id: 'placeholder',
-          data: {'displayName': 'Alice', 'peerId': 'abc-123', 'role': 'host'},
-        ),
-      );
-      final result = sanitizeSentryEvent(event)!;
-      final user = result.user!;
-      expect(user.id, isNull);
-      final data = user.data!;
-      expect(data['displayName'], '[REDACTED]');
-      expect(data['peerId'], '[REDACTED]');
-      expect(data['role'], 'host');
+      expect(result.user, isNull);
     });
   });
 

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -178,7 +178,9 @@ void main() {
     test('redacts MAC addresses from breadcrumb messages', () {
       final event = SentryEvent(
         breadcrumbs: [
-          Breadcrumb(message: 'Error getting MTU for AA:BB:CC:DD:EE:FF: timeout'),
+          Breadcrumb(
+            message: 'Error getting MTU for AA:BB:CC:DD:EE:FF: timeout',
+          ),
         ],
       );
       final result = sanitizeSentryEvent(event)!;
@@ -360,7 +362,10 @@ void main() {
             value: 'SIGSEGV',
             stackTrace: SentryStackTrace(
               frames: [
-                SentryStackFrame(function: 'native_call', fileName: 'libfoo.so'),
+                SentryStackFrame(
+                  function: 'native_call',
+                  fileName: 'libfoo.so',
+                ),
               ],
               registers: {
                 'r0': '0xAABBCCDDEEFF',
@@ -374,7 +379,10 @@ void main() {
       final result = sanitizeSentryEvent(event)!;
       final regs = result.exceptions!.single.stackTrace!.registers;
       expect(regs['r1'], '[MAC_REDACTED]');
-      expect(regs['r0'], '0xAABBCCDDEEFF'); // 12-hex-digit literal — not a MAC shape
+      expect(
+        regs['r0'],
+        '0xAABBCCDDEEFF',
+      ); // 12-hex-digit literal — not a MAC shape
       expect(regs['pc'], '0x1234');
     });
   });
@@ -439,7 +447,9 @@ void main() {
   group('sanitizeSentryEvent — request', () {
     test('redacts MAC in request URL', () {
       final event = SentryEvent(
-        request: SentryRequest(url: 'https://api.example/peer/AA:BB:CC:DD:EE:FF'),
+        request: SentryRequest(
+          url: 'https://api.example/peer/AA:BB:CC:DD:EE:FF',
+        ),
       );
       final result = sanitizeSentryEvent(event)!;
       expect(result.request!.url, contains('[MAC_REDACTED]'));

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -261,6 +261,36 @@ void main() {
       expect(result.message!.params!.single, '[MAC_REDACTED]');
       expect(result.message!.formatted, contains('[MAC_REDACTED]'));
     });
+
+    test('redacts structured (Map) message params', () {
+      final event = SentryEvent(
+        message: SentryMessage(
+          'join attempt for %s',
+          params: [
+            {'peerId': 'abc-123', 'role': 'guest'},
+          ],
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final param = result.message!.params!.single as Map<String, dynamic>;
+      expect(param['peerId'], '[REDACTED]');
+      expect(param['role'], 'guest');
+    });
+
+    test('redacts MAC inside List message params', () {
+      final event = SentryEvent(
+        message: SentryMessage(
+          'failed for %s',
+          params: [
+            ['AA:BB:CC:DD:EE:FF', 'rssi=-70'],
+          ],
+        ),
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final list = result.message!.params!.single as List;
+      expect(list[0], '[MAC_REDACTED]');
+      expect(list[1], 'rssi=-70');
+    });
   });
 
   group('sanitizeSentryEvent — exceptions', () {
@@ -320,6 +350,32 @@ void main() {
       expect(frame.vars['count'], 3);
       expect(frame.fileName, 'foo.dart');
       expect(frame.lineNo, 42);
+    });
+
+    test('redacts MAC inside stack-trace registers (native crashes)', () {
+      final event = SentryEvent(
+        exceptions: [
+          SentryException(
+            type: 'NativeCrash',
+            value: 'SIGSEGV',
+            stackTrace: SentryStackTrace(
+              frames: [
+                SentryStackFrame(function: 'native_call', fileName: 'libfoo.so'),
+              ],
+              registers: {
+                'r0': '0xAABBCCDDEEFF',
+                'r1': 'AA:BB:CC:DD:EE:FF',
+                'pc': '0x1234',
+              },
+            ),
+          ),
+        ],
+      );
+      final result = sanitizeSentryEvent(event)!;
+      final regs = result.exceptions!.single.stackTrace!.registers;
+      expect(regs['r1'], '[MAC_REDACTED]');
+      expect(regs['r0'], '0xAABBCCDDEEFF'); // 12-hex-digit literal — not a MAC shape
+      expect(regs['pc'], '0x1234');
     });
   });
 


### PR DESCRIPTION
Closes #304.

## Summary
The previous `sanitizeSentryEvent` only walked `event.contexts`, `event.tags`, and `event.breadcrumbs`. Sentry's event shape carries PII in many more places, all of which would have flowed through unredacted to Sentry's servers — breaking the Data Safety attestation that crash logs contain no PII.

## What changed
- **Extended sanitizer coverage** ([lib/services/sentry_event_sanitizer.dart](https://github.com/ElodinLaarz/walkie-talkie/blob/fix-sentry-sanitizer-pii-coverage/lib/services/sentry_event_sanitizer.dart)) to scrub:
  - `event.message` (top-level `captureMessage` payloads — `formatted`, `template`, `params`)
  - `event.exceptions[].value` and stack-frame `vars` (rebuilt via `SentryStackFrame` constructor since `vars` is exposed as an unmodifiable view in sentry 9.x)
  - `event.threads[].stacktrace`
  - `event.user` — drops `id`, `username`, `email`, `ipAddress`, `name`, `geo`; redacts PII inside `user.data`
  - `event.request` — `url`, `queryString`, `cookies`, `headers`, `data`
  - `event.fingerprint`, `event.transaction`
- **Added a BT MAC-address regex** (`AA:BB:CC:DD:EE:FF` / `aa-bb-cc-dd-ee-ff`). Previously only `displayName` / `peerId` keys were matched, so MAC-shaped strings (interpolated everywhere `\$endpointId` flows through logging) reached Sentry intact.
- **Set `options.sendDefaultPii = false`** in [lib/main.dart](https://github.com/ElodinLaarz/walkie-talkie/blob/fix-sentry-sanitizer-pii-coverage/lib/main.dart) so Sentry's server-side enrichment cannot resolve `user.ipAddress = \"{{auto}}\"` to the device's public IP.
- **Gated four release-mode `debugPrint`s** flagged in the audit (`audio_service.dart:505` and four sites in `frequency_session_cubit.dart`) so MAC / error payloads can't reach Sentry's auto-captured release-build breadcrumbs as a defense-in-depth backstop.

## Why
This is a launch blocker for Google Play. Without it, the app's crash reports could carry the user's BT MAC, peerId, displayName, or public IP — directly contradicting both [docs/play-store-data-safety.md](https://github.com/ElodinLaarz/walkie-talkie/blob/main/docs/play-store-data-safety.md) and [docs/privacy-policy.md](https://github.com/ElodinLaarz/walkie-talkie/blob/main/docs/privacy-policy.md).

## Reviewer notes
- `sentry 9.x` deprecated `copyWith` on most protocol classes in favor of mutable fields. The new sanitizer assigns directly where setters exist; the only place a constructor rebuild was needed is `SentryStackFrame` (no `vars` setter).
- `SentryUser` enforces a constructor-time assertion that at least one identifier is non-null. The scrubber only mutates fields after construction, so no assertion fires; the test that exercises `user.data`-only sanitization passes a placeholder `id` that the scrubber then nulls out.
- Stack-frame `vars` aren't populated by Dart's default stack-trace integration, so the practical risk was theoretical — but coverage is cheap and the field is reachable via custom integrations.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — 671/671 pass
- [x] Sanitizer test suite grew from 16 → 33 (new groups: MAC redaction, top-level message, exceptions + stack-frame vars, user, fingerprint/transaction, request)
- [ ] Verify on a real release build that triggering a captured exception yields a Sentry event with no MAC, no peerId, no displayName, no IP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic MAC-address redaction and a broader, ordered sanitization pipeline for messages, breadcrumbs, exceptions, stack frames, requests, extras, fingerprints and transactions.
  * Sentry configured to avoid sending PII by default.

* **Bug Fixes**
  * Debug logging adjusted so stack traces and sensitive identifiers are only printed in debug builds.

* **Tests**
  * Expanded test suite covering MAC redaction and sanitization across many event locations and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->