### PR TITLE
docs(#322): align contact email to support@formalizedchaos.com

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -139,4 +139,4 @@ be filed as an issue on the project's GitHub repository or emailed to
 the maintainers:
 
 - <https://github.com/ElodinLaarz/walkie-talkie/issues>
-- <info@formalizedchaos.com>
+- <support@formalizedchaos.com>


### PR DESCRIPTION
## Problem

`docs/privacy-policy.md` used `info@formalizedchaos.com` while the in-app block-report flow (`frequency_room_screen.dart`) and its test used `support@formalizedchaos.com`.

## Fix

Changed `privacy-policy.md` to use `support@formalizedchaos.com`, matching the in-app contact address.

Closes #322

## Audit

All occurrences of `formalizedchaos.com` across the codebase now use `support@`:
- `docs/privacy-policy.md:142` — fixed ✓
- `lib/screens/frequency_room_screen.dart:1393,1422` — already correct ✓
- `test/screens/frequency_room_screen_test.dart:1133` — already correct ✓

## Test plan

- [x] Local presubmit passes (`bash scripts/presubmit.sh`): 666 Flutter tests + all C++ tests
- [x] `dart format` reports no changes
- [x] `flutter analyze` reports no issues