### PR TITLE
ci: raise debug AAB budget from 30 MiB to 100 MiB regression alarm

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -81,7 +81,8 @@ jobs:
 
           AAB="build/app/outputs/bundle/debug/app-debug.aab"
           if [ ! -f "$AAB" ]; then
-            echo "AAB not found at $AAB — skipping size check"; exit 0
+            echo "::error::AAB not found at $AAB — Gradle output path may have changed. Update this step rather than letting the regression alarm silently no-op."
+            exit 1
           fi
 
           SIZE_BYTES=$(stat -c%s "$AAB")

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -70,7 +70,7 @@ jobs:
       # a signed release AAB. Holding a debug bundle to 30 MiB was a category
       # error (every PR fails); this step keeps the cheap on-disk regression
       # catch with a budget proportionate to debug-mode reality.
-      - name: Measure AAB size (debug, < 100 MiB regression alarm)
+      - name: Measure AAB size (debug, ≤ 100 MiB regression alarm)
         continue-on-error: false
         run: |
           set -euo pipefail

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -57,10 +57,20 @@ jobs:
         working-directory: android
         run: ./gradlew :app:testDebugUnitTest --no-daemon
 
-      # App size budget (issue #131): build a debug AAB and enforce the
-      # < 30 MB download-size target. Uses the debug keystore so no signing
-      # credentials are needed.
-      - name: Measure AAB size (< 30 MB budget)
+      # Debug AAB regression alarm (issue #131): build a debug AAB and fail
+      # fast on catastrophic on-disk bloat (e.g., accidentally vendored binary
+      # blob, fat-APK misconfig). Uses the debug keystore so no signing
+      # credentials are needed on PR builds from forks.
+      #
+      # NOT the per-device Play download number. A debug AAB intrinsically
+      # carries ~80 MiB of kernel_blob.bin + debug libflutter.so + Vulkan
+      # validation layer that a release AAB does not. The 30 MiB target from
+      # #131 is the per-device download served by Play after ABI/density/lang
+      # split — that number is measured by release.yml via bundletool against
+      # a signed release AAB. Holding a debug bundle to 30 MiB was a category
+      # error (every PR fails); this step keeps the cheap on-disk regression
+      # catch with a budget proportionate to debug-mode reality.
+      - name: Measure AAB size (debug, < 100 MiB regression alarm)
         continue-on-error: false
         run: |
           set -euo pipefail
@@ -75,12 +85,12 @@ jobs:
           fi
 
           SIZE_BYTES=$(stat -c%s "$AAB")
-          SIZE_MB=$(echo "scale=2; $SIZE_BYTES / 1048576" | bc)
-          echo "AAB size: ${SIZE_MB} MB  (${SIZE_BYTES} bytes)"
+          SIZE_MIB=$(awk "BEGIN { printf \"%.2f\", $SIZE_BYTES / 1048576 }")
+          echo "Debug AAB size: ${SIZE_MIB} MiB  (${SIZE_BYTES} bytes)"
 
-          LIMIT_BYTES=$((30 * 1048576))
+          LIMIT_BYTES=$((100 * 1048576))
           if [ "$SIZE_BYTES" -gt "$LIMIT_BYTES" ]; then
-            echo "::error::AAB exceeds 30 MB budget (${SIZE_MB} MB). Reduce dependencies or assets."
+            echo "::error::Debug AAB exceeds 100 MiB regression alarm (${SIZE_MIB} MiB). This is the on-disk debug bundle, not the Play download — see release.yml for the per-device number measured by bundletool."
             exit 1
           fi
-          echo "::notice::AAB size ${SIZE_MB} MB is within the 30 MB budget."
+          echo "::notice::Debug AAB ${SIZE_MIB} MiB is within the 100 MiB regression alarm."


### PR DESCRIPTION
## Summary

- Every PR has been red on `Measure AAB size` since #348 flipped `continue-on-error` to `false`. The step builds a **debug** AAB and asserts < 30 MiB; debug AABs are intrinsically ~80 MiB (kernel_blob, debug `libflutter.so`, Vulkan validation), so the gate could never pass.
- The 30 MiB target from #131 is the **per-device Play download** after ABI/density/language split. That number is already measured by `release.yml` via bundletool against a signed release AAB (`scripts/measure_app_size.sh`). Holding the on-disk debug bundle to it was a category error.
- Raise the debug budget to a 100 MiB regression alarm proportionate to debug-mode reality. Keeps the cheap catch for accidentally vendored binary blobs / fat-APK misconfig without flapping every PR. Comment clarifies the distinction.
- Swap `bc` → `awk` for the MiB print (bc isn't always preinstalled on minimal runners).

## Local CI (3-gate)

- [x] `bash scripts/presubmit.sh` — analyze + flutter test + native C++ + metadata limits — pass
- [x] `(cd android && ./gradlew :app:testDebugUnitTest --no-daemon)` — pass
- [x] `flutter build appbundle --debug` — built; size 79.00 MiB (< 100 MiB budget)

Sentinel: `db114d7591f1bb9ae49e1c1f3e5fc391a772e633` @ 2026-05-07T03:44:27Z

## Test plan

- [ ] CI on this PR turns green (Flutter CI / build job)
- [ ] Subsequent PRs from routines no longer red on AAB-size step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now enforces an on-disk debug AAB size regression alarm at 100 MiB (previously a stricter 30 MB check) and fails the job if exceeded.
  * Messages and outputs clarified to report the on-disk debug bundle size in MiB with two-decimal precision, treat missing AABs as errors, and provide clearer pass/fail guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->