### PR TITLE
fix(#326): delete legacy nativeGetAudioData/nativePlayAudioData JNI no-ops

### DIFF
--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -680,17 +680,4 @@ Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeSetDuckingVolume(
     g_duckingVolume.store(clamped, std::memory_order_relaxed);
 }
 
-// Legacy hooks — kept for now so AudioEngineManager.kt doesn't unsatisfied-
-// link. Both are no-ops; the native pipeline is internal to the audio
-// callback.
-JNIEXPORT jshortArray JNICALL
-Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeGetAudioData(
-    JNIEnv* env, jobject thiz, jint numFrames) {
-    return nullptr;
-}
-
-JNIEXPORT void JNICALL
-Java_com_elodin_walkie_1talkie_AudioEngineManager_nativePlayAudioData(
-    JNIEnv* env, jobject thiz, jshortArray audioData) {}
-
 }  // extern "C"

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioEngineManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioEngineManager.kt
@@ -33,23 +33,6 @@ class AudioEngineManager {
     }
     
     /**
-     * Get captured audio data from the microphone.
-     * @param numFrames Number of audio frames to retrieve
-     * @return Audio data as 16-bit PCM samples
-     */
-    fun getAudioData(numFrames: Int): ShortArray? {
-        return nativeGetAudioData(numFrames)
-    }
-    
-    /**
-     * Play received audio data through the speaker.
-     * @param audioData 16-bit PCM audio samples
-     */
-    fun playAudioData(audioData: ShortArray) {
-        nativePlayAudioData(audioData)
-    }
-
-    /**
      * Gate whether captured mic frames are sent to the mixer / transport.
      * Keeps streams warm so unmuting is instant.
      * @param muted true to silence local mic in the audio path
@@ -105,8 +88,6 @@ class AudioEngineManager {
     // Native methods
     private external fun nativeStart(): Boolean
     private external fun nativeStop()
-    private external fun nativeGetAudioData(numFrames: Int): ShortArray?
-    private external fun nativePlayAudioData(audioData: ShortArray)
     private external fun nativeSetMuted(muted: Boolean): Boolean
     private external fun nativePauseStreams(): Boolean
     private external fun nativeResumeStreams(): Boolean

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -178,9 +178,7 @@ MockFrequencySessionCubit _mockCubitForPermTest() {
   ).thenAnswer((_) => Stream<MediaCommand>.empty());
   when(
     () => cubit.weakSignalEvents,
-  ).thenAnswer(
-    (_) => Stream<({String peerId, String displayName})>.empty(),
-  );
+  ).thenAnswer((_) => Stream<({String peerId, String displayName})>.empty());
   when(
     () => cubit.sendMediaCommand(
       op: any(named: 'op'),
@@ -1062,10 +1060,7 @@ void main() {
 
         // Non-permission GATT setup failure → heartbeat watchdog handles it,
         // recheckPermissions must NOT be called (that would navigate away).
-        eventEmitter.emit({
-          'type': 'gattError',
-          'reason': 'GATT_SETUP_FAILED',
-        });
+        eventEmitter.emit({'type': 'gattError', 'reason': 'GATT_SETUP_FAILED'});
         await tester.pump();
 
         verifyNever(() => cubit.recheckPermissions());


### PR DESCRIPTION
Closes #326.

## Summary

- Deleted the two JNI stubs `nativeGetAudioData`/`nativePlayAudioData` from `audio_engine.cpp` — both were explicit no-ops (one returned `nullptr`, one was an empty body) kept solely to prevent an `UnsatisfiedLinkError` at load time.
- Removed the matching `getAudioData`/`playAudioData` wrapper methods and their `private external fun` declarations from `AudioEngineManager.kt`.
- Also applied a pre-existing `dart format` fix to `test/screens/frequency_room_screen_test.dart` (unrelated whitespace divergence that blocked the formatter gate).

No production call site invoked either method; confirmed by full-repo grep across `.kt`, `.dart`, `.cpp`, and `.java`.

## Test plan

- [x] `grep` for `nativeGetAudioData`/`nativePlayAudioData` returns zero results
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests pass
- [x] All native C++ tests pass (`mixer`, `jitter_buffer`, `resampler`, `talking_event_queue`, `ring_buffer`, `vad_detector`, `opus_codec`, `peer_audio_manager`)
- [x] Local presubmit (`scripts/presubmit.sh`) exits 0

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audio ducking volume control with improved handling and clamping.

* **Refactor**
  * Streamlined internal audio data handling mechanisms.

* **Tests**
  * Improved test code formatting and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->