### PR TITLE
test(#310): add Kotlin unit tests for BLE control plane

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -253,6 +253,7 @@ dependencies {
     // Native crash support configured via Sentry Gradle plugin above
 
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:5.11.0")
 }
 
 flutter {

--- a/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattClientManagerTest.kt
+++ b/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattClientManagerTest.kt
@@ -128,25 +128,22 @@ class GattClientManagerTest {
 
     @Test
     fun retryStopsAfterMaxConnectRetries() {
-        // MAX_CONNECT_RETRIES = 5 (total attempts = 1 initial + 5 retries = 6)
+        // MAX_CONNECT_RETRIES = 5; seed once and fire exactly MAX+1 disconnects.
         val mac = "AA:BB:CC:DD:EE:FF"
         val gatt = mockGatt(mac)
 
-        // Simulate 5 transient disconnects (retry count increments each time)
+        setPendingMac(mac)
+        // First 5 transient disconnects each increment the retry counter.
         repeat(5) {
-            setPendingMac(mac) // pendingMac is cleared after last retry exhausted
             gattCallback().onConnectionStateChange(gatt, 133, BluetoothProfile.STATE_DISCONNECTED)
         }
+        assertEquals("retryCount should be MAX_CONNECT_RETRIES after 5 retries", 5, retryCount())
+        assertEquals("pendingMac should still be set mid-retry", mac, pendingMac())
 
-        // On the 6th failure, retry counter has hit MAX_CONNECT_RETRIES so the
-        // manager gives up: pendingMacAddress is nulled out.
-        val macBeforeFinalFail = pendingMac()
-        if (macBeforeFinalFail != null) {
-            gattCallback().onConnectionStateChange(gatt, 133, BluetoothProfile.STATE_DISCONNECTED)
-            assertNull(pendingMac())
-        }
-        // Either way retry count must not exceed MAX_CONNECT_RETRIES (5)
-        assertTrue("retryCount ${retryCount()} exceeds MAX_CONNECT_RETRIES(5)", retryCount() <= 5)
+        // 6th disconnect exhausts the budget: counter resets and pending MAC is cleared.
+        gattCallback().onConnectionStateChange(gatt, 133, BluetoothProfile.STATE_DISCONNECTED)
+        assertNull("pendingMac should be null after retry exhaustion", pendingMac())
+        assertEquals("retryCount should reset to 0 on exhaustion", 0, retryCount())
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattClientManagerTest.kt
+++ b/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattClientManagerTest.kt
@@ -1,0 +1,240 @@
+package com.elodin.walkie_talkie
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Unit tests for GattClientManager covering the control-plane contracts
+ * from issue #310:
+ *
+ *  - MTU negotiation cache: getMtu returns the right value after onMtuChanged.
+ *  - 133/147 retry policy: transient GATT errors trigger a retry up to
+ *    MAX_CONNECT_RETRIES times; non-transient errors do not retry.
+ *  - RSSI sample cache: getLatestRssiSamples returns entries written by
+ *    onReadRemoteRssi.
+ */
+class GattClientManagerTest {
+
+    private val responses = mutableListOf<ByteArray>()
+    private val errors = mutableListOf<String>()
+    private lateinit var manager: GattClientManager
+
+    @Before
+    fun setup() {
+        responses.clear()
+        errors.clear()
+        manager = GattClientManager(
+            context = mock(Context::class.java),
+            onResponseBytes = { bytes -> responses.add(bytes) },
+            onError = { err -> errors.add(err) }
+        )
+    }
+
+    // ── getMtu ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun getMtuReturnsNullForUnknownAddress() {
+        assertNull(manager.getMtu("AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun getMtuReturnsCachedValue() {
+        injectMtu("AA:BB:CC:DD:EE:FF", 247)
+        assertEquals(247, manager.getMtu("AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun getMtuReturnsNullForDifferentAddress() {
+        injectMtu("AA:BB:CC:DD:EE:FF", 247)
+        assertNull(manager.getMtu("11:22:33:44:55:66"))
+    }
+
+    @Test
+    fun onMtuChangedSuccessUpdatesCacheForDevice() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val gatt = mockGatt(mac)
+        gattCallback().onMtuChanged(gatt, 200, BluetoothGatt.GATT_SUCCESS)
+        assertEquals(200, manager.getMtu(mac))
+    }
+
+    @Test
+    fun onMtuChangedFailureDoesNotUpdateCache() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val gatt = mockGatt(mac)
+        gattCallback().onMtuChanged(gatt, 200, BluetoothGatt.GATT_FAILURE)
+        assertNull(manager.getMtu(mac))
+    }
+
+    // ── 133/147 retry policy (issue #100) ────────────────────────────────────
+
+    @Test
+    fun transientError133IncrementsRetryCount() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        setPendingMac(mac)
+
+        val gatt = mockGatt(mac)
+        gattCallback().onConnectionStateChange(gatt, 133, BluetoothProfile.STATE_DISCONNECTED)
+
+        assertEquals(1, retryCount())
+    }
+
+    @Test
+    fun transientError147IncrementsRetryCount() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        setPendingMac(mac)
+
+        val gatt = mockGatt(mac)
+        gattCallback().onConnectionStateChange(gatt, 147, BluetoothProfile.STATE_DISCONNECTED)
+
+        assertEquals(1, retryCount())
+    }
+
+    @Test
+    fun transientError19IncrementsRetryCount() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        setPendingMac(mac)
+
+        val gatt = mockGatt(mac)
+        gattCallback().onConnectionStateChange(gatt, 19, BluetoothProfile.STATE_DISCONNECTED)
+
+        assertEquals(1, retryCount())
+    }
+
+    @Test
+    fun nonTransientErrorClearsPendingMac() {
+        // Status 8 is GATT_INSUFFICIENT_AUTHORIZATION — handled as auth error,
+        // not retried. Also tests a clean-disconnect (GATT_SUCCESS / 0).
+        val mac = "AA:BB:CC:DD:EE:FF"
+        setPendingMac(mac)
+
+        val gatt = mockGatt(mac)
+        gattCallback().onConnectionStateChange(gatt, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_DISCONNECTED)
+
+        assertNull(pendingMac())
+        assertEquals(0, retryCount())
+    }
+
+    @Test
+    fun retryStopsAfterMaxConnectRetries() {
+        // MAX_CONNECT_RETRIES = 5 (total attempts = 1 initial + 5 retries = 6)
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val gatt = mockGatt(mac)
+
+        // Simulate 5 transient disconnects (retry count increments each time)
+        repeat(5) {
+            setPendingMac(mac) // pendingMac is cleared after last retry exhausted
+            gattCallback().onConnectionStateChange(gatt, 133, BluetoothProfile.STATE_DISCONNECTED)
+        }
+
+        // On the 6th failure, retry counter has hit MAX_CONNECT_RETRIES so the
+        // manager gives up: pendingMacAddress is nulled out.
+        val macBeforeFinalFail = pendingMac()
+        if (macBeforeFinalFail != null) {
+            gattCallback().onConnectionStateChange(gatt, 133, BluetoothProfile.STATE_DISCONNECTED)
+            assertNull(pendingMac())
+        }
+        // Either way retry count must not exceed MAX_CONNECT_RETRIES (5)
+        assertTrue("retryCount ${retryCount()} exceeds MAX_CONNECT_RETRIES(5)", retryCount() <= 5)
+    }
+
+    @Test
+    fun transientErrorRetryPreservesPendingMac() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        setPendingMac(mac)
+
+        val gatt = mockGatt(mac)
+        gattCallback().onConnectionStateChange(gatt, 133, BluetoothProfile.STATE_DISCONNECTED)
+
+        // Still targeting the same host — pendingMac stays set so the
+        // retry runnable (posted by retryHandler) knows where to reconnect.
+        assertEquals(mac, pendingMac())
+    }
+
+    // ── RSSI sample cache ─────────────────────────────────────────────────────
+
+    @Test
+    fun rssiSamplesEmptyInitially() {
+        assertTrue(manager.getLatestRssiSamples().isEmpty())
+    }
+
+    @Test
+    fun onReadRemoteRssiSuccessPopulatesCache() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val gatt = mockGatt(mac)
+        gattCallback().onReadRemoteRssi(gatt, -70, BluetoothGatt.GATT_SUCCESS)
+
+        val samples = manager.getLatestRssiSamples()
+        assertEquals(1, samples.size)
+        assertEquals(mac, samples[0]["peerId"])
+        assertEquals(-70, samples[0]["rssi"])
+    }
+
+    @Test
+    fun onReadRemoteRssiFailureDoesNotPopulateCache() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val gatt = mockGatt(mac)
+        gattCallback().onReadRemoteRssi(gatt, -70, BluetoothGatt.GATT_FAILURE)
+
+        assertTrue(manager.getLatestRssiSamples().isEmpty())
+    }
+
+    // ── isConnected ──────────────────────────────────────────────────────────
+
+    @Test
+    fun isConnectedFalseInitially() {
+        assertFalse(manager.isConnected())
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun gattCallback(): BluetoothGattCallback {
+        val field = GattClientManager::class.java.getDeclaredField("gattCallback")
+        field.isAccessible = true
+        return field.get(manager) as BluetoothGattCallback
+    }
+
+    private fun injectMtu(mac: String, mtu: Int) {
+        val field = GattClientManager::class.java.getDeclaredField("negotiatedMtus")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        (field.get(manager) as MutableMap<String, Int>)[mac] = mtu
+    }
+
+    private fun setPendingMac(mac: String) {
+        val field = GattClientManager::class.java.getDeclaredField("pendingMacAddress")
+        field.isAccessible = true
+        field.set(manager, mac)
+    }
+
+    private fun pendingMac(): String? {
+        val field = GattClientManager::class.java.getDeclaredField("pendingMacAddress")
+        field.isAccessible = true
+        return field.get(manager) as String?
+    }
+
+    private fun retryCount(): Int {
+        val field = GattClientManager::class.java.getDeclaredField("connectRetryCount")
+        field.isAccessible = true
+        return field.getInt(manager)
+    }
+
+    private fun mockGatt(address: String): BluetoothGatt {
+        val device = mock(BluetoothDevice::class.java)
+        `when`(device.address).thenReturn(address)
+        val gatt = mock(BluetoothGatt::class.java)
+        `when`(gatt.device).thenReturn(device)
+        return gatt
+    }
+}

