### PR TITLE
ci(#325): flip continue-on-error to false on AAB-size job

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -132,11 +132,9 @@ jobs:
 
       # App size budget (issue #131): build a debug AAB and enforce the
       # < 30 MB download-size target. Uses the debug keystore so no signing
-      # credentials are needed. `continue-on-error` keeps the main test
-      # suite unblocked while the full NDK/Gradle/Opus build path is being
-      # validated; flip to `false` once the native build is stable in CI.
+      # credentials are needed.
       - name: Measure AAB size (< 30 MB budget)
-        continue-on-error: true
+        continue-on-error: false
         run: |
           set -euo pipefail
           sudo apt-get install -y -q openjdk-17-jdk-headless

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -351,8 +351,9 @@ void main() {
         identityStore: _FakeStore(initial: 'Maya')..throwOnGetPeerId = true,
       ),
       act: (cubit) => cubit.bootstrap(),
-      expect: () =>
-          [isA<SessionDiscovery>().having((s) => s.myName, 'myName', 'Maya')],
+      expect: () => [
+        isA<SessionDiscovery>().having((s) => s.myName, 'myName', 'Maya'),
+      ],
     );
 
     blocTest<FrequencySessionCubit, FrequencySessionState>(

--- a/test/protocol/discovery_test.dart
+++ b/test/protocol/discovery_test.dart
@@ -187,21 +187,18 @@ void main() {
       },
     );
 
-    test(
-      'mhzDisplay falls back to 88.0 on an odd-length sessionUuidLow8',
-      () {
-        // hex.length.isOdd → _hexToBytes returns an empty Uint8List.
-        final s = DiscoveredSession(
-          protocolVersion: 1,
-          isHost: true,
-          sessionUuidLow8: 'ABC',
-          flags: 0,
-          hostName: 'oddLen',
-          rssi: -55,
-          macAddress: 'AA:BB:CC:DD:EE:FF',
-        );
-        expect(s.mhzDisplay, '88.0');
-      },
-    );
+    test('mhzDisplay falls back to 88.0 on an odd-length sessionUuidLow8', () {
+      // hex.length.isOdd → _hexToBytes returns an empty Uint8List.
+      final s = DiscoveredSession(
+        protocolVersion: 1,
+        isHost: true,
+        sessionUuidLow8: 'ABC',
+        flags: 0,
+        hostName: 'oddLen',
+        rssi: -55,
+        macAddress: 'AA:BB:CC:DD:EE:FF',
+      );
+      expect(s.mhzDisplay, '88.0');
+    });
   });
 }

--- a/test/protocol/messages_test.dart
+++ b/test/protocol/messages_test.dart
@@ -499,10 +499,7 @@ void main() {
 
   group('MediaOp.fromWire', () {
     test('throws FormatException on unknown op', () {
-      expect(
-        () => MediaOpWire.fromWire('teleport'),
-        throwsFormatException,
-      );
+      expect(() => MediaOpWire.fromWire('teleport'), throwsFormatException);
     });
   });
 

--- a/test/protocol/voice_frame_test.dart
+++ b/test/protocol/voice_frame_test.dart
@@ -195,11 +195,7 @@ void main() {
     });
 
     test('toString includes payload byte count', () {
-      final f = VoiceFrame(
-        seq: 5,
-        senderTsMs: 10,
-        payload: Uint8List(7),
-      );
+      final f = VoiceFrame(seq: 5, senderTsMs: 10, payload: Uint8List(7));
       expect(f.toString(), contains('payload=7B'));
     });
   });

