### PR TITLE
docs(#320): add POST_NOTIFICATIONS, crash-reporting, and Block & Report smoke tests

### DIFF
--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -17,7 +17,7 @@ Manual end-to-end test procedure for verifying BLE/L2CAP/voice functionality acr
    - `BLUETOOTH_CONNECT`
    - `BLUETOOTH_ADVERTISE`
    - `RECORD_AUDIO`
-   - `POST_NOTIFICATIONS` (Android 13+) — required for the foreground service notification; denial prevents FGS from starting (see step 11)
+   - `POST_NOTIFICATIONS` (Android 13+) — **not** prompted during onboarding; the OS prompts for it the first time the app starts its foreground service (when joining or creating a room). Denial prevents FGS from starting (see step 11)
 
 ### Test Environment Record
 Document for each test run:
@@ -251,7 +251,7 @@ Document for each test run:
 **Device A**:
 1. **Verify**: Snackbar appears: *"Crash reporting enabled. Restart the app to apply."*
 2. Fully close and relaunch the app
-3. **Verify**: App launches without crash, Sentry session is active (observable via Sentry dashboard or proxy: no crash on launch)
+3. **Verify**: Sentry session is active — observable as an outbound HTTPS envelope to `*.sentry.io` in a network proxy (e.g., Charles or mitmproxy), or as a live session appearing in the Sentry dashboard within 30 seconds of launch
 
 **Device A**:
 1. Navigate back to Settings → Privacy
@@ -285,7 +285,7 @@ Document for each test run:
 1. **Verify**: System email sheet opens with:
    - **To**: `support@formalizedchaos.com`
    - **Subject**: `Frequency abuse report`
-   - **Body**: Pre-filled sanitized abuse report (peer ID, timestamp, room context — no raw display names or PII beyond what the user typed)
+   - **Body**: Pre-filled sanitized abuse report containing: timestamp (UTC), frequency (MHz string), peer display name (control characters stripped), and peer BLE device name (control characters stripped)
 
 > **If no email app is installed**: Tap **Copy report** instead and verify the clipboard contains the report text.
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -217,6 +217,7 @@ Document for each test run:
 ---
 
 ### 11. POST_NOTIFICATIONS Denial Path (Android 13+ only)
+
 **Prerequisites**: Device running Android 13+ (API 33+). Fresh install or cleared app data so the permission prompt reappears.
 
 **Device A** (Alice):
@@ -239,6 +240,7 @@ Document for each test run:
 ---
 
 ### 12. Crash Reporting Toggle Round-Trip
+
 **Prerequisites**: Build compiled with a Sentry DSN (`kSentryConfigured = true`); otherwise the toggle is read-only and this section is not applicable.
 
 **Device A**:
@@ -267,6 +269,7 @@ Document for each test run:
 ---
 
 ### 13. Block & Report
+
 **Prerequisites**: Two devices in the same Frequency room (Alice hosting, Bob joined).
 
 **Device A** (Alice):

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -17,6 +17,7 @@ Manual end-to-end test procedure for verifying BLE/L2CAP/voice functionality acr
    - `BLUETOOTH_CONNECT`
    - `BLUETOOTH_ADVERTISE`
    - `RECORD_AUDIO`
+   - `POST_NOTIFICATIONS` (Android 13+) — required for the foreground service notification; denial prevents FGS from starting (see step 11)
 
 ### Test Environment Record
 Document for each test run:
@@ -215,6 +216,81 @@ Document for each test run:
 
 ---
 
+### 11. POST_NOTIFICATIONS Denial Path (Android 13+ only)
+**Prerequisites**: Device running Android 13+ (API 33+). Fresh install or cleared app data so the permission prompt reappears.
+
+**Device A** (Alice):
+1. Launch app and proceed through onboarding
+2. When the notification permission dialog appears, tap **Don't allow**
+3. Tap **Start a new Frequency** to create a room
+
+**Device A**:
+1. **Verify**: App does not crash
+2. **Verify**: A descriptive error or warning is shown (toast, dialog, or permission-denied screen) — the app must not silently proceed as if the foreground service started normally
+3. **Verify**: Tapping the prompt (if shown) to open Settings lets the user grant the permission and retry
+
+> **Note:** On some OEM/Android combinations the foreground service notification may still appear due to OS-level exceptions. Document the outcome — pass or deviation — with device model and API level.
+
+**Pass/Fail**: ☐ Pass ☐ Fail  
+**Device model / API level**: _____________  
+**Observed behaviour**: _______________________________________________  
+**Notes**: _______________________________________________
+
+---
+
+### 12. Crash Reporting Toggle Round-Trip
+**Prerequisites**: Build compiled with a Sentry DSN (`kSentryConfigured = true`); otherwise the toggle is read-only and this section is not applicable.
+
+**Device A**:
+1. Navigate to **Settings** (gear icon or overflow menu in the room or discovery screen)
+2. Locate **Crash reporting** toggle under Privacy
+3. Enable the toggle
+
+**Device A**:
+1. **Verify**: Snackbar appears: *"Crash reporting enabled. Restart the app to apply."*
+2. Fully close and relaunch the app
+3. **Verify**: App launches without crash, Sentry session is active (observable via Sentry dashboard or proxy: no crash on launch)
+
+**Device A**:
+1. Navigate back to Settings → Privacy
+2. Disable the **Crash reporting** toggle
+
+**Device A**:
+1. **Verify**: Snackbar appears: *"Crash reporting disabled. Restart the app to apply."*
+2. Fully close and relaunch the app
+3. **Verify**: No Sentry network traffic is initiated (no outbound connections to `*.sentry.io`)
+
+**Pass/Fail (enable)**: ☐ Pass ☐ Fail  
+**Pass/Fail (disable)**: ☐ Pass ☐ Fail  
+**Notes**: _______________________________________________
+
+---
+
+### 13. Block & Report
+**Prerequisites**: Two devices in the same Frequency room (Alice hosting, Bob joined).
+
+**Device A** (Alice):
+1. Tap **Bob's avatar** or name in the room roster to open the peer drawer
+2. Tap the **Report** button in the peer drawer
+
+**Device A**:
+1. **Verify**: "Bob blocked" dialog appears with message indicating Bob has been muted and blocked
+2. **Verify**: Bob's entry in the roster now shows a muted indicator
+3. Tap **Email report**
+
+**Device A**:
+1. **Verify**: System email sheet opens with:
+   - **To**: `support@formalizedchaos.com`
+   - **Subject**: `Frequency abuse report`
+   - **Body**: Pre-filled sanitized abuse report (peer ID, timestamp, room context — no raw display names or PII beyond what the user typed)
+
+> **If no email app is installed**: Tap **Copy report** instead and verify the clipboard contains the report text.
+
+**Pass/Fail**: ☐ Pass ☐ Fail  
+**Notes**: _______________________________________________
+
+---
+
 ## Known Risks & Failure Modes
 
 ### OEM Bluetooth Roulette
@@ -265,7 +341,7 @@ Document for each test run:
 
 ## Test Completion Checklist
 
-- ☐ All 10 test steps executed
+- ☐ All 13 test steps executed (steps 11–13 require specific device/build conditions — see prerequisites)
 - ☐ Device models + Android versions recorded
 - ☐ Pass/Fail status marked for each step
 - ☐ Timing measurements recorded (where applicable)


### PR DESCRIPTION
Closes #320.

## Problem

`docs/smoke-test.md` listed only four runtime permissions in its Pre-flight section and had no test steps for three shipped, user-visible features:

- `POST_NOTIFICATIONS` (Android 13+) is runtime-grant-required and its denial prevents the foreground service from starting — yet the smoke test didn't ask testers to verify the denial path.
- The Settings → Privacy → Crash reporting toggle is a v1 user-visible Data Safety surface; not smoke-tested.
- The Block & Report flow (peer drawer → Report) is required by `play-store-content-rating.md` but was never smoke-tested.

## Fix

Added three new test sections to `docs/smoke-test.md`:

**Step 11 — POST_NOTIFICATIONS Denial Path (Android 13+)**  
Grant all other permissions but deny `POST_NOTIFICATIONS` during onboarding; verify the app fails gracefully (no crash, descriptive error shown) rather than silently proceeding with a dead foreground service.

**Step 12 — Crash Reporting Toggle Round-Trip**  
Toggle ON → verify *"Crash reporting enabled. Restart the app to apply."* snackbar → restart → Sentry active. Toggle OFF → verify *"Crash reporting disabled. Restart the app to apply."* snackbar → restart → no Sentry traffic.

**Step 13 — Block & Report**  
Tap a peer avatar in the room → peer drawer → Report → verify "blocked" dialog and muted indicator → tap **Email report** → verify email sheet with subject `Frequency abuse report` and pre-filled body to `support@formalizedchaos.com`.

Also:
- Annotated `POST_NOTIFICATIONS` in the Pre-flight permissions list with a note that denial blocks FGS start.
- Updated completion checklist from 10 to 13 test steps (with note that steps 11–13 have prerequisites).

## Test plan

- [x] `flutter analyze` — no issues (839 tests pass via `bash scripts/presubmit.sh`)
- [x] `flutter test` — 839/839 pass
- [x] Formatting clean
- [x] All C++ native tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated smoke-test runbook with Android 13+ notification handling and denial effects
  * Added POST_NOTIFICATIONS to onboarding permissions checklist and denial verification
  * Added crash-reporting toggle round-trip test (enable, restart, disable, verify outbound reports)
  * Added block-and-report flow test (muted/blocked roster state and prefilled email or clipboard fallback)
  * Expanded completion checklist to 13 steps; steps 11–13 gated by prerequisites
<!-- end of auto-generated comment: release notes by coderabbit.ai -->