### PR TITLE
fix(#305): remove unused google_fonts dep (silent egress risk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ graph TD
 3.  **`permission_handler`** — Bluetooth scan / connect / advertise + mic
     permissions. The runtime asks happen during onboarding
     ([lib/services/onboarding_permission_gateway.dart](lib/services/onboarding_permission_gateway.dart)).
-4.  **`google_fonts`** — typography.
 
 ### Android Native (Kotlin / C++)
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -429,14 +429,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.0"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,7 +60,6 @@ dependencies:
   flutter_blue_plus: ^2.2.1
   
   # UI/UX
-  google_fonts: ^8.1.0
   package_info_plus: ^10.1.0
   url_launcher: ^6.3.1
 


### PR DESCRIPTION
## Summary
- Removes `google_fonts: ^8.1.0` from `pubspec.yaml` (dep had zero call sites in `lib/`).
- Refreshes `pubspec.lock` (google_fonts dropped, no other version drift).
- Removes the stale `google_fonts` line from the README's Tech Stack table.

## Why this is the right shape of fix

Issue #305 is a 🔴 launch blocker: `google_fonts` fetches `.ttf` files from `fonts.google.com` at runtime by default, which is silent network egress that contradicts the "no internet for voice/control" privacy posture and the Play Data Safety form.

The issue suggests setting `GoogleFonts.config.allowRuntimeFetching = false` and bundling `.ttf` assets — but `grep -rn "GoogleFonts\|google_fonts" lib/` returns **zero hits** (theme/`app_theme.dart` uses Material defaults). The dep is dead. Dropping it eliminates the entire risk surface, no flag-gating or font bundling required.

## Test plan
- [x] `flutter pub get` — google_fonts removed cleanly, no other dep drift
- [x] `flutter analyze` — No issues found
- [x] `flutter test` — 708 tests pass
- [ ] Reviewer: confirm no `lib/` file imports `package:google_fonts/...`

Closes #305.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the google_fonts dependency
  * Added/updated flutter_blue_plus dependency

* **Documentation**
  * Updated tech stack listing in the README to reflect dependency changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->