--- a/test/screens/frequency_explainer_screen_test.dart
+++ b/test/screens/frequency_explainer_screen_test.dart
@@ -13,11 +13,10 @@ Widget _wrap(Widget child) => MaterialApp(
 
 void main() {
   group('FrequencyExplainerScreen non-embedded (default)', () {
-    testWidgets('renders Scaffold with Skip + Next on the first page',
-        (tester) async {
-      await tester.pumpWidget(
-        _wrap(FrequencyExplainerScreen(onDone: () {})),
-      );
+    testWidgets('renders Scaffold with Skip + Next on the first page', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(FrequencyExplainerScreen(onDone: () {})));
       await tester.pumpAndSettle();
 
       expect(find.byType(Scaffold), findsOneWidget);
@@ -41,11 +40,10 @@ void main() {
       expect(taps, 1);
     });
 
-    testWidgets('Next advances to last page where Get started appears',
-        (tester) async {
-      await tester.pumpWidget(
-        _wrap(FrequencyExplainerScreen(onDone: () {})),
-      );
+    testWidgets('Next advances to last page where Get started appears', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(FrequencyExplainerScreen(onDone: () {})));
       await tester.pumpAndSettle();
 
       // Three pages — tap Next twice to reach the end.
@@ -58,11 +56,10 @@ void main() {
       expect(find.text('Skip'), findsNothing);
     });
 
-    testWidgets('Back from page 2 returns to page 1 (exercises previousPage)',
-        (tester) async {
-      await tester.pumpWidget(
-        _wrap(FrequencyExplainerScreen(onDone: () {})),
-      );
+    testWidgets('Back from page 2 returns to page 1 (exercises previousPage)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(FrequencyExplainerScreen(onDone: () {})));
       await tester.pumpAndSettle();
 
       // Advance once.
@@ -104,10 +101,7 @@ void main() {
           // Wrap in a Scaffold so MediaQuery + Material are available; the
           // screen under test must NOT add its own.
           Scaffold(
-            body: FrequencyExplainerScreen(
-              onDone: () {},
-              embedded: true,
-            ),
+            body: FrequencyExplainerScreen(onDone: () {}, embedded: true),
           ),
         ),
       );

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -1037,38 +1037,34 @@ void main() {
       },
     );
 
-    testWidgets(
-      'audioOutputChanged away from bluetooth clears btDevice',
-      (tester) async {
-        final eventEmitter = _EventChannelEmitter(
-          'com.elodin.walkie_talkie/audio_events',
-        );
-        addTearDown(eventEmitter.dispose);
+    testWidgets('audioOutputChanged away from bluetooth clears btDevice', (
+      tester,
+    ) async {
+      final eventEmitter = _EventChannelEmitter(
+        'com.elodin.walkie_talkie/audio_events',
+      );
+      addTearDown(eventEmitter.dispose);
 
-        await tester.pumpWidget(_wrap(_room()));
-        await tester.pump();
+      await tester.pumpWidget(_wrap(_room()));
+      await tester.pump();
 
-        // First flip on with a name.
-        eventEmitter.emit({
-          'type': 'audioOutputChanged',
-          'output': 'bluetooth',
-          'btName': 'AirPods Pro',
-        });
-        await tester.pump();
-        expect(find.text('AirPods Pro'), findsOneWidget);
+      // First flip on with a name.
+      eventEmitter.emit({
+        'type': 'audioOutputChanged',
+        'output': 'bluetooth',
+        'btName': 'AirPods Pro',
+      });
+      await tester.pump();
+      expect(find.text('AirPods Pro'), findsOneWidget);
 
-        // Then flip back to speaker — the handler must clear btDevice
-        // so the device name disappears.
-        eventEmitter.emit({
-          'type': 'audioOutputChanged',
-          'output': 'speaker',
-        });
-        await tester.pump();
+      // Then flip back to speaker — the handler must clear btDevice
+      // so the device name disappears.
+      eventEmitter.emit({'type': 'audioOutputChanged', 'output': 'speaker'});
+      await tester.pump();
 
-        expect(find.text('AirPods Pro'), findsNothing);
-        expect(find.text('Phone speaker'), findsWidgets);
-      },
-    );
+      expect(find.text('AirPods Pro'), findsNothing);
+      expect(find.text('Phone speaker'), findsWidgets);
+    });
 
     testWidgets(
       'audioOutputChanged with unknown output keeps prior state (orElse branch)',

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -328,25 +328,24 @@ void main() {
       expect(find.text('Open source licenses'), findsOneWidget);
     });
 
-    testWidgets(
-      'tapping Open source licenses opens the LicensePage',
-      (tester) async {
-        await tester.pumpWidget(
-          _wrap(FrequencySettingsScreen(settingsStore: _FakeSettingsStore())),
-        );
-        await tester.pumpAndSettle();
+    testWidgets('tapping Open source licenses opens the LicensePage', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(FrequencySettingsScreen(settingsStore: _FakeSettingsStore())),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.dragUntilVisible(
-          find.text('Open source licenses'),
-          find.byType(ListView),
-          const Offset(0, -200),
-        );
-        await tester.tap(find.text('Open source licenses'));
-        await tester.pumpAndSettle();
+      await tester.dragUntilVisible(
+        find.text('Open source licenses'),
+        find.byType(ListView),
+        const Offset(0, -200),
+      );
+      await tester.tap(find.text('Open source licenses'));
+      await tester.pumpAndSettle();
 
-        expect(find.byType(LicensePage), findsOneWidget);
-      },
-    );
+      expect(find.byType(LicensePage), findsOneWidget);
+    });
 
     testWidgets(
       'tapping Privacy & Security FAQ link navigates to the SecurityFaqScreen',
@@ -370,137 +369,134 @@ void main() {
   });
 
   group('FrequencySettingsScreen reset-all-data flow', () {
-    testWidgets(
-      'cancel in confirmation dialog leaves stores untouched',
-      (tester) async {
-        final identity = _FakeIdentityStore();
-        final recents = _FakeRecentStore();
-        final blocked = _FakeBlockedStore();
-        final settings = _FakeSettingsStore(pttMode: true);
-        final cubit = _FakeCubit();
-        addTearDown(cubit.close);
+    testWidgets('cancel in confirmation dialog leaves stores untouched', (
+      tester,
+    ) async {
+      final identity = _FakeIdentityStore();
+      final recents = _FakeRecentStore();
+      final blocked = _FakeBlockedStore();
+      final settings = _FakeSettingsStore(pttMode: true);
+      final cubit = _FakeCubit();
+      addTearDown(cubit.close);
 
-        await tester.pumpWidget(
-          _ProvidedSettings(
-            identity: identity,
-            recents: recents,
-            blocked: blocked,
-            settings: settings,
-            cubit: cubit,
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _ProvidedSettings(
+          identity: identity,
+          recents: recents,
+          blocked: blocked,
+          settings: settings,
+          cubit: cubit,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.scrollUntilVisible(
-          find.text('Reset all data'),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
-        await tester.ensureVisible(find.text('Reset all data'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Reset all data'));
-        await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.text('Reset all data'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('Reset all data'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Reset all data'));
+      await tester.pumpAndSettle();
 
-        // Cancel button — no tap on the destructive option.
-        await tester.tap(find.text('Cancel'));
-        await tester.pumpAndSettle();
+      // Cancel button — no tap on the destructive option.
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
 
-        expect(identity.cleared, isFalse);
-        expect(recents.cleared, isFalse);
-        expect(blocked.cleared, isFalse);
-        expect(settings.cleared, isFalse);
-        expect(cubit.resetCalls, 0);
-      },
-    );
+      expect(identity.cleared, isFalse);
+      expect(recents.cleared, isFalse);
+      expect(blocked.cleared, isFalse);
+      expect(settings.cleared, isFalse);
+      expect(cubit.resetCalls, 0);
+    });
 
-    testWidgets(
-      'confirm in dialog clears every store and resets the cubit',
-      (tester) async {
-        final identity = _FakeIdentityStore();
-        final recents = _FakeRecentStore();
-        final blocked = _FakeBlockedStore();
-        final settings = _FakeSettingsStore(pttMode: true);
-        final cubit = _FakeCubit();
-        addTearDown(cubit.close);
+    testWidgets('confirm in dialog clears every store and resets the cubit', (
+      tester,
+    ) async {
+      final identity = _FakeIdentityStore();
+      final recents = _FakeRecentStore();
+      final blocked = _FakeBlockedStore();
+      final settings = _FakeSettingsStore(pttMode: true);
+      final cubit = _FakeCubit();
+      addTearDown(cubit.close);
 
-        await tester.pumpWidget(
-          _ProvidedSettings(
-            identity: identity,
-            recents: recents,
-            blocked: blocked,
-            settings: settings,
-            cubit: cubit,
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _ProvidedSettings(
+          identity: identity,
+          recents: recents,
+          blocked: blocked,
+          settings: settings,
+          cubit: cubit,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.scrollUntilVisible(
-          find.text('Reset all data'),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
-        await tester.ensureVisible(find.text('Reset all data'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Reset all data'));
-        await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.text('Reset all data'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('Reset all data'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Reset all data'));
+      await tester.pumpAndSettle();
 
-        // Find the confirm action — uses the destructive label "Reset".
-        // Two "Reset all data" instances exist (link + dialog title), plus
-        // a single "Reset" button — tap by exact text "Reset".
-        await tester.tap(find.widgetWithText(TextButton, 'Reset'));
-        await tester.pumpAndSettle();
+      // Find the confirm action — uses the destructive label "Reset".
+      // Two "Reset all data" instances exist (link + dialog title), plus
+      // a single "Reset" button — tap by exact text "Reset".
+      await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+      await tester.pumpAndSettle();
 
-        expect(identity.cleared, isTrue);
-        expect(recents.cleared, isTrue);
-        expect(blocked.cleared, isTrue);
-        expect(settings.cleared, isTrue);
-        expect(cubit.resetCalls, 1);
-      },
-    );
+      expect(identity.cleared, isTrue);
+      expect(recents.cleared, isTrue);
+      expect(blocked.cleared, isTrue);
+      expect(settings.cleared, isTrue);
+      expect(cubit.resetCalls, 1);
+    });
 
-    testWidgets(
-      'confirm tolerates store errors and still resets the cubit',
-      (tester) async {
-        final identity = _FakeIdentityStore(throwOnClear: true);
-        final recents = _FakeRecentStore(throwOnClear: true);
-        final blocked = _FakeBlockedStore(throwOnClear: true);
-        final settings = _FakeSettingsStore(throwOnClear: true);
-        final cubit = _FakeCubit();
-        addTearDown(cubit.close);
+    testWidgets('confirm tolerates store errors and still resets the cubit', (
+      tester,
+    ) async {
+      final identity = _FakeIdentityStore(throwOnClear: true);
+      final recents = _FakeRecentStore(throwOnClear: true);
+      final blocked = _FakeBlockedStore(throwOnClear: true);
+      final settings = _FakeSettingsStore(throwOnClear: true);
+      final cubit = _FakeCubit();
+      addTearDown(cubit.close);
 
-        await tester.pumpWidget(
-          _ProvidedSettings(
-            identity: identity,
-            recents: recents,
-            blocked: blocked,
-            settings: settings,
-            cubit: cubit,
-          ),
-        );
-        await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        _ProvidedSettings(
+          identity: identity,
+          recents: recents,
+          blocked: blocked,
+          settings: settings,
+          cubit: cubit,
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        await tester.scrollUntilVisible(
-          find.text('Reset all data'),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
-        await tester.ensureVisible(find.text('Reset all data'));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('Reset all data'));
-        await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.text('Reset all data'),
+        200,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.ensureVisible(find.text('Reset all data'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Reset all data'));
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.widgetWithText(TextButton, 'Reset'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(TextButton, 'Reset'));
+      await tester.pumpAndSettle();
 
-        // Tolerated errors → every store's clear() was attempted, and
-        // the cubit reset still ran exactly once.
-        expect(identity.clearCalls, 1);
-        expect(recents.clearCalls, 1);
-        expect(blocked.clearCalls, 1);
-        expect(settings.clearCalls, 1);
-        expect(cubit.resetCalls, 1);
-      },
-    );
+      // Tolerated errors → every store's clear() was attempted, and
+      // the cubit reset still ran exactly once.
+      expect(identity.clearCalls, 1);
+      expect(recents.clearCalls, 1);
+      expect(blocked.clearCalls, 1);
+      expect(settings.clearCalls, 1);
+      expect(cubit.resetCalls, 1);
+    });
   });
 }
 

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -606,10 +606,7 @@ void main() {
 
       test('writeNotification returns false', () async {
         installFailing();
-        expect(
-          await audioService.writeNotification('AA:BB', [1, 2, 3]),
-          false,
-        );
+        expect(await audioService.writeNotification('AA:BB', [1, 2, 3]), false);
       });
 
       test('connectVoiceClient returns false', () async {
@@ -639,7 +636,9 @@ void main() {
 
       test('writeControlBytes swallows error', () async {
         installFailing();
-        await audioService.writeControlBytes(Uint8List.fromList([1])); // no throw
+        await audioService.writeControlBytes(
+          Uint8List.fromList([1]),
+        ); // no throw
       });
 
       test('getNegotiatedMtu returns null', () async {
@@ -771,10 +770,7 @@ void main() {
         log.clear();
         expect(await audioService.getNegotiatedMtu('AA:BB'), 247);
         expect(log, [
-          isMethodCall(
-            'getNegotiatedMtu',
-            arguments: {'endpointId': 'AA:BB'},
-          ),
+          isMethodCall('getNegotiatedMtu', arguments: {'endpointId': 'AA:BB'}),
         ]);
       });
 
@@ -821,10 +817,13 @@ void main() {
         expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
       });
 
-      test('getLinkTelemetry returns null when native returns non-list', () async {
-        handler = (_) async => 'nope';
-        expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
-      });
+      test(
+        'getLinkTelemetry returns null when native returns non-list',
+        () async {
+          handler = (_) async => 'nope';
+          expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
+        },
+      );
     });
 
     group('LinkTelemetrySnapshot equality + hashCode', () {
@@ -899,8 +898,7 @@ void main() {
 
     group('controlBytes stream', () {
       test('emits typed records for Uint8List events', () async {
-        const eventChannelName =
-            'com.elodin.walkie_talkie/control_bytes';
+        const eventChannelName = 'com.elodin.walkie_talkie/control_bytes';
         final codec = const StandardMethodCodec();
 
         final received = <({String endpointId, Uint8List bytes})>[];
@@ -924,8 +922,7 @@ void main() {
       });
 
       test('emits typed records for List<int> bytes (codec branch)', () async {
-        const eventChannelName =
-            'com.elodin.walkie_talkie/control_bytes';
+        const eventChannelName = 'com.elodin.walkie_talkie/control_bytes';
         final codec = const StandardMethodCodec();
 
         final received = <({String endpointId, Uint8List bytes})>[];
@@ -949,8 +946,7 @@ void main() {
       });
 
       test('drops malformed events (missing fields)', () async {
-        const eventChannelName =
-            'com.elodin.walkie_talkie/control_bytes';
+        const eventChannelName = 'com.elodin.walkie_talkie/control_bytes';
         final codec = const StandardMethodCodec();
 
         final received = <({String endpointId, Uint8List bytes})>[];
@@ -966,7 +962,9 @@ void main() {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .handlePlatformMessage(
               eventChannelName,
-              codec.encodeSuccessEnvelope({'bytes': [1]}), // no endpointId
+              codec.encodeSuccessEnvelope({
+                'bytes': [1],
+              }), // no endpointId
               (_) {},
             );
         await Future<void>.microtask(() {});

--- a/test/services/onboarding_permission_gateway_test.dart
+++ b/test/services/onboarding_permission_gateway_test.dart
@@ -13,7 +13,10 @@ void main() {
     // Mirror the integer codes used by permission_handler's PermissionStatus enum.
     // 0 = denied, 1 = granted, 2 = restricted, 3 = limited,
     // 4 = permanentlyDenied, 5 = provisional.
-    void install({required Map<int, int> permsToStatus, bool openSettingsResult = true}) {
+    void install({
+      required Map<int, int> permsToStatus,
+      bool openSettingsResult = true,
+    }) {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (call) async {
             log.add(call);
@@ -44,60 +47,69 @@ void main() {
           .setMockMethodCallHandler(channel, null);
     });
 
-    test('requestBluetooth requests all three perms and reduces to granted', () async {
-      install(permsToStatus: {
-        ph.Permission.bluetoothScan.value: 1,
-        ph.Permission.bluetoothConnect.value: 1,
-        ph.Permission.bluetoothAdvertise.value: 1,
-      });
-      final result =
-          await const DefaultOnboardingPermissionGateway().requestBluetooth();
-      expect(result, OnboardingPermissionStatus.granted);
-      // The package may issue a checkPermissionStatus before the request, so
-      // assert that requestPermissions was invoked at least once with all
-      // three Bluetooth perms.
-      final reqCall = log.firstWhere((c) => c.method == 'requestPermissions');
-      final ids = (reqCall.arguments as List).cast<int>().toSet();
-      expect(ids, {
-        ph.Permission.bluetoothScan.value,
-        ph.Permission.bluetoothConnect.value,
-        ph.Permission.bluetoothAdvertise.value,
-      });
-    });
+    test(
+      'requestBluetooth requests all three perms and reduces to granted',
+      () async {
+        install(
+          permsToStatus: {
+            ph.Permission.bluetoothScan.value: 1,
+            ph.Permission.bluetoothConnect.value: 1,
+            ph.Permission.bluetoothAdvertise.value: 1,
+          },
+        );
+        final result = await const DefaultOnboardingPermissionGateway()
+            .requestBluetooth();
+        expect(result, OnboardingPermissionStatus.granted);
+        // The package may issue a checkPermissionStatus before the request, so
+        // assert that requestPermissions was invoked at least once with all
+        // three Bluetooth perms.
+        final reqCall = log.firstWhere((c) => c.method == 'requestPermissions');
+        final ids = (reqCall.arguments as List).cast<int>().toSet();
+        expect(ids, {
+          ph.Permission.bluetoothScan.value,
+          ph.Permission.bluetoothConnect.value,
+          ph.Permission.bluetoothAdvertise.value,
+        });
+      },
+    );
 
     test('requestBluetooth reduces to denied when one is denied', () async {
-      install(permsToStatus: {
-        ph.Permission.bluetoothScan.value: 1,
-        ph.Permission.bluetoothConnect.value: 0, // denied
-        ph.Permission.bluetoothAdvertise.value: 1,
-      });
-      final result =
-          await const DefaultOnboardingPermissionGateway().requestBluetooth();
+      install(
+        permsToStatus: {
+          ph.Permission.bluetoothScan.value: 1,
+          ph.Permission.bluetoothConnect.value: 0, // denied
+          ph.Permission.bluetoothAdvertise.value: 1,
+        },
+      );
+      final result = await const DefaultOnboardingPermissionGateway()
+          .requestBluetooth();
       expect(result, OnboardingPermissionStatus.denied);
     });
 
     test('requestBluetooth reduces to permanentlyDenied', () async {
-      install(permsToStatus: {
-        ph.Permission.bluetoothScan.value: 4, // permanentlyDenied
-        ph.Permission.bluetoothConnect.value: 1,
-        ph.Permission.bluetoothAdvertise.value: 1,
-      });
-      final result =
-          await const DefaultOnboardingPermissionGateway().requestBluetooth();
+      install(
+        permsToStatus: {
+          ph.Permission.bluetoothScan.value: 4, // permanentlyDenied
+          ph.Permission.bluetoothConnect.value: 1,
+          ph.Permission.bluetoothAdvertise.value: 1,
+        },
+      );
+      final result = await const DefaultOnboardingPermissionGateway()
+          .requestBluetooth();
       expect(result, OnboardingPermissionStatus.permanentlyDenied);
     });
 
     test('requestMicrophone returns granted', () async {
       install(permsToStatus: {ph.Permission.microphone.value: 1});
-      final result =
-          await const DefaultOnboardingPermissionGateway().requestMicrophone();
+      final result = await const DefaultOnboardingPermissionGateway()
+          .requestMicrophone();
       expect(result, OnboardingPermissionStatus.granted);
     });
 
     test('requestMicrophone returns denied', () async {
       install(permsToStatus: {ph.Permission.microphone.value: 0});
-      final result =
-          await const DefaultOnboardingPermissionGateway().requestMicrophone();
+      final result = await const DefaultOnboardingPermissionGateway()
+          .requestMicrophone();
       expect(result, OnboardingPermissionStatus.denied);
     });
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -449,9 +449,9 @@ void main() {
   testWidgets(
     'permission watcher reporting missing perms routes to permission denied screen',
     (tester) async {
-      final watcher = _DenyingPermissionWatcher(
-        const [AppPermission.bluetooth],
-      );
+      final watcher = _DenyingPermissionWatcher(const [
+        AppPermission.bluetooth,
+      ]);
       await tester.pumpWidget(
         WalkieTalkieApp(
           identityStore: _FakeIdentityStore(initial: 'Maya'),
@@ -477,8 +477,9 @@ void main() {
       // channel via `DefaultOnboardingPermissionGateway`. Stub the channel
       // so all three Bluetooth perms + microphone resolve to "granted"
       // without involving the OS.
-      const permsChannel =
-          MethodChannel('flutter.baseflow.com/permissions/methods');
+      const permsChannel = MethodChannel(
+        'flutter.baseflow.com/permissions/methods',
+      );
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(permsChannel, (call) async {
             switch (call.method) {
@@ -490,10 +491,10 @@ void main() {
             }
             return null;
           });
-      addTearDown(() => TestDefaultBinaryMessengerBinding
-          .instance
-          .defaultBinaryMessenger
-          .setMockMethodCallHandler(permsChannel, null));
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(permsChannel, null),
+      );
 
       final identity = _FakeIdentityStore();
       await tester.pumpWidget(
@@ -555,7 +556,13 @@ void main() {
       }
       await tester.enterText(nameField.first, 'Maya');
       await tester.pumpAndSettle(const Duration(milliseconds: 300));
-      for (final label in ['Find a frequency', "I'm in", 'Done', 'Continue', 'Get started']) {
+      for (final label in [
+        'Find a frequency',
+        "I'm in",
+        'Done',
+        'Continue',
+        'Get started',
+      ]) {
         final btn = find.text(label);
         if (btn.evaluate().isNotEmpty) {
           await tester.tap(btn.first);
@@ -611,43 +618,40 @@ void main() {
     },
   );
 
-  testWidgets(
-    'app lifecycle resumed re-reads PTT mode setting',
-    (tester) async {
-      final settings = _FakeSettingsStore();
-      await tester.pumpWidget(
-        WalkieTalkieApp(
-          identityStore: _FakeIdentityStore(initial: 'Maya'),
-          recentFrequenciesStore: _FakeRecentFrequenciesStore(),
-          discoveryService: _FakeDiscoveryService(),
-          permissionWatcher: _FakePermissionWatcher(),
-          settingsStore: settings,
-        ),
-      );
-      await tester.pump();
-      await tester.pump();
+  testWidgets('app lifecycle resumed re-reads PTT mode setting', (
+    tester,
+  ) async {
+    final settings = _FakeSettingsStore();
+    await tester.pumpWidget(
+      WalkieTalkieApp(
+        identityStore: _FakeIdentityStore(initial: 'Maya'),
+        recentFrequenciesStore: _FakeRecentFrequenciesStore(),
+        discoveryService: _FakeDiscoveryService(),
+        permissionWatcher: _FakePermissionWatcher(),
+        settingsStore: settings,
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
 
-      // Snapshot read count after bootstrap settles.
-      final readsAfterBoot = settings.pttReadCalls;
-      expect(readsAfterBoot, greaterThanOrEqualTo(1));
+    // Snapshot read count after bootstrap settles.
+    final readsAfterBoot = settings.pttReadCalls;
+    expect(readsAfterBoot, greaterThanOrEqualTo(1));
 
-      // Toggle the underlying setting then dispatch resumed lifecycle —
-      // the FrequencyApp's didChangeAppLifecycleState handler should
-      // re-read the value from the store.
-      await settings.setPttModeEnabled(true);
-      // Send AppLifecycleState.resumed via the platform message channel.
-      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
-        'flutter/lifecycle',
-        const StringCodec().encodeMessage(
-          AppLifecycleState.resumed.toString(),
-        ),
-        (_) {},
-      );
-      await tester.pump();
-      await tester.pump();
+    // Toggle the underlying setting then dispatch resumed lifecycle —
+    // the FrequencyApp's didChangeAppLifecycleState handler should
+    // re-read the value from the store.
+    await settings.setPttModeEnabled(true);
+    // Send AppLifecycleState.resumed via the platform message channel.
+    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      'flutter/lifecycle',
+      const StringCodec().encodeMessage(AppLifecycleState.resumed.toString()),
+      (_) {},
+    );
+    await tester.pump();
+    await tester.pump();
 
-      // The lifecycle handler must have triggered an additional read.
-      expect(settings.pttReadCalls, greaterThan(readsAfterBoot));
-    },
-  );
+    // The lifecycle handler must have triggered an additional read.
+    expect(settings.pttReadCalls, greaterThan(readsAfterBoot));
+  });
 }

--- a/test/widgets/media_source_sheet_test.dart
+++ b/test/widgets/media_source_sheet_test.dart
@@ -116,10 +116,7 @@ void main() {
         MediaSourceExtension.fromWireKey('mystery-source'),
         MediaSource.youtubeMusic,
       );
-      expect(
-        MediaSourceExtension.fromWireKey(''),
-        MediaSource.youtubeMusic,
-      );
+      expect(MediaSourceExtension.fromWireKey(''), MediaSource.youtubeMusic);
     });
   });
 


### PR DESCRIPTION
Closes #325

## Summary
- Flip `continue-on-error: true` → `false` on the \"Measure AAB size\" CI step
- Verified AAB-size step passes on every successful run for the last 10+ CI runs (failures were always in earlier steps, never in the AAB step)
- Remove stale comment about the flag being temporary

Also includes `style: auto-format 11 test files` — pre-existing dart format drift on `main` that was blocking `scripts/presubmit.sh` locally.

## Test plan
- [x] `scripts/presubmit.sh` passes locally (exit 0)
- [x] AAB-size step has been stable for 10+ CI runs (checked via `gh run view`)
- [ ] GitHub CI passes with `continue-on-error: false` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for audio output handling, data reset flows, and app lifecycle behavior
  * Enhanced validation of error handling and stream parsing

* **Chores**
  * Strengthened CI/CD workflow with stricter AAB size-budget enforcement to fail builds on size violations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->