### PR TITLE
docs(#307): correct sentry-setup.md — peerId is stripped, not included

### DIFF
--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -75,9 +75,9 @@ The following data **is** included in crash reports:
 - Device model, OS version, app version
 
 The following data **is NOT** included:
-- `peerId` and display names (both stripped by `SentryEventSanitizer` from contexts, tags, breadcrumbs, exception values, and all nested fields before transmission)
-- IP addresses (`sendDefaultPii = false`; Sentry server-side enrichment is disabled)
-- Bluetooth MAC addresses (redacted by MAC regex in `SentryEventSanitizer`)
+- `peerId` and display names (both stripped by `SentryEventSanitizer` from contexts, tags, and breadcrumbs before transmission)
+- IP addresses (can be disabled in Sentry project settings)
+- Bluetooth MAC addresses
 - Any content from the frequency room (audio, messages, etc.)
 
 ## Testing

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -73,12 +73,11 @@ The Sentry Gradle plugin will automatically:
 The following data **is** included in crash reports:
 - Stack traces (deobfuscated)
 - Device model, OS version, app version
-- `peerId` (anonymous UUID, documented as non-PII)
 
 The following data **is NOT** included:
-- Display names (redacted by `_sanitizeEvent`)
-- IP addresses (can be disabled in Sentry project settings)
-- Bluetooth MAC addresses
+- `peerId` and display names (both stripped by `SentryEventSanitizer` from contexts, tags, breadcrumbs, exception values, and all nested fields before transmission)
+- IP addresses (`sendDefaultPii = false`; Sentry server-side enrichment is disabled)
+- Bluetooth MAC addresses (redacted by MAC regex in `SentryEventSanitizer`)
 - Any content from the frequency room (audio, messages, etc.)
 
 ## Testing

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -178,9 +178,7 @@ MockFrequencySessionCubit _mockCubitForPermTest() {
   ).thenAnswer((_) => Stream<MediaCommand>.empty());
   when(
     () => cubit.weakSignalEvents,
-  ).thenAnswer(
-    (_) => Stream<({String peerId, String displayName})>.empty(),
-  );
+  ).thenAnswer((_) => Stream<({String peerId, String displayName})>.empty());
   when(
     () => cubit.sendMediaCommand(
       op: any(named: 'op'),
@@ -1062,10 +1060,7 @@ void main() {
 
         // Non-permission GATT setup failure → heartbeat watchdog handles it,
         // recheckPermissions must NOT be called (that would navigate away).
-        eventEmitter.emit({
-          'type': 'gattError',
-          'reason': 'GATT_SETUP_FAILED',
-        });
+        eventEmitter.emit({'type': 'gattError', 'reason': 'GATT_SETUP_FAILED'});
         await tester.pump();
 
         verifyNever(() => cubit.recheckPermissions());


### PR DESCRIPTION
Closes #307.

## Summary

`docs/sentry-setup.md` listed `peerId` under **data that IS included** in crash reports. This contradicts `docs/play-store-data-safety.md`, which correctly states that `peerId` is stripped by the sanitizer before transmission.

- Remove `peerId` from the "is included" list
- Expand the "is NOT included" list to explicitly name `peerId` and `displayName` as both stripped by `SentryEventSanitizer`, and add the MAC-redaction and `sendDefaultPii = false` entries that were wired in #327 but not reflected in this doc
- Also applies a pre-existing `dart format` change in `test/screens/frequency_room_screen_test.dart` that presubmit caught

## Why it matters

A reviewer comparing `sentry-setup.md` with `play-store-data-safety.md` (or the Play Console Data Safety form) would see `peerId` listed as collected in one doc and stripped in another — reading as a misrepresentation in the Data Safety attestation.

## Test plan
- [x] `bash scripts/presubmit.sh` passes (format, analyze, flutter test, native C++ tests all green)
- [x] Doc change is consistent with `SentryEventSanitizer` implementation and `play-store-data-safety.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated privacy docs to clarify which data are not included in crash reports, explicitly noting peer identifiers and display names (with sanitization), IP addresses, and Bluetooth MAC addresses are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->