### PR TITLE
chore(#355): bring presubmit to CI parity + opt-in pre-push hook

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,9 +91,43 @@ bash scripts/measure_app_size.sh
 
 ## presubmit.sh
 
-Runs the full local presubmit gate (formatting, analysis, tests, native
-C++ tests). Mirrors what CI runs on every push.
+Runs the full local presubmit gate. Mirrors what CI
+(`.github/workflows/flutter.yml`) runs on every push:
+
+1. Play Store metadata character-limit validation
+2. `dart format --set-exit-if-changed`
+3. `flutter analyze`
+4. `flutter test`
+5. Native C++ tests (`scripts/run_native_cpp_tests.sh`)
+6. Kotlin unit tests (`./gradlew :app:testDebugUnitTest --no-daemon`)
 
 ```bash
 bash scripts/presubmit.sh
 ```
+
+Step 6 is skipped automatically if `android/gradlew` is not executable
+(rare; once-per-clone fix is `chmod +x android/gradlew`). The CI AAB
+size measurement step is intentionally not mirrored — it requires a
+full JDK setup and a debug build, which add minutes for low local
+regression value.
+
+## install-git-hooks.sh
+
+Installs an opt-in `pre-push` git hook that runs `presubmit.sh` before
+every `git push`. A failing presubmit aborts the push so a CI
+round-trip is not spent on a regression a local run would have caught.
+
+```bash
+bash scripts/install-git-hooks.sh
+```
+
+Idempotent (re-running replaces the hook in place). Bypass for
+emergencies:
+
+```bash
+git push --no-verify
+```
+
+The hook resolves the hooks directory via `git rev-parse --git-path
+hooks` so it works inside worktrees and with custom `core.hooksPath`
+configurations.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,25 +91,31 @@ bash scripts/measure_app_size.sh
 
 ## presubmit.sh
 
-Runs the full local presubmit gate. Mirrors what CI
-(`.github/workflows/flutter.yml`) runs on every push:
+Runs the full local presubmit gate. A **superset** of what CI
+(`.github/workflows/flutter.yml`) runs — designed to catch every
+regression CI would catch, plus a couple of local-only checks so
+the contributor doesn't burn a CI round-trip on a fixable local
+issue:
 
-1. Play Store metadata character-limit validation
-2. `dart format --set-exit-if-changed`
-3. `flutter analyze`
-4. `flutter test`
-5. Native C++ tests (`scripts/run_native_cpp_tests.sh`)
-6. Kotlin unit tests (`./gradlew :app:testDebugUnitTest --no-daemon`)
+1. Play Store metadata character-limit validation *(also in CI)*
+2. `dart format --set-exit-if-changed` *(local-only — CI does not
+   enforce formatting; this is a contributor convenience)*
+3. `flutter analyze` *(also in CI)*
+4. `flutter test` *(without `--coverage`; CI runs the coverage variant
+   and uploads to Codecov, which is not informative locally)*
+5. Native C++ tests via `scripts/run_native_cpp_tests.sh` *(also in CI)*
+6. Kotlin unit tests: `./gradlew :app:testDebugUnitTest --no-daemon`
+   *(also in CI; auto-skipped when `android/gradlew` is not executable —
+   once-per-clone fix is `chmod +x android/gradlew`)*
 
 ```bash
 bash scripts/presubmit.sh
 ```
 
-Step 6 is skipped automatically if `android/gradlew` is not executable
-(rare; once-per-clone fix is `chmod +x android/gradlew`). The CI AAB
-size measurement step is intentionally not mirrored — it requires a
-full JDK setup and a debug build, which add minutes for low local
-regression value.
+**Intentionally NOT mirrored from CI**: the debug-AAB size regression
+alarm. It requires a full JDK setup and a `flutter build appbundle`,
+adding minutes for low local-regression value (the AAB rarely changes
+outside of dependency churn).
 
 ## install-git-hooks.sh
 
@@ -121,13 +127,20 @@ round-trip is not spent on a regression a local run would have caught.
 bash scripts/install-git-hooks.sh
 ```
 
-Idempotent (re-running replaces the hook in place). Bypass for
-emergencies:
+Re-runnable: a hook this script already installed (detected via a
+marker comment) is replaced in place. A pre-existing hook *not*
+installed by this script (husky / lefthook / hand-rolled) is **not**
+clobbered — it gets backed up to `pre-push.bak.<UTC-timestamp>` next
+to itself, with a stdout message, so you can merge in the presubmit
+step manually if you want both.
+
+Bypass for emergencies:
 
 ```bash
 git push --no-verify
 ```
 
-The hook resolves the hooks directory via `git rev-parse --git-path
-hooks` so it works inside worktrees and with custom `core.hooksPath`
-configurations.
+The hook directory is resolved via `git rev-parse
+--path-format=absolute --git-path hooks` so the path is absolute
+across linked worktrees and custom `core.hooksPath` configurations.
+Requires git ≥ 2.31 (January 2021).

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -14,14 +14,30 @@ set -e
 cd "$(dirname "$0")/.."
 
 # Resolve the real hooks directory. Worktrees and core.hooksPath both
-# move it away from .git/hooks; ask git rather than guessing.
-HOOKS_DIR="$(git rev-parse --git-path hooks)"
+# move it away from .git/hooks; ask git rather than guessing. Force an
+# absolute path so the result survives the `cd` above — without
+# --path-format=absolute, linked worktrees can return a relative path
+# that resolves against the current working directory. Requires
+# git ≥ 2.31 (January 2021).
+HOOKS_DIR="$(git rev-parse --path-format=absolute --git-path hooks)"
 
 if [ ! -d "$HOOKS_DIR" ]; then
   mkdir -p "$HOOKS_DIR"
 fi
 
 HOOK="$HOOKS_DIR/pre-push"
+MARKER="Auto-installed by scripts/install-git-hooks.sh"
+
+# If a contributor already has their own pre-push hook (husky, lefthook,
+# manual setup, etc.) silently overwriting it would lose their work.
+# Back it up so they can merge in the presubmit step manually if they
+# want both. Re-running the installer over an already-installed hook is
+# fine — those carry the MARKER and get replaced in place.
+if [ -f "$HOOK" ] && ! grep -qF "$MARKER" "$HOOK"; then
+  BACKUP="$HOOK.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+  cp "$HOOK" "$BACKUP"
+  echo "Existing pre-push hook (not auto-installed) backed up to $BACKUP"
+fi
 
 cat > "$HOOK" <<'EOF'
 #!/bin/bash

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Installs an opt-in `pre-push` git hook that runs scripts/presubmit.sh
+# before every `git push`. A failing presubmit aborts the push so a CI
+# round-trip is not spent on a regression a local run would have caught.
+#
+# Idempotent: running this twice replaces the existing hook in place.
+# Bypass: `git push --no-verify` skips the hook for genuine emergencies.
+#
+# Run once per clone:
+#   bash scripts/install-git-hooks.sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Resolve the real hooks directory. Worktrees and core.hooksPath both
+# move it away from .git/hooks; ask git rather than guessing.
+HOOKS_DIR="$(git rev-parse --git-path hooks)"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+  mkdir -p "$HOOKS_DIR"
+fi
+
+HOOK="$HOOKS_DIR/pre-push"
+
+cat > "$HOOK" <<'EOF'
+#!/bin/bash
+# Auto-installed by scripts/install-git-hooks.sh. Runs the local CI mirror
+# before every push; bypass with `git push --no-verify` if you need to
+# push a partial branch (and accept the CI round-trip).
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PRESUBMIT="$REPO_ROOT/scripts/presubmit.sh"
+
+if [ ! -f "$PRESUBMIT" ]; then
+  echo "pre-push: $PRESUBMIT not found, skipping local CI." >&2
+  exit 0
+fi
+
+echo "pre-push: running scripts/presubmit.sh (use 'git push --no-verify' to skip)"
+bash "$PRESUBMIT"
+EOF
+
+chmod +x "$HOOK"
+
+echo "Installed pre-push hook at $HOOK"
+echo "Bypass with: git push --no-verify"

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -20,3 +20,16 @@ flutter test
 
 echo "Building & running native C++ tests..."
 bash scripts/run_native_cpp_tests.sh
+
+# Kotlin unit tests run in CI as `./gradlew :app:testDebugUnitTest --no-daemon`
+# (see .github/workflows/flutter.yml). Mirror that here so a Kotlin regression
+# (e.g. the L2CAP framing tests) is caught locally instead of on the next push.
+# Skip on platforms where Gradle is unavailable; on Windows the script is
+# typically invoked from WSL where gradlew works as on Linux/macOS.
+if [ -x "android/gradlew" ]; then
+  echo "Running Kotlin unit tests..."
+  (cd android && ./gradlew :app:testDebugUnitTest --no-daemon)
+else
+  echo "Skipping Kotlin unit tests: android/gradlew not executable."
+  echo "If this is a real environment, run 'chmod +x android/gradlew' once."
+fi


### PR DESCRIPTION
Closes #355.

## Summary
Two small additions so contributors can catch CI regressions locally before the round-trip:

- **`scripts/presubmit.sh`** now runs `./gradlew :app:testDebugUnitTest --no-daemon`, matching the Kotlin unit-test step in `.github/workflows/flutter.yml`. The previous version of the script ran format / analyze / `flutter test` / native C++ tests but skipped Kotlin entirely, so a Kotlin regression (e.g. `L2capFramingTest.kt`) only surfaced in CI after a push. The step is auto-skipped when `android/gradlew` is not executable so the script still works in a fresh clone before `chmod +x`.
- **`scripts/install-git-hooks.sh`** (new) installs an opt-in `pre-push` git hook that runs `presubmit.sh` before every `git push`. Idempotent, worktree-aware (resolves the hook directory via `git rev-parse --git-path hooks`), and bypassable with `git push --no-verify` for emergencies.
- **`scripts/README.md`** documents both, including the explicit reasoning for *not* mirroring the CI AAB-size step locally (slow, needs full JDK setup, low regression value compared to test suites).

## Why
Per [#355](https://github.com/ElodinLaarz/walkie-talkie/issues/355): running `presubmit.sh` was opt-in, easy to forget, and missing the Kotlin step. Both gaps wasted CI minutes on regressions a local run would have caught. Hook installation stays opt-in (no Husky-style mandatory tooling) so contributors who prefer manual checks are unaffected.

## Reviewer notes
- The pre-push hook script is written into `$(git rev-parse --git-path hooks)/pre-push`, which correctly resolves to the per-worktree hooks dir (or to a custom `core.hooksPath` if set), instead of hard-coding `.git/hooks/pre-push`.
- Hook bypass remains `git push --no-verify` — surfaced in both the install script's stdout and the hook's own pre-run echo so a developer who hits a one-off issue isn't stuck.
- The `if [ -x "android/gradlew" ]` guard is for first-clone ergonomics on Windows/WSL where the executable bit may not propagate. The CI workflow does not need this guard since CI runs after a fresh checkout on Linux.

## Test plan
- [x] `bash scripts/presubmit.sh` — passes end-to-end on this branch (Gradle build successful, 173 actionable tasks, all prior steps green; verified locally in WSL Debian)
- [ ] Run `bash scripts/install-git-hooks.sh` in a fresh clone, confirm `pre-push` hook is installed and fires on next `git push`
- [ ] Confirm `git push --no-verify` skips the hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded local presubmit gate docs with step-by-step order and note that CI debug-AAB size check is not mirrored locally.
  * Added docs for an opt-in git hook installer, bypass instructions, and absolute hook-path resolution.

* **Chores**
  * Added an opt-in pre-push hook installer that is idempotent, preserves/backups existing hooks, prints install details, and supports bypass.
  * Presubmit now conditionally runs Kotlin unit tests when the Android wrapper is executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->