--- a/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattConstantsTest.kt
+++ b/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattConstantsTest.kt
@@ -1,0 +1,75 @@
+package com.elodin.walkie_talkie
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.UUID
+
+class GattConstantsTest {
+
+    @Test
+    fun serviceUuidMatchesSpec() {
+        assertEquals(
+            UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e"),
+            GattConstants.SERVICE_UUID
+        )
+    }
+
+    @Test
+    fun requestCharUuidMatchesSpec() {
+        assertEquals(
+            UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e01"),
+            GattConstants.REQUEST_CHAR_UUID
+        )
+    }
+
+    @Test
+    fun responseCharUuidMatchesSpec() {
+        assertEquals(
+            UUID.fromString("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e02"),
+            GattConstants.RESPONSE_CHAR_UUID
+        )
+    }
+
+    @Test
+    fun cccdUuidMatchesStandardSpec() {
+        assertEquals(
+            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"),
+            GattConstants.CCCD_UUID
+        )
+    }
+
+    @Test
+    fun targetMtuIs247() {
+        assertEquals(247, GattConstants.TARGET_ATT_MTU)
+    }
+
+    @Test
+    fun voiceMtuIs128() {
+        assertEquals(128, GattConstants.VOICE_MTU)
+    }
+
+    @Test
+    fun authorizationErrorsContainsInsufficientAuthorizationCode() {
+        assertTrue("GATT_INSUFFICIENT_AUTHORIZATION(8) missing", 8 in GattConstants.AUTHORIZATION_ERRORS)
+    }
+
+    @Test
+    fun authorizationErrorsContainsInsufficientAuthenticationCode() {
+        assertTrue("GATT_INSUFFICIENT_AUTHENTICATION(5) missing", 5 in GattConstants.AUTHORIZATION_ERRORS)
+    }
+
+    @Test
+    fun authorizationErrorsContainsInsufficientEncryptionCode() {
+        assertTrue("GATT_INSUFFICIENT_ENCRYPTION(15) missing", 15 in GattConstants.AUTHORIZATION_ERRORS)
+    }
+
+    @Test
+    fun authorizationErrorsExcludesTransientGattErrors() {
+        // 133 / 147 are retried, not treated as auth denials
+        assertFalse("133 should not be an auth error", 133 in GattConstants.AUTHORIZATION_ERRORS)
+        assertFalse("147 should not be an auth error", 147 in GattConstants.AUTHORIZATION_ERRORS)
+        assertFalse("0 should not be an auth error", 0 in GattConstants.AUTHORIZATION_ERRORS)
+    }
+}

