### PR TITLE
test(#324): unit tests for uuid, peer, and styled_template

### DIFF
--- a/test/l10n/styled_template_test.dart
+++ b/test/l10n/styled_template_test.dart
@@ -9,7 +9,7 @@ void main() {
   group('styledTemplate', () {
     test('single placeholder produces prefix + value + suffix spans', () {
       // Simulates a template like "Join {freq} now".
-      String template(String s) => 'Join ${s}now';
+      String template(String s) => 'Join $s now';
       final spans = styledTemplate(
         template: template,
         value: '92.5',
@@ -21,7 +21,7 @@ void main() {
       expect((spans[0] as TextSpan).style, surroundingStyle);
       expect((spans[1] as TextSpan).text, '92.5');
       expect((spans[1] as TextSpan).style, valueStyle);
-      expect((spans[2] as TextSpan).text, 'now');
+      expect((spans[2] as TextSpan).text, ' now');
       expect((spans[2] as TextSpan).style, surroundingStyle);
     });
 

--- a/test/l10n/styled_template_test.dart
+++ b/test/l10n/styled_template_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/l10n/styled_template.dart';
+
+void main() {
+  const valueStyle = TextStyle(fontWeight: FontWeight.bold);
+  const surroundingStyle = TextStyle(fontStyle: FontStyle.italic);
+
+  group('styledTemplate', () {
+    test('single placeholder produces prefix + value + suffix spans', () {
+      // Simulates a template like "Join {freq} now".
+      String template(String s) => 'Join ${s}now';
+      final spans = styledTemplate(
+        template: template,
+        value: '92.5',
+        valueStyle: valueStyle,
+        surroundingStyle: surroundingStyle,
+      );
+      expect(spans.length, 3);
+      expect((spans[0] as TextSpan).text, 'Join ');
+      expect((spans[0] as TextSpan).style, surroundingStyle);
+      expect((spans[1] as TextSpan).text, '92.5');
+      expect((spans[1] as TextSpan).style, valueStyle);
+      expect((spans[2] as TextSpan).text, 'now');
+      expect((spans[2] as TextSpan).style, surroundingStyle);
+    });
+
+    test('placeholder at start: value span comes first', () {
+      String template(String s) => '${s}MHz';
+      final spans = styledTemplate(
+        template: template,
+        value: '101',
+        valueStyle: valueStyle,
+      );
+      // Empty prefix part is dropped; only value + suffix.
+      expect(spans.length, 2);
+      expect((spans[0] as TextSpan).text, '101');
+      expect((spans[1] as TextSpan).text, 'MHz');
+    });
+
+    test('placeholder at end: value span comes last', () {
+      String template(String s) => 'Freq: $s';
+      final spans = styledTemplate(
+        template: template,
+        value: '107.9',
+        valueStyle: valueStyle,
+      );
+      // Empty suffix part is dropped; only prefix + value.
+      expect(spans.length, 2);
+      expect((spans[0] as TextSpan).text, 'Freq: ');
+      expect((spans[1] as TextSpan).text, '107.9');
+    });
+
+    test('surrounding style is null when not provided', () {
+      String template(String s) => 'a${s}b';
+      final spans = styledTemplate(
+        template: template,
+        value: 'X',
+        valueStyle: valueStyle,
+      );
+      expect((spans[0] as TextSpan).style, isNull);
+    });
+
+    test('empty surrounding text parts are omitted', () {
+      // Template with no text around the placeholder.
+      String template(String s) => s;
+      final spans = styledTemplate(
+        template: template,
+        value: '88',
+        valueStyle: valueStyle,
+      );
+      expect(spans.length, 1);
+      expect((spans[0] as TextSpan).text, '88');
+    });
+
+    test('value is inserted only once for single placeholder', () {
+      String template(String s) => 'before${s}after';
+      final spans = styledTemplate(
+        template: template,
+        value: 'VAL',
+        valueStyle: valueStyle,
+      );
+      final valueSpans = spans
+          .whereType<TextSpan>()
+          .where((s) => s.text == 'VAL')
+          .toList();
+      expect(valueSpans.length, 1);
+    });
+  });
+}

--- a/test/protocol/peer_test.dart
+++ b/test/protocol/peer_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/protocol/peer.dart';
+
+void main() {
+  const base = ProtocolPeer(
+    peerId: 'peer-1',
+    displayName: 'Alice',
+    btDevice: 'AA:BB:CC:DD:EE:FF',
+    muted: false,
+    talking: false,
+  );
+
+  group('ProtocolPeer.copyWith', () {
+    test('no-arg copy returns equal peer', () {
+      expect(base.copyWith(), equals(base));
+    });
+
+    test('updates displayName', () {
+      final updated = base.copyWith(displayName: 'Bob');
+      expect(updated.displayName, 'Bob');
+      expect(updated.peerId, base.peerId);
+    });
+
+    test('updates muted and talking independently', () {
+      final muted = base.copyWith(muted: true);
+      expect(muted.muted, isTrue);
+      expect(muted.talking, isFalse);
+
+      final talking = base.copyWith(talking: true);
+      expect(talking.talking, isTrue);
+      expect(talking.muted, isFalse);
+    });
+
+    test('omitting btDevice preserves existing value', () {
+      final copy = base.copyWith(muted: true);
+      expect(copy.btDevice, 'AA:BB:CC:DD:EE:FF');
+    });
+
+    test('passing btDevice: null clears the field', () {
+      final cleared = base.copyWith(btDevice: null);
+      expect(cleared.btDevice, isNull);
+    });
+
+    test('passing new btDevice value replaces it', () {
+      final updated = base.copyWith(btDevice: '11:22:33:44:55:66');
+      expect(updated.btDevice, '11:22:33:44:55:66');
+    });
+
+    test('copyWith on peer with null btDevice: omitting preserves null', () {
+      const noBt = ProtocolPeer(peerId: 'p', displayName: 'X');
+      expect(noBt.copyWith(muted: true).btDevice, isNull);
+    });
+
+    test('copyWith on peer with null btDevice: can set a value', () {
+      const noBt = ProtocolPeer(peerId: 'p', displayName: 'X');
+      expect(
+        noBt.copyWith(btDevice: 'FF:EE:DD:CC:BB:AA').btDevice,
+        'FF:EE:DD:CC:BB:AA',
+      );
+    });
+  });
+
+  group('ProtocolPeer equality', () {
+    test('equal peers with same fields', () {
+      const a = ProtocolPeer(peerId: 'x', displayName: 'Y');
+      const b = ProtocolPeer(peerId: 'x', displayName: 'Y');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('peers with different peerId are not equal', () {
+      const a = ProtocolPeer(peerId: 'x', displayName: 'Y');
+      const b = ProtocolPeer(peerId: 'z', displayName: 'Y');
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('ProtocolPeer JSON round-trip', () {
+    test('toJson / fromJson preserves all fields', () {
+      final json = base.toJson();
+      final restored = ProtocolPeer.fromJson(json);
+      expect(restored, equals(base));
+    });
+
+    test('btDevice absent in JSON parses as null', () {
+      const noBt = ProtocolPeer(peerId: 'p', displayName: 'X');
+      final json = noBt.toJson();
+      expect(json.containsKey('btDevice'), isFalse);
+      final restored = ProtocolPeer.fromJson(json);
+      expect(restored.btDevice, isNull);
+    });
+  });
+}

--- a/test/protocol/uuid_test.dart
+++ b/test/protocol/uuid_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/protocol/uuid.dart';
+
+void main() {
+  group('generateUuidV4', () {
+    test('returns canonical 8-4-4-4-12 hyphenated format', () {
+      final uuid = generateUuidV4();
+      final parts = uuid.split('-');
+      expect(parts.length, 5);
+      expect(parts[0].length, 8);
+      expect(parts[1].length, 4);
+      expect(parts[2].length, 4);
+      expect(parts[3].length, 4);
+      expect(parts[4].length, 12);
+    });
+
+    test('version nibble is 4', () {
+      final uuid = generateUuidV4();
+      // Third group, first character must be '4'.
+      expect(uuid.split('-')[2][0], '4');
+    });
+
+    test('variant bits are 10xx (high nibble 8–b)', () {
+      final uuid = generateUuidV4();
+      // Fourth group, first hex digit must be 8, 9, a, or b.
+      final variantChar = uuid.split('-')[3][0];
+      expect(
+        '89ab'.contains(variantChar),
+        isTrue,
+        reason: 'Expected variant nibble in {8,9,a,b}, got $variantChar',
+      );
+    });
+
+    test('output is lowercase hex', () {
+      final uuid = generateUuidV4();
+      final noHyphens = uuid.replaceAll('-', '');
+      expect(noHyphens, matches(RegExp(r'^[0-9a-f]+$')));
+    });
+
+    test('successive calls return distinct values', () {
+      final a = generateUuidV4();
+      final b = generateUuidV4();
+      expect(a, isNot(equals(b)));
+    });
+  });
+}


### PR DESCRIPTION
Closes #324

## Summary
- **`test/protocol/uuid_test.dart`** — verifies RFC 4122 v4 constraints: canonical `8-4-4-4-12` format, version nibble `4`, variant nibble in `{8,9,a,b}`, lowercase hex output, and that successive calls return distinct values
- **`test/protocol/peer_test.dart`** — exercises `ProtocolPeer.copyWith` with the `_noChange` sentinel (distinguishing omitted vs explicit-null `btDevice`), JSON round-trip fidelity, and `==`/`hashCode` invariants  
- **`test/l10n/styled_template_test.dart`** — covers `styledTemplate` for prefix/infix/suffix placeholder positions, empty-part elision, `null` surroundingStyle passthrough, and single-insertion guarantee

## Test plan
- [ ] `flutter test test/protocol/uuid_test.dart test/protocol/peer_test.dart test/l10n/styled_template_test.dart` — all 23 tests pass
- [ ] `bash scripts/presubmit.sh` — full local CI passes (format, analyze, test, native C++)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering template styling behavior and span generation edge cases.
  * Added protocol peer tests for copy/update semantics, equality/hash, and JSON round-trip handling.
  * Added UUID v4 tests validating canonical format, version/variant bits, lowercase hex, and uniqueness across calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->