### PR TITLE
fix(#315): call Sentry.close() when crash reporting is toggled off

### DIFF
--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import '../l10n/generated/app_localizations.dart';
 import '../services/sentry_config.dart';
@@ -135,6 +136,11 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
             onChanged: (v) {
               setState(() => _crashReporting = v);
               unawaited(widget.settingsStore.setCrashReportingEnabled(v));
+              if (!v) {
+                // Close the active Sentry session immediately so no events are
+                // captured or transmitted until the user re-enables on next launch.
+                unawaited(Sentry.close());
+              }
               if (!mounted) return;
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(

--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -137,9 +137,10 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
               setState(() => _crashReporting = v);
               unawaited(widget.settingsStore.setCrashReportingEnabled(v));
               if (!v) {
-                // Close the active Sentry session immediately so no events are
-                // captured or transmitted until the user re-enables on next launch.
-                unawaited(Sentry.close());
+                // Stop Sentry from capturing new events immediately. Any events
+                // already queued will be flushed during shutdown; re-init happens
+                // on the next launch if the user re-enables crash reporting.
+                unawaited(Sentry.close().catchError((_) {}));
               }
               if (!mounted) return;
               ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -62,6 +62,29 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
     });
   }
 
+  Future<void> _onCrashReportingChanged(bool v) async {
+    setState(() => _crashReporting = v);
+    await widget.settingsStore.setCrashReportingEnabled(v);
+    if (!v) {
+      // Stop capturing new events immediately. Any events already queued will
+      // be flushed during shutdown; re-init happens on the next launch if the
+      // user re-enables crash reporting.
+      await Sentry.close().catchError((_) {});
+    }
+    if (!mounted) return;
+    final l10n = AppLocalizations.of(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          v
+              ? l10n.settingsCrashReportingEnabledSnackbar
+              : l10n.settingsCrashReportingDisabledSnackbar,
+        ),
+        duration: const Duration(seconds: 4),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
@@ -133,27 +156,7 @@ class _FrequencySettingsScreenState extends State<FrequencySettingsScreen> {
             subtitle: l10n.settingsCrashReportingDescription,
             value: _crashReporting,
             c: c,
-            onChanged: (v) {
-              setState(() => _crashReporting = v);
-              unawaited(widget.settingsStore.setCrashReportingEnabled(v));
-              if (!v) {
-                // Stop Sentry from capturing new events immediately. Any events
-                // already queued will be flushed during shutdown; re-init happens
-                // on the next launch if the user re-enables crash reporting.
-                unawaited(Sentry.close().catchError((_) {}));
-              }
-              if (!mounted) return;
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    v
-                        ? l10n.settingsCrashReportingEnabledSnackbar
-                        : l10n.settingsCrashReportingDisabledSnackbar,
-                  ),
-                  duration: const Duration(seconds: 4),
-                ),
-              );
-            },
+            onChanged: (v) => unawaited(_onCrashReportingChanged(v)),
           )
         else
           _SettingsToggle(


### PR DESCRIPTION
Closes #315.

## Problem
Toggling crash reporting off in Settings only persisted the preference — it did not stop the active Sentry session. Any events captured between toggle-off and the next app launch (when `SentryFlutter.init` is skipped due to the stored preference) still reached Sentry's servers, creating a small privacy leak window.

## Fix
In the `onChanged` off-path of the crash reporting toggle in `frequency_settings_screen.dart`, call `unawaited(Sentry.close())` to flush and terminate the active session immediately.

Re-initialization is deferred to the next app launch (the existing `main()` path already handles this) to avoid mid-session re-init complexity.

## Notes
- `kSentryConfigured` is `false` in all test builds (no `SENTRY_DSN` dart-define), so this code path is only reachable in release/profile builds with a real DSN. No unit test is added for the `Sentry.close()` call itself for this reason.
- `Sentry.close()` is safe to call even if Sentry was never initialized — the SDK no-ops gracefully.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 654/654 pass
- [x] Formatting clean (`dart format --set-exit-if-changed`)
- [x] All C++ native tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crash reporting toggle now reliably persists the setting and immediately closes any active crash-reporting session when disabled.
  * UI toggle behavior consolidated so disabling crash reporting stops data flow and shows appropriate confirmation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->