### PR TITLE
fix(#314): wire getLinkTelemetry and setPeerBitrate MethodChannel arms

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -494,6 +494,35 @@ class MainActivity : FlutterActivity() {
                     voiceTransport = null
                     result.success(true)
                 }
+                "getLinkTelemetry" -> {
+                    val mac = call.argument<String>("macAddress")
+                    if (mac == null) {
+                        result.error("INVALID_ARGUMENT", "macAddress is required", null)
+                    } else {
+                        val t = peerAudioManager?.getTelemetry(mac)
+                        if (t == null) {
+                            result.success(null)
+                        } else {
+                            result.success(intArrayOf(
+                                t.underrunCount,
+                                t.lateFrameCount,
+                                t.targetDepthFrames,
+                                t.currentDepthFrames,
+                                t.currentBitrateBps,
+                            ))
+                        }
+                    }
+                }
+                "setPeerBitrate" -> {
+                    val mac = call.argument<String>("macAddress")
+                    val bps = call.argument<Int>("bps")
+                    if (mac == null || bps == null) {
+                        result.error("INVALID_ARGUMENT", "macAddress and bps are required", null)
+                    } else {
+                        val applied = peerAudioManager?.setPeerBitrate(mac, bps) ?: -1
+                        result.success(applied)
+                    }
+                }
                 else -> {
                     result.notImplemented()
                 }


### PR DESCRIPTION
Closes #314.

MainActivity.kt had no when-arms for getLinkTelemetry or setPeerBitrate, so both fell through to result.notImplemented(). The complete path through LinkQualityReporter -> getLinkTelemetry -> BitrateAdapter -> setPeerBitrate was dead end-to-end; this wires the missing arms.

- getLinkTelemetry(macAddress): delegates to peerAudioManager?.getTelemetry(mac), returns a 5-element IntArray matching the Dart-side invokeMethod<dynamic> shape
- setPeerBitrate(macAddress, bps): delegates to peerAudioManager?.setPeerBitrate(mac, bps), returns clamped bitrate

Also fixes two pre-existing Gradle build blockers that were preventing Kotlin unit tests from running locally:
- kotlinOptions.jvmTarget deprecated setter -> kotlin.compilerOptions.jvmTarget (Kotlin 2.2 DSL)
- android:postSplashScreenTheme removed from values-v31 styles: attribute was dropped from the framework resource table in API 34; aapt2 with compileSdk >= 34 cannot resolve it

## Test plan
- flutter analyze: no issues
- flutter test: 654 tests pass
- C++ unit tests (mixer, jitter buffer, resampler, ring buffer, opus codec): all pass
- ./gradlew :app:testDebugUnitTest: BUILD SUCCESSFUL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving audio performance metrics for peer connections.
  * Added ability to dynamically adjust bitrate settings for individual peer connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->