### PR TITLE
ci: fetch submodules in flutter.yml checkout

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # opus + oboe are git submodules under android/app/src/main/cpp/.
+          # Without this the Gradle CMake step in `Measure AAB size` fails
+          # with "does not contain a CMakeLists.txt file" on the opus path.
+          submodules: recursive
 
       # Run before flutter-action so a metadata character-limit violation
       # fails fast without paying the cost of downloading and caching the

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -12,9 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # opus + oboe are git submodules under android/app/src/main/cpp/.
-          # Without this the Gradle CMake step in `Measure AAB size` fails
-          # with "does not contain a CMakeLists.txt file" on the opus path.
+          # opus is a git submodule at android/app/src/main/cpp/opus (see
+          # .gitmodules). Without this the Gradle CMake step in
+          # `Measure AAB size` fails with "does not contain a CMakeLists.txt
+          # file" on the opus path. oboe is vendored directly (not a
+          # submodule) so checkout already includes it.
           submodules: recursive
 
       # Run before flutter-action so a metadata character-limit violation


### PR DESCRIPTION
## Summary

Follow-up to #353. The `Measure AAB size` step still fails on CI because `actions/checkout@v6` doesn't fetch git submodules by default, so the Gradle CMake configure step dies with:

```
CMake Error at CMakeLists.txt:15 (add_subdirectory):
  The source directory
    /home/runner/work/walkie-talkie/walkie-talkie/android/app/src/main/cpp/opus
  does not contain a CMakeLists.txt file.
```

`opus` and `oboe` are git submodules (see `.gitmodules`). Locally they're already populated so the AAB step passes; on CI the directory is empty after checkout. This step has been broken since opus was vendored as a submodule — `continue-on-error: true` hid it until #325/#348 flipped to false. #353 fixed the budget number; this fixes the build.

## Local CI (3-gate)

- [x] `bash scripts/presubmit.sh` — pass (already verified for #353 base, no Dart/Flutter changes)
- [x] `(cd android && ./gradlew :app:testDebugUnitTest --no-daemon)` — pass
- [x] `flutter build appbundle --debug` → 79.00 MiB AAB (< 100 MiB)

Sentinel matches HEAD.

## Test plan

- [ ] CI on this PR turns green (Flutter CI / build job, including the AAB step)
- [ ] PRs #327 and #332 unblock once this lands and they rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to ensure native build steps complete successfully, preventing build-time failures caused by missing components. This improves reliability of release artifact generation, reduces intermittent pipeline errors, and leads to more consistent, timely deployments. No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->