--- a/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattServerManagerTest.kt
+++ b/android/app/src/test/kotlin/com/elodin/walkie_talkie/GattServerManagerTest.kt
@@ -1,0 +1,190 @@
+package com.elodin.walkie_talkie
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Unit tests for GattServerManager covering the control-plane contracts
+ * from issue #310:
+ *
+ *  - MTU negotiation cache: getMtu returns the right value after onMtuChanged.
+ *  - REQUEST characteristic writes invoke onBytesReceived (admit path).
+ *  - Writes to unknown characteristics are silently ignored (deny path).
+ */
+class GattServerManagerTest {
+
+    private val receivedBytes = mutableListOf<Pair<String, ByteArray>>()
+    private val errors = mutableListOf<String>()
+    private lateinit var manager: GattServerManager
+
+    @Before
+    fun setup() {
+        receivedBytes.clear()
+        errors.clear()
+        manager = GattServerManager(
+            context = mock(Context::class.java),
+            onBytesReceived = { addr, bytes -> receivedBytes.add(addr to bytes) },
+            onError = { err -> errors.add(err) }
+        )
+    }
+
+    // ── getMtu ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun getMtuReturnsNullForUnknownAddress() {
+        assertNull(manager.getMtu("AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test
+    fun getMtuReturnsCachedValueAfterOnMtuChanged() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        injectMtu(mac, 200)
+        assertEquals(200, manager.getMtu(mac))
+    }
+
+    @Test
+    fun getMtuReturnsNullForDifferentAddress() {
+        injectMtu("AA:BB:CC:DD:EE:FF", 200)
+        assertNull(manager.getMtu("11:22:33:44:55:66"))
+    }
+
+    @Test
+    fun onMtuChangedViaCallbackUpdatesMtuCache() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val device = mockDevice(mac)
+        gattCallback().onMtuChanged(device, 247)
+        assertEquals(247, manager.getMtu(mac))
+    }
+
+    @Test
+    fun latestMtuValueOverwritesPreviousEntry() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        injectMtu(mac, 100)
+        injectMtu(mac, 247)
+        assertEquals(247, manager.getMtu(mac))
+    }
+
+    // ── onCharacteristicWriteRequest — admit (REQUEST char) ──────────────────
+
+    @Test
+    fun requestCharWriteDeliversBytesToCallback() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val payload = byteArrayOf(1, 2, 3, 4)
+        val device = mockDevice(mac)
+        val char = mockChar(GattConstants.REQUEST_CHAR_UUID)
+
+        // Java method — positional args required (device, requestId, characteristic,
+        // preparedWrite, responseNeeded, offset, value)
+        gattCallback().onCharacteristicWriteRequest(device, 1, char, false, false, 0, payload)
+
+        assertEquals(1, receivedBytes.size)
+        assertEquals(mac, receivedBytes[0].first)
+        assertArrayEquals(payload, receivedBytes[0].second)
+    }
+
+    @Test
+    fun requestCharWriteWithEmptyValueDoesNotCallCallback() {
+        val device = mockDevice("AA:BB:CC:DD:EE:FF")
+        val char = mockChar(GattConstants.REQUEST_CHAR_UUID)
+
+        gattCallback().onCharacteristicWriteRequest(device, 1, char, false, false, 0, byteArrayOf())
+
+        assertEquals(0, receivedBytes.size)
+    }
+
+    @Test
+    fun requestCharWriteWithNullValueDoesNotCallCallback() {
+        val device = mockDevice("AA:BB:CC:DD:EE:FF")
+        val char = mockChar(GattConstants.REQUEST_CHAR_UUID)
+
+        gattCallback().onCharacteristicWriteRequest(device, 1, char, false, false, 0, null)
+
+        assertEquals(0, receivedBytes.size)
+    }
+
+    // ── onCharacteristicWriteRequest — deny (unknown char) ───────────────────
+
+    @Test
+    fun writeToUnknownCharacteristicDoesNotCallBytesReceivedCallback() {
+        val device = mockDevice("AA:BB:CC:DD:EE:FF")
+        val unknownChar = mockChar(GattConstants.RESPONSE_CHAR_UUID) // not REQUEST
+
+        gattCallback().onCharacteristicWriteRequest(device, 2, unknownChar, false, false, 0, byteArrayOf(0x42))
+
+        assertEquals(0, receivedBytes.size)
+        assertEquals(0, errors.size)
+    }
+
+    // ── getConnectedAddresses ─────────────────────────────────────────────────
+
+    @Test
+    fun getConnectedAddressesEmptyInitially() {
+        assertEquals(emptyList<String>(), manager.getConnectedAddresses())
+    }
+
+    @Test
+    fun connectedDeviceAppearsAfterStateConnectedCallback() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val device = mockDevice(mac)
+        gattCallback().onConnectionStateChange(device, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_CONNECTED)
+        assertEquals(listOf(mac), manager.getConnectedAddresses())
+    }
+
+    @Test
+    fun disconnectedDeviceRemovedFromConnectedSet() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val device = mockDevice(mac)
+        gattCallback().onConnectionStateChange(device, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_CONNECTED)
+        gattCallback().onConnectionStateChange(device, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_DISCONNECTED)
+        assertEquals(emptyList<String>(), manager.getConnectedAddresses())
+    }
+
+    @Test
+    fun mtuRemovedOnDisconnect() {
+        val mac = "AA:BB:CC:DD:EE:FF"
+        val device = mockDevice(mac)
+        injectMtu(mac, 247)
+        gattCallback().onConnectionStateChange(device, BluetoothGatt.GATT_SUCCESS, BluetoothProfile.STATE_DISCONNECTED)
+        assertNull(manager.getMtu(mac))
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun gattCallback(): BluetoothGattServerCallback {
+        val field = GattServerManager::class.java.getDeclaredField("gattCallback")
+        field.isAccessible = true
+        return field.get(manager) as BluetoothGattServerCallback
+    }
+
+    private fun injectMtu(mac: String, mtu: Int) {
+        val field = GattServerManager::class.java.getDeclaredField("negotiatedMtus")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        (field.get(manager) as ConcurrentHashMap<String, Int>)[mac] = mtu
+    }
+
+    private fun mockDevice(address: String): BluetoothDevice {
+        val d = mock(BluetoothDevice::class.java)
+        `when`(d.address).thenReturn(address)
+        return d
+    }
+
+    private fun mockChar(uuid: java.util.UUID): BluetoothGattCharacteristic {
+        val c = mock(BluetoothGattCharacteristic::class.java)
+        `when`(c.uuid).thenReturn(uuid)
+        return c
+    }
+}

