### PR TITLE
test: push line coverage 86.22% → 90.53% for codecov badge

### DIFF
--- a/test/bloc/discovery_cubit_test.dart
+++ b/test/bloc/discovery_cubit_test.dart
@@ -86,45 +86,14 @@ void main() {
   });
 
   test(
-    'startDiscovery from DiscoveryStopped(with prior sessions) preserves them on failure',
+    'startDiscovery from DiscoveryStopped emits empty DiscoveryStopped on failure',
     () async {
-      // First scan: succeeds, fills in sessions.
       await cubit.startDiscovery();
-      final sessions = [
-        DiscoveredSession(
-          protocolVersion: 1,
-          isHost: true,
-          sessionUuidLow8: '1234567890ABCDEF',
-          flags: 0,
-          hostName: 'Host',
-          rssi: -55,
-          macAddress: 'AA:BB:CC:DD:EE:FF',
-        ),
-      ];
-      resultsController.add(sessions);
-      await Future.delayed(Duration.zero);
-
-      // Stop — cubit is now DiscoveryStopped(sessions: sessions).
-      await cubit.stopDiscovery();
-      // stopDiscovery emits an empty DiscoveryStopped(); inject one with
-      // sessions to exercise the inner ternary branch on retry.
-      // Restart with a failure: the catch block reads
-      // `state is DiscoveryStopped`, so seed the state first by emitting
-      // the test sessions after a successful scan that we then stop with
-      // a non-default emit. We simulate that here by triggering startScan
-      // again immediately and feeding sessions.
-      await cubit.startDiscovery();
-      resultsController.add(sessions);
-      await Future.delayed(Duration.zero);
       await cubit.stopDiscovery();
 
-      // Now the state is DiscoveryStopped() (empty by default). The inner
-      // ternary branch exists for *future* paths where stopDiscovery may
-      // return non-empty; reaching it from the cubit's public API is not
-      // possible today. Verify the failure-path emission without leaking
-      // through that ternary.
       when(mockService.startScan()).thenThrow(Exception('boom'));
       await cubit.startDiscovery();
+
       expect(cubit.state, const DiscoveryStopped());
     },
   );

--- a/test/bloc/discovery_cubit_test.dart
+++ b/test/bloc/discovery_cubit_test.dart
@@ -84,4 +84,48 @@ void main() {
     await cubit.stopDiscovery();
     expect(cubit.state, const DiscoveryStopped()); // empty sessions expected
   });
+
+  test(
+    'startDiscovery from DiscoveryStopped(with prior sessions) preserves them on failure',
+    () async {
+      // First scan: succeeds, fills in sessions.
+      await cubit.startDiscovery();
+      final sessions = [
+        DiscoveredSession(
+          protocolVersion: 1,
+          isHost: true,
+          sessionUuidLow8: '1234567890ABCDEF',
+          flags: 0,
+          hostName: 'Host',
+          rssi: -55,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        ),
+      ];
+      resultsController.add(sessions);
+      await Future.delayed(Duration.zero);
+
+      // Stop — cubit is now DiscoveryStopped(sessions: sessions).
+      await cubit.stopDiscovery();
+      // stopDiscovery emits an empty DiscoveryStopped(); inject one with
+      // sessions to exercise the inner ternary branch on retry.
+      // Restart with a failure: the catch block reads
+      // `state is DiscoveryStopped`, so seed the state first by emitting
+      // the test sessions after a successful scan that we then stop with
+      // a non-default emit. We simulate that here by triggering startScan
+      // again immediately and feeding sessions.
+      await cubit.startDiscovery();
+      resultsController.add(sessions);
+      await Future.delayed(Duration.zero);
+      await cubit.stopDiscovery();
+
+      // Now the state is DiscoveryStopped() (empty by default). The inner
+      // ternary branch exists for *future* paths where stopDiscovery may
+      // return non-empty; reaching it from the cubit's public API is not
+      // possible today. Verify the failure-path emission without leaking
+      // through that ternary.
+      when(mockService.startScan()).thenThrow(Exception('boom'));
+      await cubit.startDiscovery();
+      expect(cubit.state, const DiscoveryStopped());
+    },
+  );
 }

--- a/test/bloc/discovery_cubit_test.dart
+++ b/test/bloc/discovery_cubit_test.dart
@@ -95,6 +95,10 @@ void main() {
       await cubit.startDiscovery();
 
       expect(cubit.state, const DiscoveryStopped());
+      // Pin the interaction — without this, an early return that never
+      // reached the service would still leave the state at
+      // DiscoveryStopped() and pass the assertion.
+      verify(mockService.startScan()).called(2);
     },
   );
 }

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -346,6 +346,16 @@ void main() {
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(
+      'bootstrap tolerates getPeerId throwing and still advances state',
+      build: () => _makeCubit(
+        identityStore: _FakeStore(initial: 'Maya')..throwOnGetPeerId = true,
+      ),
+      act: (cubit) => cubit.bootstrap(),
+      expect: () =>
+          [isA<SessionDiscovery>().having((s) => s.myName, 'myName', 'Maya')],
+    );
+
+    blocTest<FrequencySessionCubit, FrequencySessionState>(
       'completeOnboarding persists and advances to Discovery',
       build: () => _makeCubit(),
       seed: () => const SessionOnboarding(),

--- a/test/protocol/discovery_test.dart
+++ b/test/protocol/discovery_test.dart
@@ -167,5 +167,41 @@ void main() {
       // low12 = 250, tenths = 880 + (250 % 200) = 880 + 50 = 930, mhz = 93.0
       expect(s3.mhzDisplay, '93.0');
     });
+
+    test(
+      'mhzDisplay falls back to 88.0 on a sessionUuidLow8 with non-hex chars',
+      () {
+        // Hits the int.tryParse-null branch in _hexToBytes; the parse fails,
+        // _hexToBytes returns an empty Uint8List, and _deriveMhz returns the
+        // 88.0 default when bytes.length < 2.
+        final s = DiscoveredSession(
+          protocolVersion: 1,
+          isHost: true,
+          sessionUuidLow8: 'ZZZZ00FF00FF00FF',
+          flags: 0,
+          hostName: 'badHex',
+          rssi: -60,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        expect(s.mhzDisplay, '88.0');
+      },
+    );
+
+    test(
+      'mhzDisplay falls back to 88.0 on an odd-length sessionUuidLow8',
+      () {
+        // hex.length.isOdd → _hexToBytes returns an empty Uint8List.
+        final s = DiscoveredSession(
+          protocolVersion: 1,
+          isHost: true,
+          sessionUuidLow8: 'ABC',
+          flags: 0,
+          hostName: 'oddLen',
+          rssi: -55,
+          macAddress: 'AA:BB:CC:DD:EE:FF',
+        );
+        expect(s.mhzDisplay, '88.0');
+      },
+    );
   });
 }

--- a/test/protocol/frequency_session_test.dart
+++ b/test/protocol/frequency_session_test.dart
@@ -84,5 +84,19 @@ void main() {
         throwsFormatException,
       );
     });
+
+    test('hashCode + toString cover terminal members', () {
+      const a = FrequencySession(
+        sessionUuid: '550e8400-e29b-41d4-a716-446655440000',
+        hostPeerId: 'h1',
+      );
+      const b = FrequencySession(
+        sessionUuid: '550e8400-e29b-41d4-a716-446655440000',
+        hostPeerId: 'h1',
+      );
+      expect(a.hashCode, b.hashCode);
+      expect(a.toString(), contains('FrequencySession('));
+      expect(a.toString(), contains('h1'));
+    });
   });
 }

--- a/test/protocol/messages_test.dart
+++ b/test/protocol/messages_test.dart
@@ -466,6 +466,94 @@ void main() {
       expect(round.talking, isFalse);
       expect(round.btDevice, isNull);
     });
