### PR TITLE
fix(#303): switch ReconnectController to connectToHost (GATT)

### DIFF
--- a/lib/services/reconnect_controller.dart
+++ b/lib/services/reconnect_controller.dart
@@ -39,7 +39,7 @@ class ReconnectController {
       await Future.delayed(delay);
       if (_cancelled) return false;
       try {
-        final connected = await _audio.connectDevice(macAddress);
+        final connected = await _audio.connectToHost(macAddress);
         if (_cancelled) return false;
         if (connected) return true;
       } catch (_) {

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -2027,7 +2027,7 @@ void main() {
     late AudioService audio;
     // The mock handler returns values pushed here; empty = return false.
     final List<bool> connectQueue = [];
-    // Completer to block the first connectDevice call so we can inspect
+    // Completer to block the first connectToHost call so we can inspect
     // intermediate state.
     Completer<bool>? blockFirst;
 
@@ -2041,7 +2041,7 @@ void main() {
           .setMockMethodCallHandler(
             const MethodChannel('com.elodin.walkie_talkie/audio'),
             (MethodCall call) async {
-              if (call.method == 'connectDevice') {
+              if (call.method == 'connectToHost') {
                 final blocker = blockFirst;
                 if (blocker != null) {
                   blockFirst = null;
@@ -2104,7 +2104,7 @@ void main() {
     });
 
     test('notifyDrop transitions state to reconnecting', () async {
-      // Block the first connectDevice so we can observe the intermediate state.
+      // Block the first connectToHost so we can observe the intermediate state.
       final blocker = Completer<bool>();
       blockFirst = blocker;
 
@@ -2123,7 +2123,7 @@ void main() {
 
       final dropFuture = cubit.notifyDrop(macAddress: 'AA:BB:CC:DD:EE:FF');
 
-      // Yield to let the cubit emit reconnecting before connectDevice resolves.
+      // Yield to let the cubit emit reconnecting before connectToHost resolves.
       await Future<void>.delayed(Duration.zero);
 
       expect(
@@ -2237,7 +2237,7 @@ void main() {
           ),
         );
 
-        // Let the blocked connectDevice resolve with false (the cancel signal
+        // Let the blocked connectToHost resolve with false (the cancel signal
         // will override it anyway, but the mock needs to settle).
         blocker.complete(false);
         await dropFuture;

--- a/test/services/reconnect_controller_test.dart
+++ b/test/services/reconnect_controller_test.dart
@@ -17,7 +17,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late AudioService audio;
-  // connectDevice results consumed in order; empty = false.
+  // connectToHost results consumed in order; empty = false.
   final List<bool> connectResults = [];
   int connectCallCount = 0;
 
@@ -30,7 +30,7 @@ void main() {
         .setMockMethodCallHandler(
           const MethodChannel('com.elodin.walkie_talkie/audio'),
           (MethodCall call) async {
-            if (call.method == 'connectDevice') {
+            if (call.method == 'connectToHost') {
               connectCallCount++;
               if (connectResults.isEmpty) return false;
               return connectResults.removeAt(0);


### PR DESCRIPTION
Closes #303

## Summary

- `ReconnectController.attempt` was calling `audio.connectDevice(macAddress)`, which dials the classic LE Audio profile (`BluetoothLeAudioManager`) — not the GATT control plane the cubit expects.
- Every reconnect attempt burned its full 19-second exponential-backoff budget against the wrong native code path before falling to Discovery.
- Fix: call `audio.connectToHost(macAddress)` instead, which opens the GATT link (`GattClientManager`) that the `JoinAccepted`-bearing control plane runs over.

## Changes

- [`lib/services/reconnect_controller.dart`](lib/services/reconnect_controller.dart): `connectDevice` → `connectToHost`
- [`test/services/reconnect_controller_test.dart`](test/services/reconnect_controller_test.dart): update `MethodChannel` mock to intercept `connectToHost`
- [`test/bloc/frequency_session_cubit_test.dart`](test/bloc/frequency_session_cubit_test.dart): same mock update in the `notifyDrop / ConnectionPhase` group

## Test plan

- [x] `bash scripts/presubmit.sh` — all 708 tests pass, no analyzer issues
- [x] `reconnect_controller_test.dart` — all 6 tests pass
- [x] `frequency_session_cubit_test.dart` — all 143 tests pass (watchdog and reconnect phase tests previously failing now pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal audio service connection mechanism during device reconnection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->