### PR TITLE
feat(#318): scope user CA trust to sentry.io domain only

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -7,18 +7,28 @@
 
   Policy:
   - Cleartext (HTTP) traffic is forbidden globally.
-  - TLS to any host is permitted (Sentry's ingestion endpoint hostname is
-    baked into the DSN at build time via dart-define and may vary per
-    deployment; host-specific pinning would break on cert rotation so we
-    rely on the system trust store and Sentry's TLS instead).
+  - User-installed CAs (enterprise TLS-inspection proxies) are trusted only
+    for Sentry's ingestion hosts; they are not trusted globally.
+  - Certificate pinning is intentionally omitted — the Sentry DSN host is
+    baked into the DSN at build time and may vary per deployment; pinning
+    would break on cert rotation.
 -->
 <network-security-config>
+    <!-- Global policy: no cleartext, system trust store only. -->
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
-            <!-- Also trust user-installed CAs so devices behind enterprise
-                 TLS-inspection proxies can still upload crash reports. -->
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+
+    <!-- Sentry crash reporting — the only intended external endpoint.
+         Also trust user-installed CAs so devices behind enterprise
+         TLS-inspection proxies can still upload crash reports. -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">sentry.io</domain>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary

Closes #318.

The existing `network_security_config.xml` (added in #334 for #308) set cleartext to `false` globally and trusted both system and user-installed CAs in `base-config`. This meant user-installed CA roots (e.g. enterprise TLS-inspection proxies) were trusted for **all** TLS connections, not just Sentry.

This PR tightens that:

- **`base-config`**: system CAs only — cleartext still forbidden.
- **New `domain-config` for `*.sentry.io`**: trusts both system and user CAs so devices behind enterprise TLS-inspection proxies can still upload crash reports.

This makes the security posture auditable: the config now explicitly names Sentry as the sole intended external endpoint and limits the blast radius of any user-installed CA to only that domain.

Certificate pinning is intentionally omitted — the Sentry DSN host is baked into the DSN at build time and may vary per deployment; pinning would break on cert rotation.

## Test plan

- [ ] `bash scripts/presubmit.sh` passes (format + analyze + flutter test + native C++ tests)
- [ ] Android build succeeds with `network_security_config` referenced correctly
- [ ] No regression in Sentry crash-report upload (user CA trust preserved for `*.sentry.io`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network security by disabling unencrypted traffic globally and restricting certificate authority trust exclusively to crash reporting services, while maintaining compatibility with enterprise network environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->