### PR TITLE
ci(#311): run Kotlin unit tests in CI via Gradle

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -126,6 +126,10 @@ jobs:
               -o build/cpp_test/opus_codec_test
           build/cpp_test/opus_codec_test
 
+      - name: Run Kotlin unit tests
+        working-directory: android
+        run: ./gradlew :app:testDebugUnitTest --no-daemon
+
       # App size budget (issue #131): build a debug AAB and enforce the
       # < 30 MB download-size target. Uses the debug keystore so no signing
       # credentials are needed. `continue-on-error` keeps the main test


### PR DESCRIPTION
Closes #311.

## Summary

- CI never invoked `./gradlew :app:testDebugUnitTest`, so `L2capFramingTest` (the only Kotlin unit test) ran only for contributors who manually ran Gradle locally.
- Added a `Run Kotlin unit tests` step after the native C++ block that calls `./gradlew :app:testDebugUnitTest --no-daemon`.
- No Java install step is needed — `ubuntu-latest` ships with a JDK and `flutter-action` (already in the workflow) sets up the Android toolchain.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 654/654 pass
- [x] All C++ tests pass (mixer, jitter_buffer, resampler, talking_event_queue, ring_buffer, vad_detector, opus_codec, peer_audio_manager)
- [ ] `./gradlew :app:testDebugUnitTest` — validated by CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced testing infrastructure for the Android app to improve code quality and reliability during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->