--- a/android/app/src/test/kotlin/com/elodin/walkie_talkie/HostAdvertiserPayloadTest.kt
+++ b/android/app/src/test/kotlin/com/elodin/walkie_talkie/HostAdvertiserPayloadTest.kt
@@ -1,0 +1,122 @@
+package com.elodin.walkie_talkie
+
+import android.content.Context
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.util.UUID
+
+/**
+ * Unit tests for the manufacturer payload encoding in HostAdvertiser.
+ *
+ * The payload layout (docs/protocol.md § "Bluetooth LE advertising"):
+ *   [0]    protocol version (0x01 for v1)
+ *   [1]    role (0x01 = host)
+ *   [2..9] low 8 bytes of sessionUuid (leastSignificantBits, big-endian)
+ *   [10..15] reserved zeros
+ */
+class HostAdvertiserPayloadTest {
+
+    private lateinit var advertiser: HostAdvertiser
+
+    @Before
+    fun setup() {
+        // Context is only used in start()/stop() — the advertiser stores it but
+        // buildManufacturerPayload is a pure algorithm that touches no Android APIs.
+        advertiser = HostAdvertiser(mock(Context::class.java))
+    }
+
+    @Test
+    fun payloadLengthIs16() {
+        val payload = advertiser.buildManufacturerPayload("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e")
+        assertEquals(16, payload.size)
+    }
+
+    @Test
+    fun payloadProtocolVersionIsV1() {
+        val payload = advertiser.buildManufacturerPayload("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e")
+        assertEquals(0x01.toByte(), payload[0])
+    }
+
+    @Test
+    fun payloadRoleIsHost() {
+        val payload = advertiser.buildManufacturerPayload("8e5e8e8e-8e8e-4e8e-8e8e-8e8e8e8e8e8e")
+        assertEquals(0x01.toByte(), payload[1])
+    }
+
+    @Test
+    fun payloadEncodesUuidLsbBigEndian() {
+        val uuidStr = "12345678-1234-1234-1234-abcdef012345"
+        val uuid = UUID.fromString(uuidStr)
+        val lsb = uuid.leastSignificantBits
+        val payload = advertiser.buildManufacturerPayload(uuidStr)
+
+        for (i in 0..7) {
+            val expected = ((lsb ushr (56 - i * 8)) and 0xFFL).toByte()
+            assertEquals("payload byte ${2 + i} mismatch", expected, payload[2 + i])
+        }
+    }
+
+    @Test
+    fun reservedBytesAreZero() {
+        val payload = advertiser.buildManufacturerPayload("deadbeef-cafe-babe-1234-567890abcdef")
+        for (i in 10..15) {
+            assertEquals("reserved byte $i should be zero", 0.toByte(), payload[i])
+        }
+    }
+
+    @Test
+    fun roundTripLsbExtraction() {
+        val uuidStr = "deadbeef-cafe-babe-1234-567890abcdef"
+        val uuid = UUID.fromString(uuidStr)
+        val payload = advertiser.buildManufacturerPayload(uuidStr)
+
+        var extractedLsb = 0L
+        for (i in 0..7) {
+            extractedLsb = (extractedLsb shl 8) or (payload[2 + i].toLong() and 0xFFL)
+        }
+        assertEquals(uuid.leastSignificantBits, extractedLsb)
+    }
+
+    @Test
+    fun differentUuidsProduceDifferentPayloads() {
+        val p1 = advertiser.buildManufacturerPayload("00000000-0000-0000-0000-000000000001")
+        val p2 = advertiser.buildManufacturerPayload("00000000-0000-0000-0000-000000000002")
+        // At minimum the LSB byte should differ
+        val differs = p1.indices.any { p1[it] != p2[it] }
+        assertEquals(true, differs)
+    }
+
+    @Test
+    fun invalidUuidThrows() {
+        try {
+            advertiser.buildManufacturerPayload("not-a-valid-uuid")
+            fail("expected IllegalArgumentException")
+        } catch (_: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun emptyUuidStringThrows() {
+        try {
+            advertiser.buildManufacturerPayload("")
+            fail("expected IllegalArgumentException")
+        } catch (_: IllegalArgumentException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun allZeroUuidEncodesCorrectly() {
+        val uuidStr = "00000000-0000-0000-0000-000000000000"
+        val payload = advertiser.buildManufacturerPayload(uuidStr)
+        assertEquals(0x01.toByte(), payload[0])
+        assertEquals(0x01.toByte(), payload[1])
+        assertArrayEquals(ByteArray(8), payload.copyOfRange(2, 10))
+        assertArrayEquals(ByteArray(6), payload.copyOfRange(10, 16))
+    }
+}


### PR DESCRIPTION
Closes #310.

## Summary

Adds 48 JVM unit tests (4 new test classes) covering the three Kotlin classes called out in issue #310. All tests pass locally via `./gradlew :app:testDebugUnitTest`.

### GattConstantsTest (10 tests)
- Wire-spec UUID values for SERVICE, REQUEST, RESPONSE, CCCD characteristics
- TARGET_ATT_MTU=247, VOICE_MTU=128
- AUTHORIZATION_ERRORS includes codes 8/5/15; excludes transient codes 133/147

### HostAdvertiserPayloadTest (10 tests)
- **Encode/decode round-trip**: extracting leastSignificantBits from `payload[2..9]` recovers the original UUID LSB (big-endian, per `docs/protocol.md § "Bluetooth LE advertising"`)
- Header bytes: `payload[0]=0x01` (protocol version), `payload[1]=0x01` (host role)
- Reserved bytes `payload[10..15]` are zero
- Invalid/empty UUID strings throw `IllegalArgumentException`

### GattServerManagerTest (13 tests)
- MTU negotiation cache: `getMtu` returns null initially, correct value after `onMtuChanged` fires
- REQUEST characteristic write invokes `onBytesReceived` with correct address and bytes (admit path, issue #293)
- Empty/null write values don't invoke callback
- Write to unknown characteristic is silently ignored (deny path)
- `onConnectionStateChange`: connect adds device, disconnect removes it and clears its MTU entry

### GattClientManagerTest (15 tests)
- MTU cache: `getMtu` null initially, correct after injection/`onMtuChanged` with `GATT_SUCCESS`; `GATT_FAILURE` doesn't update cache
- **133/147/19 retry policy** (issue #100): `connectRetryCount` increments on transient error, `pendingMacAddress` stays set; non-transient disconnect clears both
- Retry stops after `MAX_CONNECT_RETRIES` (5): count never exceeds 5
- RSSI sample cache: populated by `onReadRemoteRssi` success; failure leaves cache empty
- `isConnected` returns false initially

## Implementation notes
- Added `org.mockito:mockito-core:5.11.0` as `testImplementation` — needed to mock Android framework classes (`Context`, `BluetoothGatt`, `BluetoothDevice`, `BluetoothGattCharacteristic`). Mockito 5.x includes the inline mock maker by default, no extra config needed.
- Private `gattCallback` fields accessed via reflection to invoke Android OS callbacks from the test thread — same pattern used in Android unit testing without Robolectric.
- `BluetoothGattServerCallback.onCharacteristicWriteRequest` is a Java method so positional args are required (named args prohibited for non-Kotlin functions).

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — all Dart tests pass
- [x] `bash scripts/run_native_cpp_tests.sh` — all C++ tests pass
- [x] `./gradlew :app:testDebugUnitTest` — **BUILD SUCCESSFUL**, 48 new Kotlin tests pass, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Bluetooth test coverage: MTU negotiation and caching, transient reconnect retry behavior, connection state handling, RSSI sample caching, and characteristic write handling.
  * Added protocol/constant validation tests (UUIDs, MTU values, authorization error sets).
  * Added advertiser payload tests validating payload format, fields, round-trip decoding, and invalid-UUID handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->