+
+    test('hashCode + toString cover terminal members', () {
+      const a = ProtocolPeer(
+        peerId: 'p',
+        displayName: 'Maya',
+        btDevice: 'AirPods Pro',
+        muted: true,
+        talking: true,
+      );
+      const b = ProtocolPeer(
+        peerId: 'p',
+        displayName: 'Maya',
+        btDevice: 'AirPods Pro',
+        muted: true,
+        talking: true,
+      );
+      expect(a.hashCode, b.hashCode);
+      expect(a.toString(), contains('Maya'));
+      expect(a.toString(), contains('muted=true'));
+    });
+  });
+
+  group('JoinDenyReason.fromWire', () {
+    test('throws FormatException on unknown reason', () {
+      expect(
+        () => JoinDenyReasonWire.fromWire('moon-phase'),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('MediaOp.fromWire', () {
+    test('throws FormatException on unknown op', () {
+      expect(
+        () => MediaOpWire.fromWire('teleport'),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('MediaState equality + hashCode', () {
+    test('value-equal instances are equal', () {
+      const a = MediaState(
+        source: 'spotify',
+        trackIdx: 1,
+        playing: true,
+        positionMs: 4200,
+      );
+      const b = MediaState(
+        source: 'spotify',
+        trackIdx: 1,
+        playing: true,
+        positionMs: 4200,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different field flips equality', () {
+      const a = MediaState(
+        source: 'spotify',
+        trackIdx: 1,
+        playing: true,
+        positionMs: 4200,
+      );
+      const b = MediaState(
+        source: 'spotify',
+        trackIdx: 1,
+        playing: false,
+        positionMs: 4200,
+      );
+      expect(a == b, isFalse);
+    });
+  });
+
+  group('NeighborSignal equality + hashCode', () {
+    test('value-equal instances are equal', () {
+      const a = NeighborSignal(peerId: 'p', rssi: -65);
+      const b = NeighborSignal(peerId: 'p', rssi: -65);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different rssi flips equality', () {
+      const a = NeighborSignal(peerId: 'p', rssi: -65);
+      const b = NeighborSignal(peerId: 'p', rssi: -70);
+      expect(a == b, isFalse);
+    });
   });
 
   group('exhaustive switch on FrequencyMessage', () {

--- a/test/protocol/voice_frame_test.dart
+++ b/test/protocol/voice_frame_test.dart
@@ -178,5 +178,29 @@ void main() {
       // The frame's payload must not reflect the mutation.
       expect(frame.payload[0], 0xAB);
     });
+
+    test('hashCode is stable for equal frames', () {
+      final a = VoiceFrame(
+        seq: 1,
+        senderTsMs: 2,
+        payload: Uint8List.fromList([1, 2, 3]),
+      );
+      final b = VoiceFrame(
+        seq: 1,
+        senderTsMs: 2,
+        payload: Uint8List.fromList([1, 2, 3]),
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toString includes payload byte count', () {
+      final f = VoiceFrame(
+        seq: 5,
+        senderTsMs: 10,
+        payload: Uint8List(7),
+      );
+      expect(f.toString(), contains('payload=7B'));
+    });
   });
 }

--- a/test/screens/frequency_explainer_screen_test.dart
+++ b/test/screens/frequency_explainer_screen_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/l10n/generated/app_localizations.dart';
+import 'package:walkie_talkie/screens/frequency_explainer_screen.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  theme: AppTheme.light(),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: child,
+);
+
+void main() {
+  group('FrequencyExplainerScreen non-embedded (default)', () {
+    testWidgets('renders Scaffold with Skip + Next on the first page',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(FrequencyExplainerScreen(onDone: () {})),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Scaffold), findsOneWidget);
+      // Skip button shows on non-last pages.
+      expect(find.text('Skip'), findsOneWidget);
+      expect(find.text('Next'), findsOneWidget);
+      // Get started only shows on the final page.
+      expect(find.text('Get started'), findsNothing);
+    });
+
+    testWidgets('tapping Skip invokes onDone', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _wrap(FrequencyExplainerScreen(onDone: () => taps++)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Skip'));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('Next advances to last page where Get started appears',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(FrequencyExplainerScreen(onDone: () {})),
+      );
+      await tester.pumpAndSettle();
+
+      // Three pages — tap Next twice to reach the end.
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Get started'), findsOneWidget);
+      expect(find.text('Skip'), findsNothing);
+    });
+
+    testWidgets('Back from page 2 returns to page 1 (exercises previousPage)',
+        (tester) async {
+      await tester.pumpWidget(
+        _wrap(FrequencyExplainerScreen(onDone: () {})),
+      );
+      await tester.pumpAndSettle();
+
+      // Advance once.
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+
+      // Back button should now be active.
+      await tester.tap(find.text('Back'));
+      await tester.pumpAndSettle();
+
+      // Skip is visible only on non-last pages — being back on page 0
+      // (still non-last) means it's still showing.
+      expect(find.text('Skip'), findsOneWidget);
+    });
+
+    testWidgets('Get started invokes onDone', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _wrap(FrequencyExplainerScreen(onDone: () => taps++)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Next'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Get started'));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+    });
+  });
+
+  group('FrequencyExplainerScreen embedded', () {
+    testWidgets('embedded mode skips Scaffold + chrome', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          // Wrap in a Scaffold so MediaQuery + Material are available; the
+          // screen under test must NOT add its own.
+          Scaffold(
+            body: FrequencyExplainerScreen(
+              onDone: () {},
+              embedded: true,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // No Skip button in embedded mode (chrome is suppressed).
+      expect(find.text('Skip'), findsNothing);
+      // Next button still shows.
+      expect(find.text('Next'), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/frequency_explainer_screen_test.dart
+++ b/test/screens/frequency_explainer_screen_test.dart
@@ -113,6 +113,9 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      // The wrapping Scaffold is the only one — embedded mode must not
+      // build its own.
+      expect(find.byType(Scaffold), findsOneWidget);
       // No Skip button in embedded mode (chrome is suppressed).
       expect(find.text('Skip'), findsNothing);
       // Next button still shows.

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -987,7 +987,7 @@ void main() {
     );
 
     testWidgets(
-      'audioOutputChanged to bluetooth with btName updates output state',
+      'audioOutputChanged to bluetooth with btName flips chrome label + me-row',
       (tester) async {
         final eventEmitter = _EventChannelEmitter(
           'com.elodin.walkie_talkie/audio_events',
@@ -997,6 +997,9 @@ void main() {
         await tester.pumpWidget(_wrap(_room()));
         await tester.pump();
 
+        // Pre-condition: speaker output → chrome shows "Speaker".
+        expect(find.text('Phone speaker'), findsWidgets);
+
         eventEmitter.emit({
           'type': 'audioOutputChanged',
           'output': 'bluetooth',
@@ -1004,10 +1007,10 @@ void main() {
         });
         await tester.pump();
 
-        // No public surface to assert on directly; coverage of the event
-        // handler's bluetooth-with-name branch is the value here. The
-        // widget should still be mounted without throwing.
-        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+        // Chrome label flips to "headphones"; the me-row's btDevice slot
+        // shows the device name from the event payload.
+        expect(find.text('headphones'), findsOneWidget);
+        expect(find.text('AirPods Pro'), findsOneWidget);
       },
     );
 
@@ -1028,7 +1031,9 @@ void main() {
         });
         await tester.pump();
 
-        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+        // No btName in payload + no prior btDevice → fallback "Bluetooth".
+        expect(find.text('headphones'), findsOneWidget);
+        expect(find.text('Bluetooth'), findsOneWidget);
       },
     );
 
@@ -1050,20 +1055,23 @@ void main() {
           'btName': 'AirPods Pro',
         });
         await tester.pump();
+        expect(find.text('AirPods Pro'), findsOneWidget);
 
-        // Then flip back to speaker — the handler must clear btDevice.
+        // Then flip back to speaker — the handler must clear btDevice
+        // so the device name disappears.
         eventEmitter.emit({
           'type': 'audioOutputChanged',
           'output': 'speaker',
         });
         await tester.pump();
 
-        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+        expect(find.text('AirPods Pro'), findsNothing);
+        expect(find.text('Phone speaker'), findsWidgets);
       },
     );
 
     testWidgets(
-      'audioOutputChanged with unknown output is ignored (orElse branch)',
+      'audioOutputChanged with unknown output keeps prior state (orElse branch)',
       (tester) async {
         final eventEmitter = _EventChannelEmitter(
           'com.elodin.walkie_talkie/audio_events',
@@ -1072,6 +1080,8 @@ void main() {
 
         await tester.pumpWidget(_wrap(_room()));
         await tester.pump();
+        // Pre-condition: speaker.
+        expect(find.text('Phone speaker'), findsWidgets);
 
         eventEmitter.emit({
           'type': 'audioOutputChanged',
@@ -1079,7 +1089,9 @@ void main() {
         });
         await tester.pump();
 
-        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+        // orElse returns the current output → still Speaker.
+        expect(find.text('Phone speaker'), findsWidgets);
+        expect(find.text('headphones'), findsNothing);
       },
     );
 

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -987,6 +987,103 @@ void main() {
     );
 
     testWidgets(
+      'audioOutputChanged to bluetooth with btName updates output state',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        await tester.pumpWidget(_wrap(_room()));
+        await tester.pump();
+
+        eventEmitter.emit({
+          'type': 'audioOutputChanged',
+          'output': 'bluetooth',
+          'btName': 'AirPods Pro',
+        });
+        await tester.pump();
+
+        // No public surface to assert on directly; coverage of the event
+        // handler's bluetooth-with-name branch is the value here. The
+        // widget should still be mounted without throwing.
+        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'audioOutputChanged to bluetooth without btName falls back to placeholder',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        await tester.pumpWidget(_wrap(_room()));
+        await tester.pump();
+
+        eventEmitter.emit({
+          'type': 'audioOutputChanged',
+          'output': 'bluetooth',
+        });
+        await tester.pump();
+
+        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'audioOutputChanged away from bluetooth clears btDevice',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        await tester.pumpWidget(_wrap(_room()));
+        await tester.pump();
+
+        // First flip on with a name.
+        eventEmitter.emit({
+          'type': 'audioOutputChanged',
+          'output': 'bluetooth',
+          'btName': 'AirPods Pro',
+        });
+        await tester.pump();
+
+        // Then flip back to speaker — the handler must clear btDevice.
+        eventEmitter.emit({
+          'type': 'audioOutputChanged',
+          'output': 'speaker',
+        });
+        await tester.pump();
+
+        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'audioOutputChanged with unknown output is ignored (orElse branch)',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        await tester.pumpWidget(_wrap(_room()));
+        await tester.pump();
+
+        eventEmitter.emit({
+          'type': 'audioOutputChanged',
+          'output': 'martian-speaker',
+        });
+        await tester.pump();
+
+        expect(find.byType(FrequencyRoomScreen), findsOneWidget);
+      },
+    );
+
+    testWidgets(
       'audioError and error events trigger immediate permission recheck (#250)',
       (tester) async {
         final eventEmitter = _EventChannelEmitter(

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -5,7 +5,6 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:walkie_talkie/bloc/frequency_session_cubit.dart';
 import 'package:walkie_talkie/bloc/frequency_session_state.dart';
 import 'package:walkie_talkie/l10n/generated/app_localizations.dart';
-import 'package:walkie_talkie/protocol/peer.dart';
 import 'package:walkie_talkie/screens/frequency_privacy_policy_screen.dart';
 import 'package:walkie_talkie/screens/frequency_settings_screen.dart';
 import 'package:walkie_talkie/screens/security_faq_screen.dart';
@@ -59,8 +58,11 @@ class _FakeSettingsStore implements SettingsStore {
   Future<void> setCrashReportingEnabled(bool v) async =>
       calls.add(('setCrashReporting', v));
 
+  int clearCalls = 0;
+
   @override
   Future<void> clear() async {
+    clearCalls++;
     if (throwOnClear) throw StateError('boom');
     pttMode = false;
     keepScreenOn = false;
@@ -487,7 +489,12 @@ void main() {
         await tester.tap(find.widgetWithText(TextButton, 'Reset'));
         await tester.pumpAndSettle();
 
-        // Tolerated errors → still reset.
+        // Tolerated errors → every store's clear() was attempted, and
+        // the cubit reset still ran exactly once.
+        expect(identity.clearCalls, 1);
+        expect(recents.clearCalls, 1);
+        expect(blocked.clearCalls, 1);
+        expect(settings.clearCalls, 1);
         expect(cubit.resetCalls, 1);
       },
     );
@@ -532,6 +539,7 @@ class _ProvidedSettings extends StatelessWidget {
 
 class _FakeIdentityStore implements IdentityStore {
   bool cleared = false;
+  int clearCalls = 0;
   final bool throwOnClear;
   _FakeIdentityStore({this.throwOnClear = false});
 
@@ -543,6 +551,7 @@ class _FakeIdentityStore implements IdentityStore {
   Future<String> getPeerId() async => 'fake-peer';
   @override
   Future<void> clear() async {
+    clearCalls++;
     if (throwOnClear) throw StateError('boom');
     cleared = true;
   }
@@ -550,6 +559,7 @@ class _FakeIdentityStore implements IdentityStore {
 
 class _FakeRecentStore implements RecentFrequenciesStore {
   bool cleared = false;
+  int clearCalls = 0;
   final bool throwOnClear;
   _FakeRecentStore({this.throwOnClear = false});
 
@@ -567,6 +577,7 @@ class _FakeRecentStore implements RecentFrequenciesStore {
   Future<void> delete(String freq) async {}
   @override
   Future<void> clear() async {
+    clearCalls++;
     if (throwOnClear) throw StateError('boom');
     cleared = true;
   }
@@ -574,6 +585,7 @@ class _FakeRecentStore implements RecentFrequenciesStore {
 
 class _FakeBlockedStore implements BlockedPeersStore {
   bool cleared = false;
+  int clearCalls = 0;
   final bool throwOnClear;
   _FakeBlockedStore({this.throwOnClear = false});
 
@@ -585,6 +597,7 @@ class _FakeBlockedStore implements BlockedPeersStore {
   Future<void> unblock(String peerId) async {}
   @override
   Future<void> clear() async {
+    clearCalls++;
     if (throwOnClear) throw StateError('boom');
     cleared = true;
   }

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -1,9 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:walkie_talkie/bloc/frequency_session_cubit.dart';
+import 'package:walkie_talkie/bloc/frequency_session_state.dart';
 import 'package:walkie_talkie/l10n/generated/app_localizations.dart';
+import 'package:walkie_talkie/protocol/peer.dart';
 import 'package:walkie_talkie/screens/frequency_privacy_policy_screen.dart';
 import 'package:walkie_talkie/screens/frequency_settings_screen.dart';
+import 'package:walkie_talkie/screens/security_faq_screen.dart';
+import 'package:walkie_talkie/services/blocked_peers_store.dart';
+import 'package:walkie_talkie/services/identity_store.dart';
+import 'package:walkie_talkie/services/recent_frequencies_store.dart';
 import 'package:walkie_talkie/services/settings_store.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/frequency_atoms.dart';
@@ -20,10 +28,16 @@ Widget _wrap(Widget child) {
 class _FakeSettingsStore implements SettingsStore {
   bool pttMode;
   bool keepScreenOn;
+  bool cleared = false;
+  final bool throwOnClear;
 
   final List<(String, bool)> calls = [];
 
-  _FakeSettingsStore({this.pttMode = false, this.keepScreenOn = false});
+  _FakeSettingsStore({
+    this.pttMode = false,
+    this.keepScreenOn = false,
+    this.throwOnClear = false,
+  });
 
   @override
   Future<bool> getPttModeEnabled() async => pttMode;
@@ -47,8 +61,10 @@ class _FakeSettingsStore implements SettingsStore {
 
   @override
   Future<void> clear() async {
+    if (throwOnClear) throw StateError('boom');
     pttMode = false;
     keepScreenOn = false;
+    cleared = true;
   }
 }
 
@@ -309,5 +325,283 @@ void main() {
       );
       expect(find.text('Open source licenses'), findsOneWidget);
     });
+
+    testWidgets(
+      'tapping Open source licenses opens the LicensePage',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(FrequencySettingsScreen(settingsStore: _FakeSettingsStore())),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.dragUntilVisible(
+          find.text('Open source licenses'),
+          find.byType(ListView),
+          const Offset(0, -200),
+        );
+        await tester.tap(find.text('Open source licenses'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(LicensePage), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping Privacy & Security FAQ link navigates to the SecurityFaqScreen',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(FrequencySettingsScreen(settingsStore: _FakeSettingsStore())),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.dragUntilVisible(
+          find.text('Privacy & Security FAQ'),
+          find.byType(ListView),
+          const Offset(0, -200),
+        );
+        await tester.tap(find.text('Privacy & Security FAQ'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(SecurityFaqScreen), findsOneWidget);
+      },
+    );
   });
+
+  group('FrequencySettingsScreen reset-all-data flow', () {
+    testWidgets(
+      'cancel in confirmation dialog leaves stores untouched',
+      (tester) async {
+        final identity = _FakeIdentityStore();
+        final recents = _FakeRecentStore();
+        final blocked = _FakeBlockedStore();
+        final settings = _FakeSettingsStore(pttMode: true);
+        final cubit = _FakeCubit();
+
+        await tester.pumpWidget(
+          _ProvidedSettings(
+            identity: identity,
+            recents: recents,
+            blocked: blocked,
+            settings: settings,
+            cubit: cubit,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.scrollUntilVisible(
+          find.text('Reset all data'),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(find.text('Reset all data'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Reset all data'));
+        await tester.pumpAndSettle();
+
+        // Cancel button — no tap on the destructive option.
+        await tester.tap(find.text('Cancel'));
+        await tester.pumpAndSettle();
+
+        expect(identity.cleared, isFalse);
+        expect(recents.cleared, isFalse);
+        expect(blocked.cleared, isFalse);
+        expect(settings.cleared, isFalse);
+        expect(cubit.resetCalls, 0);
+      },
+    );
+
+    testWidgets(
+      'confirm in dialog clears every store and resets the cubit',
+      (tester) async {
+        final identity = _FakeIdentityStore();
+        final recents = _FakeRecentStore();
+        final blocked = _FakeBlockedStore();
+        final settings = _FakeSettingsStore(pttMode: true);
+        final cubit = _FakeCubit();
+
+        await tester.pumpWidget(
+          _ProvidedSettings(
+            identity: identity,
+            recents: recents,
+            blocked: blocked,
+            settings: settings,
+            cubit: cubit,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.scrollUntilVisible(
+          find.text('Reset all data'),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(find.text('Reset all data'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Reset all data'));
+        await tester.pumpAndSettle();
+
+        // Find the confirm action — uses the destructive label "Reset".
+        // Two "Reset all data" instances exist (link + dialog title), plus
+        // a single "Reset" button — tap by exact text "Reset".
+        await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+        await tester.pumpAndSettle();
+
+        expect(identity.cleared, isTrue);
+        expect(recents.cleared, isTrue);
+        expect(blocked.cleared, isTrue);
+        expect(settings.cleared, isTrue);
+        expect(cubit.resetCalls, 1);
+      },
+    );
+
+    testWidgets(
+      'confirm tolerates store errors and still resets the cubit',
+      (tester) async {
+        final identity = _FakeIdentityStore(throwOnClear: true);
+        final recents = _FakeRecentStore(throwOnClear: true);
+        final blocked = _FakeBlockedStore(throwOnClear: true);
+        final settings = _FakeSettingsStore(throwOnClear: true);
+        final cubit = _FakeCubit();
+
+        await tester.pumpWidget(
+          _ProvidedSettings(
+            identity: identity,
+            recents: recents,
+            blocked: blocked,
+            settings: settings,
+            cubit: cubit,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.scrollUntilVisible(
+          find.text('Reset all data'),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.ensureVisible(find.text('Reset all data'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Reset all data'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+        await tester.pumpAndSettle();
+
+        // Tolerated errors → still reset.
+        expect(cubit.resetCalls, 1);
+      },
+    );
+  });
+}
+
+class _ProvidedSettings extends StatelessWidget {
+  final IdentityStore identity;
+  final RecentFrequenciesStore recents;
+  final BlockedPeersStore blocked;
+  final SettingsStore settings;
+  final FrequencySessionCubit cubit;
+
+  const _ProvidedSettings({
+    required this.identity,
+    required this.recents,
+    required this.blocked,
+    required this.settings,
+    required this.cubit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiRepositoryProvider(
+      providers: [
+        RepositoryProvider<IdentityStore>.value(value: identity),
+        RepositoryProvider<RecentFrequenciesStore>.value(value: recents),
+        RepositoryProvider<BlockedPeersStore>.value(value: blocked),
+      ],
+      child: BlocProvider<FrequencySessionCubit>.value(
+        value: cubit,
+        child: MaterialApp(
+          theme: AppTheme.light(),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: FrequencySettingsScreen(settingsStore: settings),
+        ),
+      ),
+    );
+  }
+}
+
+class _FakeIdentityStore implements IdentityStore {
+  bool cleared = false;
+  final bool throwOnClear;
+  _FakeIdentityStore({this.throwOnClear = false});
+
+  @override
+  Future<String?> getDisplayName() async => null;
+  @override
+  Future<void> setDisplayName(String value) async {}
+  @override
+  Future<String> getPeerId() async => 'fake-peer';
+  @override
+  Future<void> clear() async {
+    if (throwOnClear) throw StateError('boom');
+    cleared = true;
+  }
+}
+
+class _FakeRecentStore implements RecentFrequenciesStore {
+  bool cleared = false;
+  final bool throwOnClear;
+  _FakeRecentStore({this.throwOnClear = false});
+
+  @override
+  Future<List<String>> getRecent() async => const [];
+  @override
+  Future<List<RecentFrequency>> getRecentDetailed() async => const [];
+  @override
+  Future<void> record(String freq, {String? sessionUuid}) async {}
+  @override
+  Future<void> setNickname(String freq, String? nickname) async {}
+  @override
+  Future<void> setPinned(String freq, bool pinned) async {}
+  @override
+  Future<void> delete(String freq) async {}
+  @override
+  Future<void> clear() async {
+    if (throwOnClear) throw StateError('boom');
+    cleared = true;
+  }
+}
+
+class _FakeBlockedStore implements BlockedPeersStore {
+  bool cleared = false;
+  final bool throwOnClear;
+  _FakeBlockedStore({this.throwOnClear = false});
+
+  @override
+  Future<Set<String>> getAll() async => const {};
+  @override
+  Future<void> block(String peerId) async {}
+  @override
+  Future<void> unblock(String peerId) async {}
+  @override
+  Future<void> clear() async {
+    if (throwOnClear) throw StateError('boom');
+    cleared = true;
+  }
+}
+
+class _FakeCubit extends Cubit<FrequencySessionState>
+    implements FrequencySessionCubit {
+  int resetCalls = 0;
+  _FakeCubit() : super(const SessionBooting());
+
+  @override
+  void resetToOnboarding() {
+    resetCalls++;
+    emit(const SessionOnboarding());
+  }
+
+  // Unused surface for these tests — let unimplemented members throw if hit.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -378,6 +378,7 @@ void main() {
         final blocked = _FakeBlockedStore();
         final settings = _FakeSettingsStore(pttMode: true);
         final cubit = _FakeCubit();
+        addTearDown(cubit.close);
 
         await tester.pumpWidget(
           _ProvidedSettings(
@@ -420,6 +421,7 @@ void main() {
         final blocked = _FakeBlockedStore();
         final settings = _FakeSettingsStore(pttMode: true);
         final cubit = _FakeCubit();
+        addTearDown(cubit.close);
 
         await tester.pumpWidget(
           _ProvidedSettings(
@@ -464,6 +466,7 @@ void main() {
         final blocked = _FakeBlockedStore(throwOnClear: true);
         final settings = _FakeSettingsStore(throwOnClear: true);
         final cubit = _FakeCubit();
+        addTearDown(cubit.close);
 
         await tester.pumpWidget(
           _ProvidedSettings(

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/services/audio_service.dart';
@@ -502,6 +504,504 @@ void main() {
         final result = await audioService.stopVoiceTransport();
         expect(result, true);
         expect(log, [isMethodCall('stopVoiceTransport', arguments: null)]);
+      });
+    });
+
+    group('error path coverage (catch blocks return defaults)', () {
+      void installFailing() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('com.elodin.walkie_talkie/audio'),
+              (call) async => throw PlatformException(code: 'BOOM'),
+            );
+        addTearDown(
+          () => TestDefaultBinaryMessengerBinding
+              .instance
+              .defaultBinaryMessenger
+              .setMockMethodCallHandler(
+                const MethodChannel('com.elodin.walkie_talkie/audio'),
+                null,
+              ),
+        );
+      }
+
+      test('startService returns false', () async {
+        installFailing();
+        expect(await audioService.startService(), false);
+      });
+
+      test('stopService returns false', () async {
+        installFailing();
+        expect(await audioService.stopService(), false);
+      });
+
+      test('startScan returns false', () async {
+        installFailing();
+        expect(await audioService.startScan(), false);
+      });
+
+      test('stopScan swallows error', () async {
+        installFailing();
+        await audioService.stopScan(); // no throw
+      });
+
+      test('connectDevice returns false', () async {
+        installFailing();
+        expect(await audioService.connectDevice('AA:BB'), false);
+      });
+
+      test('disconnectDevice returns false', () async {
+        installFailing();
+        expect(await audioService.disconnectDevice('AA:BB'), false);
+      });
+
+      test('startVoice returns false', () async {
+        installFailing();
+        expect(await audioService.startVoice(), false);
+      });
+
+      test('stopVoice returns false', () async {
+        installFailing();
+        expect(await audioService.stopVoice(), false);
+      });
+
+      test('setMuted returns false', () async {
+        installFailing();
+        expect(await audioService.setMuted(true), false);
+      });
+
+      test('setAudioOutput returns false', () async {
+        installFailing();
+        expect(await audioService.setAudioOutput('speaker'), false);
+      });
+
+      test('getConnectedDevices returns empty list', () async {
+        installFailing();
+        expect(await audioService.getConnectedDevices(), isEmpty);
+      });
+
+      test('startAdvertising returns false', () async {
+        installFailing();
+        expect(
+          await audioService.startAdvertising(
+            sessionUuid: 'uuid',
+            displayName: 'Maya',
+          ),
+          false,
+        );
+      });
+
+      test('stopAdvertising returns false', () async {
+        installFailing();
+        expect(await audioService.stopAdvertising(), false);
+      });
+
+      test('startGattServer returns false', () async {
+        installFailing();
+        expect(await audioService.startGattServer(), false);
+      });
+
+      test('stopGattServer returns false', () async {
+        installFailing();
+        expect(await audioService.stopGattServer(), false);
+      });
+
+      test('writeNotification returns false', () async {
+        installFailing();
+        expect(
+          await audioService.writeNotification('AA:BB', [1, 2, 3]),
+          false,
+        );
+      });
+
+      test('connectVoiceClient returns false', () async {
+        installFailing();
+        expect(await audioService.connectVoiceClient('AA:BB', 0x81), false);
+      });
+
+      test('stopVoiceTransport returns false', () async {
+        installFailing();
+        expect(await audioService.stopVoiceTransport(), false);
+      });
+
+      test('connectToHost returns false', () async {
+        installFailing();
+        expect(await audioService.connectToHost('AA:BB'), false);
+      });
+
+      test('disconnectFromHost returns false', () async {
+        installFailing();
+        expect(await audioService.disconnectFromHost(), false);
+      });
+
+      test('writeRequest returns false', () async {
+        installFailing();
+        expect(await audioService.writeRequest(Uint8List.fromList([1])), false);
+      });
+
+      test('writeControlBytes swallows error', () async {
+        installFailing();
+        await audioService.writeControlBytes(Uint8List.fromList([1])); // no throw
+      });
+
+      test('getNegotiatedMtu returns null', () async {
+        installFailing();
+        expect(await audioService.getNegotiatedMtu('AA:BB'), isNull);
+      });
+
+      test('setPeerBitrate returns null', () async {
+        installFailing();
+        expect(await audioService.setPeerBitrate('AA:BB', 24000), isNull);
+      });
+
+      test('getLinkTelemetry returns null', () async {
+        installFailing();
+        expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
+      });
+    });
+
+    group('happy-path coverage for missing methods', () {
+      Future<dynamic> Function(MethodCall)? handler;
+
+      setUp(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('com.elodin.walkie_talkie/audio'),
+              (call) async {
+                log.add(call);
+                return handler == null ? null : await handler!(call);
+              },
+            );
+      });
+
+      tearDown(() {
+        handler = null;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('com.elodin.walkie_talkie/audio'),
+              null,
+            );
+      });
+
+      test('setAudioOutput forwards arg', () async {
+        handler = (_) async => true;
+        log.clear();
+        expect(await audioService.setAudioOutput('bluetooth'), true);
+        expect(log, [
+          isMethodCall('setAudioOutput', arguments: {'output': 'bluetooth'}),
+        ]);
+      });
+
+      test('startAdvertising forwards args', () async {
+        handler = (_) async => true;
+        log.clear();
+        expect(
+          await audioService.startAdvertising(
+            sessionUuid: 'abc-123',
+            displayName: 'Maya',
+          ),
+          true,
+        );
+        expect(log, [
+          isMethodCall(
+            'startAdvertising',
+            arguments: {'sessionUuid': 'abc-123', 'displayName': 'Maya'},
+          ),
+        ]);
+      });
+
+      test('stopAdvertising calls correct method', () async {
+        handler = (_) async => true;
+        log.clear();
+        expect(await audioService.stopAdvertising(), true);
+        expect(log, [isMethodCall('stopAdvertising', arguments: null)]);
+      });
+
+      test('startGattServer / stopGattServer', () async {
+        handler = (_) async => true;
+        log.clear();
+        expect(await audioService.startGattServer(), true);
+        expect(await audioService.stopGattServer(), true);
+        expect(log.map((c) => c.method), ['startGattServer', 'stopGattServer']);
+      });
+
+      test('writeNotification forwards args', () async {
+        handler = (_) async => true;
+        log.clear();
+        expect(
+          await audioService.writeNotification('AA:BB:CC', [9, 8, 7]),
+          true,
+        );
+        expect(log, [
+          isMethodCall(
+            'writeNotification',
+            arguments: {
+              'deviceAddress': 'AA:BB:CC',
+              'bytes': [9, 8, 7],
+            },
+          ),
+        ]);
+      });
+
+      test('connectToHost / disconnectFromHost / writeRequest', () async {
+        handler = (_) async => true;
+        log.clear();
+        expect(await audioService.connectToHost('AA:BB'), true);
+        expect(await audioService.disconnectFromHost(), true);
+        expect(
+          await audioService.writeRequest(Uint8List.fromList([1, 2])),
+          true,
+        );
+        expect(log.map((c) => c.method), [
+          'connectToHost',
+          'disconnectFromHost',
+          'writeRequest',
+        ]);
+      });
+
+      test('writeControlBytes forwards bytes', () async {
+        handler = (_) async => null;
+        log.clear();
+        await audioService.writeControlBytes(Uint8List.fromList([1, 2, 3]));
+        expect(log, hasLength(1));
+        expect(log.first.method, 'writeControlBytes');
+        expect(log.first.arguments['bytes'], isA<Uint8List>());
+      });
+
+      test('getNegotiatedMtu returns native int', () async {
+        handler = (_) async => 247;
+        log.clear();
+        expect(await audioService.getNegotiatedMtu('AA:BB'), 247);
+        expect(log, [
+          isMethodCall(
+            'getNegotiatedMtu',
+            arguments: {'endpointId': 'AA:BB'},
+          ),
+        ]);
+      });
+
+      test('setPeerBitrate returns clamped value', () async {
+        handler = (_) async => 16000;
+        log.clear();
+        expect(await audioService.setPeerBitrate('AA:BB', 24000), 16000);
+        expect(log, [
+          isMethodCall(
+            'setPeerBitrate',
+            arguments: {'macAddress': 'AA:BB', 'bps': 24000},
+          ),
+        ]);
+      });
+
+      test('setPeerBitrate returns null on negative result', () async {
+        handler = (_) async => -1;
+        expect(await audioService.setPeerBitrate('AA:BB', 24000), isNull);
+      });
+
+      test('setPeerBitrate returns null when native returns null', () async {
+        handler = (_) async => null;
+        expect(await audioService.setPeerBitrate('AA:BB', 24000), isNull);
+      });
+
+      test('getLinkTelemetry returns parsed snapshot', () async {
+        handler = (_) async => [10, 5, 8, 4, 16000];
+        final snap = await audioService.getLinkTelemetry('AA:BB');
+        expect(snap, isNotNull);
+        expect(snap!.underrunCount, 10);
+        expect(snap.lateFrameCount, 5);
+        expect(snap.targetDepthFrames, 8);
+        expect(snap.currentDepthFrames, 4);
+        expect(snap.currentBitrateBps, 16000);
+      });
+
+      test('getLinkTelemetry returns null on wrong shape (length)', () async {
+        handler = (_) async => [1, 2, 3]; // only 3 elements
+        expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
+      });
+
+      test('getLinkTelemetry returns null on wrong type element', () async {
+        handler = (_) async => [1, 2, 3, 4, '16000']; // last is string
+        expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
+      });
+
+      test('getLinkTelemetry returns null when native returns non-list', () async {
+        handler = (_) async => 'nope';
+        expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
+      });
+    });
+
+    group('LinkTelemetrySnapshot equality + hashCode', () {
+      const a = LinkTelemetrySnapshot(
+        underrunCount: 1,
+        lateFrameCount: 2,
+        targetDepthFrames: 3,
+        currentDepthFrames: 4,
+        currentBitrateBps: 16000,
+      );
+      const b = LinkTelemetrySnapshot(
+        underrunCount: 1,
+        lateFrameCount: 2,
+        targetDepthFrames: 3,
+        currentDepthFrames: 4,
+        currentBitrateBps: 16000,
+      );
+      const c = LinkTelemetrySnapshot(
+        underrunCount: 99,
+        lateFrameCount: 2,
+        targetDepthFrames: 3,
+        currentDepthFrames: 4,
+        currentBitrateBps: 16000,
+      );
+
+      test('identical instances are equal', () {
+        expect(a, equals(a));
+      });
+
+      test('value-equal instances are equal', () {
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('different fields are not equal', () {
+        expect(a == c, isFalse);
+      });
+
+      test('not equal to a different type', () {
+        expect(a == Object(), isFalse);
+      });
+    });
+
+    group('audioEvents stream', () {
+      test('parses native events into Map<String,dynamic>', () async {
+        const eventChannelName = 'com.elodin.walkie_talkie/audio_events';
+        final codec = const StandardMethodCodec();
+
+        final received = <Map<String, dynamic>>[];
+        final sub = audioService.audioEvents.listen(received.add);
+        addTearDown(sub.cancel);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              eventChannelName,
+              codec.encodeSuccessEnvelope({'type': 'foo', 'value': 7}),
+              (_) {},
+            );
+        await Future<void>.microtask(() {});
+
+        expect(received, hasLength(1));
+        expect(received.first['type'], 'foo');
+        expect(received.first['value'], 7);
+      });
+
+      test('caches a single broadcast stream across reads', () {
+        final s1 = audioService.audioEvents;
+        final s2 = audioService.audioEvents;
+        expect(identical(s1, s2), isTrue);
+      });
+    });
+
+    group('controlBytes stream', () {
+      test('emits typed records for Uint8List events', () async {
+        const eventChannelName =
+            'com.elodin.walkie_talkie/control_bytes';
+        final codec = const StandardMethodCodec();
+
+        final received = <({String endpointId, Uint8List bytes})>[];
+        final sub = audioService.controlBytes.listen(received.add);
+        addTearDown(sub.cancel);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              eventChannelName,
+              codec.encodeSuccessEnvelope({
+                'endpointId': 'AA:BB',
+                'bytes': Uint8List.fromList([1, 2, 3]),
+              }),
+              (_) {},
+            );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(received, hasLength(1));
+        expect(received[0].endpointId, 'AA:BB');
+        expect(received[0].bytes, Uint8List.fromList([1, 2, 3]));
+      });
+
+      test('emits typed records for List<int> bytes (codec branch)', () async {
+        const eventChannelName =
+            'com.elodin.walkie_talkie/control_bytes';
+        final codec = const StandardMethodCodec();
+
+        final received = <({String endpointId, Uint8List bytes})>[];
+        final sub = audioService.controlBytes.listen(received.add);
+        addTearDown(sub.cancel);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              eventChannelName,
+              codec.encodeSuccessEnvelope({
+                'endpointId': 'CC:DD',
+                'bytes': <int>[9, 8, 7],
+              }),
+              (_) {},
+            );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(received, hasLength(1));
+        expect(received[0].endpointId, 'CC:DD');
+        expect(received[0].bytes, Uint8List.fromList([9, 8, 7]));
+      });
+
+      test('drops malformed events (missing fields)', () async {
+        const eventChannelName =
+            'com.elodin.walkie_talkie/control_bytes';
+        final codec = const StandardMethodCodec();
+
+        final received = <({String endpointId, Uint8List bytes})>[];
+        final sub = audioService.controlBytes.listen(received.add);
+        addTearDown(sub.cancel);
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              eventChannelName,
+              codec.encodeSuccessEnvelope({'endpointId': 'AA'}), // no bytes
+              (_) {},
+            );
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              eventChannelName,
+              codec.encodeSuccessEnvelope({'bytes': [1]}), // no endpointId
+              (_) {},
+            );
+        await Future<void>.microtask(() {});
+
+        expect(received, isEmpty);
+      });
+
+      test('caches the broadcast stream across reads', () {
+        final s1 = audioService.controlBytes;
+        final s2 = audioService.controlBytes;
+        // The exposed stream is the where/map wrapper, so identity does not
+        // hold; assert via the underlying caching by listening twice and
+        // letting a single backing source feed both.
+        final eventChannelName = 'com.elodin.walkie_talkie/control_bytes';
+        final codec = const StandardMethodCodec();
+        final a = <({String endpointId, Uint8List bytes})>[];
+        final b = <({String endpointId, Uint8List bytes})>[];
+        final subA = s1.listen(a.add);
+        final subB = s2.listen(b.add);
+        addTearDown(() async {
+          await subA.cancel();
+          await subB.cancel();
+        });
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage(
+              eventChannelName,
+              codec.encodeSuccessEnvelope({
+                'endpointId': 'X',
+                'bytes': Uint8List.fromList([42]),
+              }),
+              (_) {},
+            );
       });
     });
   });

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/services/audio_service.dart';

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -976,12 +976,13 @@ void main() {
         expect(received, isEmpty);
       });
 
-      test('caches the broadcast stream across reads', () {
+      test('caches the broadcast source across reads', () async {
+        // The exposed stream is the where/map wrapper, so identity does not
+        // hold; instead, verify a single emission fan-outs to two listeners
+        // attached to two separate `controlBytes` reads — this is only
+        // possible if the underlying broadcast source is cached.
         final s1 = audioService.controlBytes;
         final s2 = audioService.controlBytes;
-        // The exposed stream is the where/map wrapper, so identity does not
-        // hold; assert via the underlying caching by listening twice and
-        // letting a single backing source feed both.
         final eventChannelName = 'com.elodin.walkie_talkie/control_bytes';
         final codec = const StandardMethodCodec();
         final a = <({String endpointId, Uint8List bytes})>[];
@@ -1002,6 +1003,14 @@ void main() {
               }),
               (_) {},
             );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(a, hasLength(1));
+        expect(b, hasLength(1));
+        expect(a.first.endpointId, 'X');
+        expect(a.first.bytes, Uint8List.fromList([42]));
+        expect(b.first.endpointId, 'X');
+        expect(b.first.bytes, Uint8List.fromList([42]));
       });
     });
   });

--- a/test/services/onboarding_permission_gateway_test.dart
+++ b/test/services/onboarding_permission_gateway_test.dart
@@ -1,8 +1,113 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:permission_handler/permission_handler.dart' as ph;
 import 'package:walkie_talkie/services/onboarding_permission_gateway.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DefaultOnboardingPermissionGateway platform-channel paths', () {
+    const channel = MethodChannel('flutter.baseflow.com/permissions/methods');
+    final List<MethodCall> log = <MethodCall>[];
+
+    // Mirror the integer codes used by permission_handler's PermissionStatus enum.
+    // 0 = denied, 1 = granted, 2 = restricted, 3 = limited,
+    // 4 = permanentlyDenied, 5 = provisional.
+    void install({required Map<int, int> permsToStatus, bool openSettingsResult = true}) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            log.add(call);
+            switch (call.method) {
+              case 'requestPermissions':
+                // call.arguments is List<int> of perm indices. Echo back map.
+                final List requested = call.arguments as List;
+                return <int, int>{
+                  for (final p in requested.cast<int>())
+                    p: permsToStatus[p] ?? 0,
+                };
+              case 'checkPermissionStatus':
+                final perm = call.arguments as int;
+                return permsToStatus[perm] ?? 0;
+              case 'openAppSettings':
+                return openSettingsResult;
+            }
+            return null;
+          });
+    }
+
+    setUp(() {
+      log.clear();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('requestBluetooth requests all three perms and reduces to granted', () async {
+      install(permsToStatus: {
+        ph.Permission.bluetoothScan.value: 1,
+        ph.Permission.bluetoothConnect.value: 1,
+        ph.Permission.bluetoothAdvertise.value: 1,
+      });
+      final result =
+          await const DefaultOnboardingPermissionGateway().requestBluetooth();
+      expect(result, OnboardingPermissionStatus.granted);
+      // The package may issue a checkPermissionStatus before the request, so
+      // assert that requestPermissions was invoked at least once with all
+      // three Bluetooth perms.
+      final reqCall = log.firstWhere((c) => c.method == 'requestPermissions');
+      final ids = (reqCall.arguments as List).cast<int>().toSet();
+      expect(ids, {
+        ph.Permission.bluetoothScan.value,
+        ph.Permission.bluetoothConnect.value,
+        ph.Permission.bluetoothAdvertise.value,
+      });
+    });
+
+    test('requestBluetooth reduces to denied when one is denied', () async {
+      install(permsToStatus: {
+        ph.Permission.bluetoothScan.value: 1,
+        ph.Permission.bluetoothConnect.value: 0, // denied
+        ph.Permission.bluetoothAdvertise.value: 1,
+      });
+      final result =
+          await const DefaultOnboardingPermissionGateway().requestBluetooth();
+      expect(result, OnboardingPermissionStatus.denied);
+    });
+
+    test('requestBluetooth reduces to permanentlyDenied', () async {
+      install(permsToStatus: {
+        ph.Permission.bluetoothScan.value: 4, // permanentlyDenied
+        ph.Permission.bluetoothConnect.value: 1,
+        ph.Permission.bluetoothAdvertise.value: 1,
+      });
+      final result =
+          await const DefaultOnboardingPermissionGateway().requestBluetooth();
+      expect(result, OnboardingPermissionStatus.permanentlyDenied);
+    });
+
+    test('requestMicrophone returns granted', () async {
+      install(permsToStatus: {ph.Permission.microphone.value: 1});
+      final result =
+          await const DefaultOnboardingPermissionGateway().requestMicrophone();
+      expect(result, OnboardingPermissionStatus.granted);
+    });
+
+    test('requestMicrophone returns denied', () async {
+      install(permsToStatus: {ph.Permission.microphone.value: 0});
+      final result =
+          await const DefaultOnboardingPermissionGateway().requestMicrophone();
+      expect(result, OnboardingPermissionStatus.denied);
+    });
+
+    test('openAppSettings invokes the platform method', () async {
+      install(permsToStatus: const {});
+      await const DefaultOnboardingPermissionGateway().openAppSettings();
+      expect(log.any((c) => c.method == 'openAppSettings'), isTrue);
+    });
+  });
+
   group('OnboardingPermissionGateway.reduce', () {
     /// Direct test of the reduce static method.
     /// The method is marked @visibleForTesting to allow unit testing.

--- a/test/services/sentry_config_test.dart
+++ b/test/services/sentry_config_test.dart
@@ -2,9 +2,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/services/sentry_config.dart';
 
 void main() {
-  test('kSentryConfigured is a compile-time bool', () {
+  test('kSentryConfigured tracks the SENTRY_DSN dart-define', () {
+    // Derive the expected value from the same env var rather than hard-
+    // coding `false` — the production config flips on whenever the test
+    // runner is launched with `--dart-define=SENTRY_DSN=...`, and a
+    // hard-coded expectation would fail in those configurations.
+    const dsn = String.fromEnvironment('SENTRY_DSN', defaultValue: '');
+    expect(kSentryConfigured, dsn.isNotEmpty);
     expect(kSentryConfigured, isA<bool>());
-    // In tests there's no SENTRY_DSN dart-define, so it must be false.
-    expect(kSentryConfigured, isFalse);
   });
 }

--- a/test/services/sentry_config_test.dart
+++ b/test/services/sentry_config_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/sentry_config.dart';
+
+void main() {
+  test('kSentryConfigured is a compile-time bool', () {
+    expect(kSentryConfigured, isA<bool>());
+    // In tests there's no SENTRY_DSN dart-define, so it must be false.
+    expect(kSentryConfigured, isFalse);
+  });
+}

--- a/test/theme/app_theme_test.dart
+++ b/test/theme/app_theme_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/theme/app_theme.dart';
+
+void main() {
+  group('AppTheme', () {
+    test('light + dark themes attach FrequencyTheme extensions', () {
+      final light = AppTheme.light();
+      final dark = AppTheme.dark();
+      expect(light.extension<FrequencyTheme>(), isNotNull);
+      expect(dark.extension<FrequencyTheme>(), isNotNull);
+    });
+
+    testWidgets('FrequencyTheme.of pulls the extension from context', (
+      tester,
+    ) async {
+      late FrequencyTheme captured;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(),
+          home: Builder(
+            builder: (ctx) {
+              captured = FrequencyTheme.of(ctx);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      expect(captured, isNotNull);
+    });
+  });
+
+  group('FrequencyTheme lerp + copyWith', () {
+    test('copyWith returns a new instance with the same colors', () {
+      final orig = AppTheme.light().extension<FrequencyTheme>()!;
+      final copy = orig.copyWith();
+      expect(identical(orig, copy), isFalse);
+      expect(copy.colors, orig.colors);
+    });
+
+    test('copyWith with override returns the override', () {
+      final orig = AppTheme.light().extension<FrequencyTheme>()!;
+      final dark = AppTheme.dark().extension<FrequencyTheme>()!;
+      final overridden = orig.copyWith(colors: dark.colors);
+      expect(overridden.colors, dark.colors);
+    });
+
+    test('lerp returns this when other is not a FrequencyTheme', () {
+      final orig = AppTheme.light().extension<FrequencyTheme>()!;
+      expect(identical(orig.lerp(null, 0.5), orig), isTrue);
+    });
+
+    test('lerp with t < 0.5 returns this', () {
+      final orig = AppTheme.light().extension<FrequencyTheme>()!;
+      final dark = AppTheme.dark().extension<FrequencyTheme>()!;
+      expect(identical(orig.lerp(dark, 0.0), orig), isTrue);
+      expect(identical(orig.lerp(dark, 0.49), orig), isTrue);
+    });
+
+    test('lerp with t >= 0.5 returns other', () {
+      final orig = AppTheme.light().extension<FrequencyTheme>()!;
+      final dark = AppTheme.dark().extension<FrequencyTheme>()!;
+      expect(identical(orig.lerp(dark, 0.5), dark), isTrue);
+      expect(identical(orig.lerp(dark, 1.0), dark), isTrue);
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/main.dart';
@@ -210,6 +213,23 @@ class _FakePermissionWatcher implements PermissionWatcher {
   Future<void> dispose() async {}
 }
 
+class _DenyingPermissionWatcher implements PermissionWatcher {
+  final List<AppPermission> missing;
+
+  _DenyingPermissionWatcher(this.missing);
+
+  @override
+  Stream<List<AppPermission>> watch() async* {
+    yield missing;
+  }
+
+  @override
+  Future<List<AppPermission>> checkNow() async => missing;
+
+  @override
+  Future<void> dispose() async {}
+}
+
 /// In-memory [SettingsStore] for widget tests — avoids hitting the sqflite
 /// platform channel or requiring [databaseFactoryFfi] initialisation.
 class _FakeSettingsStore implements SettingsStore {
@@ -311,6 +331,207 @@ void main() {
       // UI elements that may also display the frequency.
       expect(find.textContaining('Host on 100.1'), findsOneWidget);
       expect(find.textContaining('Host on 92.4'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'didUpdateWidget releases owned watcher when caller starts supplying one',
+    (tester) async {
+      // First pump: no permissionWatcher → app owns a default one.
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+          discoveryService: _FakeDiscoveryService(),
+          settingsStore: _FakeSettingsStore(),
+        ),
+      );
+      await tester.pump();
+
+      // Re-pump with a supplied watcher — exercises wasOwning && !stillOwning.
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+          discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: _FakePermissionWatcher(),
+          settingsStore: _FakeSettingsStore(),
+        ),
+      );
+      await tester.pump();
+
+      // No assertion on internals — coverage is the assertion. The widget
+      // must still render without throwing.
+      expect(find.byType(WalkieTalkieApp), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'didUpdateWidget mints a fresh owned watcher when caller drops the supplied one',
+    (tester) async {
+      // First pump: caller supplies a watcher.
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+          discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: _FakePermissionWatcher(),
+          settingsStore: _FakeSettingsStore(),
+        ),
+      );
+      await tester.pump();
+
+      // Re-pump with no watcher — exercises !wasOwning && stillOwning.
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+          discoveryService: _FakeDiscoveryService(),
+          settingsStore: _FakeSettingsStore(),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(WalkieTalkieApp), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'permission watcher reporting missing perms routes to permission denied screen',
+    (tester) async {
+      final watcher = _DenyingPermissionWatcher(
+        const [AppPermission.bluetooth],
+      );
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+          discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: watcher,
+          settingsStore: _FakeSettingsStore(),
+        ),
+      );
+      // Bootstrap, then watcher.checkNow returns missing perms; the
+      // post-bootstrap _onPermissionsChanged routes us to denied.
+      await tester.pumpAndSettle(const Duration(milliseconds: 500));
+      // The denied screen renders the localised "Permissions revoked"
+      // headline.
+      expect(find.text('Permissions revoked'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'completing onboarding hands the name to the cubit and shows Discovery',
+    (tester) async {
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+          discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: _FakePermissionWatcher(),
+          settingsStore: _FakeSettingsStore(),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      // Onboarding → tap Get started, then pick / type a name and confirm.
+      // The screen has multiple steps; we drive only what's needed to exit
+      // onboarding. The exact widgets vary, so probe by widget types and
+      // use enterText on the first TextField, then tap a confirm button.
+      // Skip if the layout has changed — the cubit has its own coverage.
+      final getStarted = find.text('Get started');
+      if (getStarted.evaluate().isEmpty) return;
+      await tester.tap(getStarted);
+      await tester.pumpAndSettle(const Duration(milliseconds: 600));
+
+      final nameField = find.byType(TextField);
+      if (nameField.evaluate().isNotEmpty) {
+        await tester.enterText(nameField.first, 'Maya');
+        await tester.pumpAndSettle(const Duration(milliseconds: 300));
+        // Re-tap any visible submit button.
+        for (final label in ['Done', "I'm in", 'Confirm', 'Continue', 'Get started']) {
+          final btn = find.text(label);
+          if (btn.evaluate().isNotEmpty) {
+            await tester.tap(btn.first);
+            break;
+          }
+        }
+        // A few frames for the cubit to settle.
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+      }
+    },
+  );
+
+  testWidgets(
+    'tapping a recent frequency triggers joinRoom routing into SessionRoom',
+    (tester) async {
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(
+            initial: const ['100.1'],
+          ),
+          discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: _FakePermissionWatcher(),
+          settingsStore: _FakeSettingsStore(),
+        ),
+      );
+      // Bootstrap → Discovery.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // Find a recent row and tap. The row text "Host on 100.1" identifies it.
+      final freqRow = find.textContaining('Host on 100.1');
+      expect(freqRow, findsOneWidget);
+      await tester.tap(freqRow);
+      // Don't pumpAndSettle — the room screen has perpetual animations.
+      // A few frames are enough for the SessionRoom emission to commit.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // Either joinRoom fired (state moves) or stays — coverage of the
+      // onPick closure body is the value here. The tap reaches the
+      // callback, exercising lines 335–353 in main.dart.
+    },
+  );
+
+  testWidgets(
+    'app lifecycle resumed re-reads PTT mode setting',
+    (tester) async {
+      final settings = _FakeSettingsStore();
+      await tester.pumpWidget(
+        WalkieTalkieApp(
+          identityStore: _FakeIdentityStore(initial: 'Maya'),
+          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+          discoveryService: _FakeDiscoveryService(),
+          permissionWatcher: _FakePermissionWatcher(),
+          settingsStore: settings,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      // Toggle the underlying setting then dispatch resumed lifecycle —
+      // the FrequencyApp's didChangeAppLifecycleState handler should
+      // re-read the value from the store.
+      await settings.setPttModeEnabled(true);
+      // Send AppLifecycleState.resumed via the platform message channel.
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/lifecycle',
+        const StringCodec().encodeMessage(
+          AppLifecycleState.resumed.toString(),
+        ),
+        (_) {},
+      );
+      await tester.pump();
+
+      // No public surface to assert on — coverage of the lifecycle handler
+      // is the value here.
+      expect(find.byType(WalkieTalkieApp), findsOneWidget);
     },
   );
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -390,8 +390,21 @@ void main() {
   testWidgets(
     'didUpdateWidget mints a fresh owned watcher when caller drops the supplied one',
     (tester) async {
-      // First pump: caller supplies a watcher.
+      // Snapshot the test-fake constructor counter so we can verify the
+      // supplied watcher counts as a creation. The owned default watcher
+      // (DefaultPermissionWatcher) is a production class and isn't tracked
+      // here; the indirect signal is that the widget keeps building
+      // without throwing in build(), which would happen if the
+      // null-coalesce on `widget.permissionWatcher ?? _ownedWatcher!`
+      // tripped on a null owned watcher.
+      final beforeSupplied = _FakePermissionWatcher.createdInstances;
       final supplied = _FakePermissionWatcher();
+      expect(
+        _FakePermissionWatcher.createdInstances,
+        beforeSupplied + 1,
+        reason: 'supplied watcher should bump the constructor counter',
+      );
+
       await tester.pumpWidget(
         WalkieTalkieApp(
           identityStore: _FakeIdentityStore(initial: 'Maya'),
@@ -420,6 +433,13 @@ void main() {
       await tester.pump();
 
       expect(supplied.disposed, isFalse);
+      // No new fake watcher should have been minted — the replacement is
+      // a real DefaultPermissionWatcher, not our test fake.
+      expect(
+        _FakePermissionWatcher.createdInstances,
+        beforeSupplied + 1,
+        reason: 'owned-watcher mint must not pull in a test fake',
+      );
       // The widget must remain mounted — if the new owned-watcher branch
       // failed to mint a default, the build() null-coalesce would throw.
       expect(find.byType(WalkieTalkieApp), findsOneWidget);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/main.dart';
@@ -203,6 +202,13 @@ class _FakeDiscoveryService implements DiscoveryService {
 /// at the end of the test. The fake's stream is empty, so the cubit's
 /// permission listener never fires and no transitions race the test.
 class _FakePermissionWatcher implements PermissionWatcher {
+  static int createdInstances = 0;
+  bool disposed = false;
+
+  _FakePermissionWatcher() {
+    createdInstances++;
+  }
+
   @override
   Stream<List<AppPermission>> watch() => const Stream.empty();
 
@@ -210,7 +216,9 @@ class _FakePermissionWatcher implements PermissionWatcher {
   Future<List<AppPermission>> checkNow() async => const [];
 
   @override
-  Future<void> dispose() async {}
+  Future<void> dispose() async {
+    disposed = true;
+  }
 }
 
 class _DenyingPermissionWatcher implements PermissionWatcher {
@@ -236,6 +244,7 @@ class _FakeSettingsStore implements SettingsStore {
   bool _crashReporting = false;
   bool _pttMode = false;
   bool _keepScreenOn = false;
+  int pttReadCalls = 0;
 
   @override
   Future<bool> getCrashReportingEnabled() async => _crashReporting;
@@ -243,7 +252,11 @@ class _FakeSettingsStore implements SettingsStore {
   Future<void> setCrashReportingEnabled(bool v) async => _crashReporting = v;
 
   @override
-  Future<bool> getPttModeEnabled() async => _pttMode;
+  Future<bool> getPttModeEnabled() async {
+    pttReadCalls++;
+    return _pttMode;
+  }
+
   @override
   Future<void> setPttModeEnabled(bool v) async => _pttMode = v;
 
@@ -335,9 +348,10 @@ void main() {
   );
 
   testWidgets(
-    'didUpdateWidget releases owned watcher when caller starts supplying one',
+    'didUpdateWidget keeps caller-supplied watcher alive across pumps',
     (tester) async {
-      // First pump: no permissionWatcher → app owns a default one.
+      // First pump: no permissionWatcher → app owns a default one (a real
+      // DefaultPermissionWatcher, not directly observable from a unit test).
       await tester.pumpWidget(
         WalkieTalkieApp(
           identityStore: _FakeIdentityStore(initial: 'Maya'),
@@ -349,19 +363,26 @@ void main() {
       await tester.pump();
 
       // Re-pump with a supplied watcher — exercises wasOwning && !stillOwning.
+      // We can't directly assert that the previously-owned default watcher
+      // was disposed (it's a production singleton), but we *can* assert
+      // that the now-supplied watcher is NOT disposed by us (caller owns it).
+      final supplied = _FakePermissionWatcher();
+      expect(supplied.disposed, isFalse);
       await tester.pumpWidget(
         WalkieTalkieApp(
           identityStore: _FakeIdentityStore(initial: 'Maya'),
           recentFrequenciesStore: _FakeRecentFrequenciesStore(),
           discoveryService: _FakeDiscoveryService(),
-          permissionWatcher: _FakePermissionWatcher(),
+          permissionWatcher: supplied,
           settingsStore: _FakeSettingsStore(),
         ),
       );
       await tester.pump();
 
-      // No assertion on internals — coverage is the assertion. The widget
-      // must still render without throwing.
+      // The widget must not have disposed the caller-supplied watcher,
+      // either as part of didUpdateWidget reconciliation or as the cubit
+      // teardown for the discarded prior cubit instance.
+      expect(supplied.disposed, isFalse);
       expect(find.byType(WalkieTalkieApp), findsOneWidget);
     },
   );
@@ -370,18 +391,24 @@ void main() {
     'didUpdateWidget mints a fresh owned watcher when caller drops the supplied one',
     (tester) async {
       // First pump: caller supplies a watcher.
+      final supplied = _FakePermissionWatcher();
       await tester.pumpWidget(
         WalkieTalkieApp(
           identityStore: _FakeIdentityStore(initial: 'Maya'),
           recentFrequenciesStore: _FakeRecentFrequenciesStore(),
           discoveryService: _FakeDiscoveryService(),
-          permissionWatcher: _FakePermissionWatcher(),
+          permissionWatcher: supplied,
           settingsStore: _FakeSettingsStore(),
         ),
       );
       await tester.pump();
+      expect(supplied.disposed, isFalse);
 
       // Re-pump with no watcher — exercises !wasOwning && stillOwning.
+      // The caller is now no longer supplying their watcher; it's the
+      // *caller's* responsibility to dispose it (matches the `dispose()`
+      // doc on _WalkieTalkieAppState). We assert the widget didn't
+      // erroneously dispose the previously-supplied watcher.
       await tester.pumpWidget(
         WalkieTalkieApp(
           identityStore: _FakeIdentityStore(initial: 'Maya'),
@@ -392,6 +419,9 @@ void main() {
       );
       await tester.pump();
 
+      expect(supplied.disposed, isFalse);
+      // The widget must remain mounted — if the new owned-watcher branch
+      // failed to mint a default, the build() null-coalesce would throw.
       expect(find.byType(WalkieTalkieApp), findsOneWidget);
     },
   );
@@ -423,9 +453,32 @@ void main() {
   testWidgets(
     'completing onboarding hands the name to the cubit and shows Discovery',
     (tester) async {
+      // The onboarding flow's step 2 hits permission_handler's platform
+      // channel via `DefaultOnboardingPermissionGateway`. Stub the channel
+      // so all three Bluetooth perms + microphone resolve to "granted"
+      // without involving the OS.
+      const permsChannel =
+          MethodChannel('flutter.baseflow.com/permissions/methods');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(permsChannel, (call) async {
+            switch (call.method) {
+              case 'requestPermissions':
+                final ids = (call.arguments as List).cast<int>();
+                return <int, int>{for (final id in ids) id: 1}; // granted
+              case 'checkPermissionStatus':
+                return 1; // granted
+            }
+            return null;
+          });
+      addTearDown(() => TestDefaultBinaryMessengerBinding
+          .instance
+          .defaultBinaryMessenger
+          .setMockMethodCallHandler(permsChannel, null));
+
+      final identity = _FakeIdentityStore();
       await tester.pumpWidget(
         WalkieTalkieApp(
-          identityStore: _FakeIdentityStore(),
+          identityStore: identity,
           recentFrequenciesStore: _FakeRecentFrequenciesStore(),
           discoveryService: _FakeDiscoveryService(),
           permissionWatcher: _FakePermissionWatcher(),
@@ -434,33 +487,67 @@ void main() {
       );
       await tester.pump();
       await tester.pump();
-      // Onboarding → tap Get started, then pick / type a name and confirm.
-      // The screen has multiple steps; we drive only what's needed to exit
-      // onboarding. The exact widgets vary, so probe by widget types and
-      // use enterText on the first TextField, then tap a confirm button.
-      // Skip if the layout has changed — the cubit has its own coverage.
-      final getStarted = find.text('Get started');
-      if (getStarted.evaluate().isEmpty) return;
-      await tester.tap(getStarted);
+
+      // Step 0 — Welcome. Tap "Get started".
+      expect(find.text('Get started'), findsOneWidget);
+      await tester.tap(find.text('Get started'));
       await tester.pumpAndSettle(const Duration(milliseconds: 600));
 
-      final nameField = find.byType(TextField);
-      if (nameField.evaluate().isNotEmpty) {
-        await tester.enterText(nameField.first, 'Maya');
-        await tester.pumpAndSettle(const Duration(milliseconds: 300));
-        // Re-tap any visible submit button.
-        for (final label in ['Done', "I'm in", 'Confirm', 'Continue', 'Get started']) {
+      // Step 1 — Explainer (3 pages). Tap Next twice, then "Get started".
+      for (var i = 0; i < 5; i++) {
+        if (find.text('Continue').evaluate().isNotEmpty ||
+            find.byType(TextField).evaluate().isNotEmpty) {
+          break;
+        }
+        for (final label in ['Next', 'Get started']) {
           final btn = find.text(label);
           if (btn.evaluate().isNotEmpty) {
             await tester.tap(btn.first);
+            await tester.pumpAndSettle(const Duration(milliseconds: 400));
             break;
           }
         }
-        // A few frames for the cubit to settle.
-        await tester.pump();
-        await tester.pump();
-        await tester.pump();
       }
+
+      // Step 2 — Permissions. Tap the per-permission "Allow" buttons until
+      // both perms are granted, then Continue.
+      for (var i = 0; i < 6; i++) {
+        if (find.byType(TextField).evaluate().isNotEmpty) break;
+        final allow = find.text('Allow');
+        if (allow.evaluate().isNotEmpty) {
+          await tester.tap(allow.first);
+          await tester.pumpAndSettle(const Duration(milliseconds: 400));
+          continue;
+        }
+        final cont = find.text('Continue');
+        if (cont.evaluate().isNotEmpty) {
+          await tester.tap(cont.first);
+          await tester.pumpAndSettle(const Duration(milliseconds: 400));
+          continue;
+        }
+        break;
+      }
+
+      // Step 3 — Name picker. Enter the name and tap the continue button.
+      final nameField = find.byType(TextField);
+      if (nameField.evaluate().isEmpty) {
+        fail('Onboarding name TextField not found — layout changed');
+      }
+      await tester.enterText(nameField.first, 'Maya');
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      for (final label in ['Find a frequency', "I'm in", 'Done', 'Continue', 'Get started']) {
+        final btn = find.text(label);
+        if (btn.evaluate().isNotEmpty) {
+          await tester.tap(btn.first);
+          break;
+        }
+      }
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // Postcondition: cubit persisted the name to the identity store.
+      expect(await identity.getDisplayName(), 'Maya');
     },
   );
 
@@ -483,6 +570,9 @@ void main() {
       await tester.pump();
       await tester.pump();
 
+      // Pre-condition: Discovery is showing (RECENT label is unique to it).
+      expect(find.text('RECENT'), findsOneWidget);
+
       // Find a recent row and tap. The row text "Host on 100.1" identifies it.
       final freqRow = find.textContaining('Host on 100.1');
       expect(freqRow, findsOneWidget);
@@ -493,9 +583,11 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      // Either joinRoom fired (state moves) or stays — coverage of the
-      // onPick closure body is the value here. The tap reaches the
-      // callback, exercising lines 335–353 in main.dart.
+      // Postcondition: cubit transitioned out of Discovery — the unique
+      // RECENT label is gone, proving that the onPick callback fired
+      // joinRoom on the cubit and the state machine has moved off
+      // SessionDiscovery (the screen no longer renders).
+      expect(find.text('RECENT'), findsNothing);
     },
   );
 
@@ -515,6 +607,10 @@ void main() {
       await tester.pump();
       await tester.pump();
 
+      // Snapshot read count after bootstrap settles.
+      final readsAfterBoot = settings.pttReadCalls;
+      expect(readsAfterBoot, greaterThanOrEqualTo(1));
+
       // Toggle the underlying setting then dispatch resumed lifecycle —
       // the FrequencyApp's didChangeAppLifecycleState handler should
       // re-read the value from the store.
@@ -528,10 +624,10 @@ void main() {
         (_) {},
       );
       await tester.pump();
+      await tester.pump();
 
-      // No public surface to assert on — coverage of the lifecycle handler
-      // is the value here.
-      expect(find.byType(WalkieTalkieApp), findsOneWidget);
+      // The lifecycle handler must have triggered an additional read.
+      expect(settings.pttReadCalls, greaterThan(readsAfterBoot));
     },
   );
 }

--- a/test/widgets/media_source_sheet_test.dart
+++ b/test/widgets/media_source_sheet_test.dart
@@ -80,4 +80,54 @@ void main() {
       );
     });
   });
+
+  group('MediaSource enum metadata', () {
+    test('isPodcast is true for podcast sources', () {
+      expect(MediaSource.podcasts.isPodcast, isTrue);
+      expect(MediaSource.pocketCasts.isPodcast, isTrue);
+      expect(MediaSource.youtubeMusic.isPodcast, isFalse);
+      expect(MediaSource.spotify.isPodcast, isFalse);
+    });
+
+    test('appUri is null for the generic Podcasts source', () {
+      expect(MediaSource.podcasts.appUri, isNull);
+    });
+
+    test('appUri returns expected URIs for non-generic sources', () {
+      expect(
+        MediaSource.youtubeMusic.appUri,
+        Uri.parse('https://music.youtube.com/'),
+      );
+      expect(
+        MediaSource.spotify.appUri,
+        Uri.parse('https://open.spotify.com/'),
+      );
+      expect(MediaSource.pocketCasts.appUri, Uri.parse('https://pca.st/'));
+    });
+
+    test('fromWireKey resolves known keys', () {
+      for (final s in MediaSource.values) {
+        expect(MediaSourceExtension.fromWireKey(s.wireKey), s);
+      }
+    });
+
+    test('fromWireKey falls back to youtubeMusic for unknown keys', () {
+      expect(
+        MediaSourceExtension.fromWireKey('mystery-source'),
+        MediaSource.youtubeMusic,
+      );
+      expect(
+        MediaSourceExtension.fromWireKey(''),
+        MediaSource.youtubeMusic,
+      );
+    });
+  });
+
+  group('launchSourceApp', () {
+    test('returns false immediately for sources with null appUri', () async {
+      // Generic Podcasts has no canonical app — fast path, never hits
+      // url_launcher's platform channel.
+      expect(await launchSourceApp(MediaSource.podcasts), isFalse);
+    });
+  });
 }

--- a/test/widgets/push_to_talk_button_test.dart
+++ b/test/widgets/push_to_talk_button_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/push_to_talk_button.dart';
@@ -52,6 +53,53 @@ void main() {
         _wrap(PushToTalkButton(holding: false, onChange: (_) {})),
       );
       expect(find.bySemanticsLabel('Push to talk'), findsOneWidget);
+    });
+
+    testWidgets('semantics onTap fires true then false', (tester) async {
+      final events = <bool>[];
+      await tester.pumpWidget(
+        _wrap(PushToTalkButton(holding: false, onChange: events.add)),
+      );
+
+      final handle = tester.ensureSemantics();
+      final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
+      tester.binding.pipelineOwner.semanticsOwner!
+          .performAction(id, SemanticsAction.tap);
+      await tester.pump();
+      expect(events, [true, false]);
+      handle.dispose();
+    });
+
+    testWidgets('semantics onLongPress fires true then false', (tester) async {
+      final events = <bool>[];
+      await tester.pumpWidget(
+        _wrap(PushToTalkButton(holding: false, onChange: events.add)),
+      );
+
+      final handle = tester.ensureSemantics();
+      final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
+      tester.binding.pipelineOwner.semanticsOwner!
+          .performAction(id, SemanticsAction.longPress);
+      await tester.pump();
+      expect(events, [true, false]);
+      handle.dispose();
+    });
+
+    testWidgets('pointer cancel fires false', (tester) async {
+      final events = <bool>[];
+      await tester.pumpWidget(
+        _wrap(PushToTalkButton(holding: false, onChange: events.add)),
+      );
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(PushToTalkButton)),
+      );
+      await tester.pump();
+      expect(events, [true]);
+
+      await gesture.cancel();
+      await tester.pump();
+      expect(events, [true, false]);
     });
   });
 }

--- a/test/widgets/push_to_talk_button_test.dart
+++ b/test/widgets/push_to_talk_button_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/push_to_talk_button.dart';
@@ -61,23 +60,12 @@ void main() {
         _wrap(PushToTalkButton(holding: false, onChange: events.add)),
       );
 
-      // Wrap in try/finally so the handle is released even if expect()
-      // throws — Flutter checks for leaked semantics handles in
-      // _endOfTestVerifications, which runs *before* addTearDown.
-      final handle = tester.ensureSemantics();
-      try {
-        final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
-        // pipelineOwner is technically deprecated in favour of
-        // rootPipelineOwner, but the latter has a null semanticsOwner in
-        // standalone widget tests on Flutter 3.41.
-        // ignore: deprecated_member_use
-        tester.binding.pipelineOwner.semanticsOwner!
-            .performAction(id, SemanticsAction.tap);
-        await tester.pump();
-        expect(events, [true, false]);
-      } finally {
-        handle.dispose();
-      }
+      // tester.semantics is the modern non-deprecated entry point; pair it
+      // with `find.semantics.byLabel(...)` to look up the SemanticsNode by
+      // its label rather than by widget type.
+      tester.semantics.tap(find.semantics.byLabel('Push to talk'));
+      await tester.pump();
+      expect(events, [true, false]);
     });
 
     testWidgets('semantics onLongPress fires true then false', (tester) async {
@@ -86,17 +74,9 @@ void main() {
         _wrap(PushToTalkButton(holding: false, onChange: events.add)),
       );
 
-      final handle = tester.ensureSemantics();
-      try {
-        final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
-        // ignore: deprecated_member_use
-        tester.binding.pipelineOwner.semanticsOwner!
-            .performAction(id, SemanticsAction.longPress);
-        await tester.pump();
-        expect(events, [true, false]);
-      } finally {
-        handle.dispose();
-      }
+      tester.semantics.longPress(find.semantics.byLabel('Push to talk'));
+      await tester.pump();
+      expect(events, [true, false]);
     });
 
     testWidgets('pointer cancel fires false', (tester) async {

--- a/test/widgets/push_to_talk_button_test.dart
+++ b/test/widgets/push_to_talk_button_test.dart
@@ -61,13 +61,23 @@ void main() {
         _wrap(PushToTalkButton(holding: false, onChange: events.add)),
       );
 
+      // Wrap in try/finally so the handle is released even if expect()
+      // throws — Flutter checks for leaked semantics handles in
+      // _endOfTestVerifications, which runs *before* addTearDown.
       final handle = tester.ensureSemantics();
-      final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
-      tester.binding.pipelineOwner.semanticsOwner!
-          .performAction(id, SemanticsAction.tap);
-      await tester.pump();
-      expect(events, [true, false]);
-      handle.dispose();
+      try {
+        final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
+        // pipelineOwner is technically deprecated in favour of
+        // rootPipelineOwner, but the latter has a null semanticsOwner in
+        // standalone widget tests on Flutter 3.41.
+        // ignore: deprecated_member_use
+        tester.binding.pipelineOwner.semanticsOwner!
+            .performAction(id, SemanticsAction.tap);
+        await tester.pump();
+        expect(events, [true, false]);
+      } finally {
+        handle.dispose();
+      }
     });
 
     testWidgets('semantics onLongPress fires true then false', (tester) async {
@@ -77,12 +87,16 @@ void main() {
       );
 
       final handle = tester.ensureSemantics();
-      final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
-      tester.binding.pipelineOwner.semanticsOwner!
-          .performAction(id, SemanticsAction.longPress);
-      await tester.pump();
-      expect(events, [true, false]);
-      handle.dispose();
+      try {
+        final id = tester.getSemantics(find.byType(PushToTalkButton)).id;
+        // ignore: deprecated_member_use
+        tester.binding.pipelineOwner.semanticsOwner!
+            .performAction(id, SemanticsAction.longPress);
+        await tester.pump();
+        expect(events, [true, false]);
+      } finally {
+        handle.dispose();
+      }
     });
 
     testWidgets('pointer cancel fires false', (tester) async {


### PR DESCRIPTION
## Summary
- Pushes line coverage from 86.22% (4763/5524) to 90.53% (5001/5524) — +238 lines covered, 51 new tests, 816 tests passing.
- No `lib/` changes. Tests only.
- Targets the codecov badge on `README.md`.

## Coverage breakdown

| File | Before | After |
|---|---|---|
| `services/audio_service.dart` | 50.9% | covered for all methods + error paths + streams |
| `services/onboarding_permission_gateway.dart` | 25.0% | request methods now cover the platform-channel path |
| `screens/frequency_settings_screen.dart` | 74.0% | reset-all-data dialog (cancel / confirm / store-error) + license + FAQ links |
| `screens/frequency_room_screen.dart` | 69.0% | audioOutputChanged event handler branches |
| `widgets/push_to_talk_button.dart` | 74.1% | semantics tap/longPress + pointer-cancel |
| `widgets/media_source_sheet.dart` | 86.0% | enum metadata + launchSourceApp null short-circuit |
| `theme/app_theme.dart` | 89.4% | new test file: copyWith / lerp branches |
| `services/sentry_config.dart` | absent | new test file |
| `screens/frequency_explainer_screen.dart` | 85.3% | new test file: Skip / Next / Back / Get-started + embedded mode |
| `main.dart` | 58.0% | didUpdateWidget reconciliation, lifecycle resumed, permission-revoked routing, recent-row tap, onboarding completion |
| protocol files (discovery, messages, voice_frame, frequency_session) | 88–96% | hashCode/toString + fromWire error branches + non-hex fallback |

## What's left

Remaining gaps are dominated by:
- Native-channel boundaries — `bluetooth_discovery_service.dart` startScan / stopScan / dispose hit `FlutterBluePlus` static singletons that aren't mockable from a unit test.
- `main()` itself — sqflite + Sentry init paths.
- Deeply conditional message handlers in `frequency_session_cubit.dart` (heartbeat / bitrate / signal-report hot loops) that already have extensive tests; further coverage would require fakes for multi-service interaction.

## Test plan
- [x] `flutter test` — all 816 tests pass locally.
- [x] `flutter test --coverage` — `coverage/lcov.info` produced; aggregate ratio is 90.53%.
- [ ] CI `Flutter CI` job green.
- [ ] Codecov reports the new ratio against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for discovery, session lifecycle, frequency parsing (mhz fallback), and protocol value stability (hashCode/toString).
  * Added widget tests for onboarding, explainer, room, settings (reset-all-data flows, navigation, audio output labels), and lifecycle/permission flows.
  * Broadened service tests for audio, telemetry, permission gateway, platform-channel error paths, media sources, theme, and UI semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->