### PR TITLE
fix(#302): fan-out host writeControlBytes to all connected guests

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -361,15 +361,28 @@ class MainActivity : FlutterActivity() {
                     }
                 }
                 "writeControlBytes" -> {
-                    // Alias for writeRequest used by BleControlTransport.
-                    // Guests write to the host's REQUEST characteristic.
+                    // Guests write to the host's REQUEST characteristic via
+                    // gattClientManager. Hosts fan-out via gattServerManager
+                    // notifications to every connected guest device.
                     val bytes = call.argument<ByteArray>("bytes")
                     if (bytes == null) {
                         result.error("INVALID_ARGUMENT", "bytes is required", null)
                     } else {
-                        Log.d(TAG, "Writing ${bytes.size} control bytes")
-                        val success = gattClientManager?.writeRequest(bytes) ?: false
-                        result.success(success)
+                        val server = gattServerManager
+                        if (server != null) {
+                            // Host path: notify each connected guest.
+                            val addresses = server.getConnectedAddresses()
+                            Log.d(TAG, "Host broadcasting ${bytes.size} control bytes to ${addresses.size} guest(s)")
+                            val success = addresses.fold(false) { any, addr ->
+                                server.notify(addr, bytes) || any
+                            }
+                            result.success(success)
+                        } else {
+                            // Guest path: write to the host's REQUEST characteristic.
+                            Log.d(TAG, "Writing ${bytes.size} control bytes")
+                            val success = gattClientManager?.writeRequest(bytes) ?: false
+                            result.success(success)
+                        }
                     }
                 }
                 "getNegotiatedMtu" -> {

--- a/lib/services/ble_control_transport.dart
+++ b/lib/services/ble_control_transport.dart
@@ -53,9 +53,9 @@ class BleControlTransport {
   _subscription;
 
   /// Endpoint the next [send] should size against. The cubit sets this
-  /// to the host's BT MAC once a guest has connected; the host has no
-  /// outbound use of [send] today (it writes notifications via
-  /// `audio.writeNotification`), so the value stays null on that side.
+  /// to the host's BT MAC once a guest has connected; on the host side
+  /// this stays null because `audio.writeControlBytes` fans out to all
+  /// connected guests via `gattServerManager` notifications directly.
   String? _activeEndpoint;
 
   /// Serialiser for [send]. Each call chains its body onto this future


### PR DESCRIPTION
Closes #302.

## Summary

- `writeControlBytes` in `MainActivity.kt` only routed to `gattClientManager?.writeRequest(bytes)`. On the host, `gattClientManager` is null, so every host→guest control message (JoinAccepted, RosterUpdate, HostTransfer, re-broadcasts) silently dropped.
- Fix: in `writeControlBytes`, check `gattServerManager` first. When non-null (host mode), call `server.getConnectedAddresses()` and `server.notify(addr, bytes)` for each connected guest. Fall through to the existing `gattClientManager.writeRequest()` path only when running as a guest.
- `GattServerManager.notify` and `getConnectedAddresses` were already implemented and wired; nothing new needed on the Kotlin side beyond the routing fix.
- Also corrects a stale comment in `BleControlTransport` that claimed "the host has no outbound use of send today."

## Why this is safe

`JoinAccepted` carries `recipientPeerId`. Guests that aren't the intended recipient already call `return` at `applyJoinAccepted:1821` — so broadcasting JoinAccepted to all connected guests via the fan-out path is correct: non-recipients drop it silently. RosterUpdate and HostTransfer were always intended as broadcasts.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 654/654 pass
- [x] All C++ tests pass (mixer, jitter_buffer, resampler, talking_event_queue, ring_buffer, vad_detector, opus_codec, peer_audio_manager)
- [ ] On-device: host phone + guest phone — guest sends JoinRequest → host sends JoinAccepted → guest enters room

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements

- Bluetooth control signaling system upgraded to support broadcasting to multiple connected devices simultaneously, significantly enhancing multi-device communication capabilities
- Host and guest device communication pathways optimized to ensure improved message delivery and connection reliability
- Control data transmission handling refined for better performance and stability across all device connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->