### PR TITLE
fix(#304): redact PII inside tag values, not just PII-named tag keys

### DIFF
--- a/lib/services/sentry_event_sanitizer.dart
+++ b/lib/services/sentry_event_sanitizer.dart
@@ -207,10 +207,16 @@ SentryEvent? sanitizeSentryEvent(SentryEvent event) {
     }
   }
 
-  // Strip PII-keyed tags.
+  // Strip PII-keyed tags AND redact PII inside surviving tag values. Without
+  // the value pass, a tag like `endpoint=AA:BB:CC:DD:EE:FF` or
+  // `route=peerId=abc-123` would forward verbatim — the docstring promises
+  // tags are covered, so cover them.
   final tags = event.tags;
-  if (tags != null && tags.keys.any(_isPiiKey)) {
-    event.tags = Map.fromEntries(tags.entries.where((e) => !_isPiiKey(e.key)));
+  if (tags != null) {
+    event.tags = <String, String>{
+      for (final e in tags.entries)
+        if (!_isPiiKey(e.key)) e.key: _redactMessage(e.value),
+    };
   }
 
   // Redact breadcrumbs in-place (Breadcrumb is mutable in sentry 9.x).

--- a/test/services/sentry_event_sanitizer_test.dart
+++ b/test/services/sentry_event_sanitizer_test.dart
@@ -73,6 +73,25 @@ void main() {
       expect(result.tags!['version'], '1.0');
     });
 
+    test('redacts MAC inside surviving tag values', () {
+      final event = SentryEvent(
+        tags: {'endpoint': 'AA:BB:CC:DD:EE:FF', 'version': '1.0'},
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.tags!['endpoint'], '[MAC_REDACTED]');
+      expect(result.tags!['version'], '1.0');
+    });
+
+    test('redacts peerId inside surviving tag values', () {
+      final event = SentryEvent(
+        tags: {'route': 'peerId=abc-123', 'version': '1.0'},
+      );
+      final result = sanitizeSentryEvent(event)!;
+      expect(result.tags!['route'], contains('[REDACTED]'));
+      expect(result.tags!['route'], isNot(contains('abc-123')));
+      expect(result.tags!['version'], '1.0');
+    });
+
     test('redacts peerId key in breadcrumb data', () {
       final event = SentryEvent(
         breadcrumbs: [


### PR DESCRIPTION
Follow-up to [#327](https://github.com/ElodinLaarz/walkie-talkie/pull/327) (already merged). Addresses the unmerged \"redact tag values\" CodeRabbit finding (severity: 🟠 Major) on that PR.

## Summary
The previous tag pass only filtered entries whose **key** matched `_isPiiKey`. Surviving tags like `endpoint=AA:BB:CC:DD:EE:FF` or `route=peerId=abc-123` would forward to Sentry verbatim, contradicting the sanitizer docstring claim that tags are covered.

This PR runs every kept value through `_redactMessage` so MAC addresses and `peerId=…` strings get the same treatment as breadcrumbs, request URLs, and message params.

## What changed
- [lib/services/sentry_event_sanitizer.dart](https://github.com/ElodinLaarz/walkie-talkie/blob/fix/304-redact-tag-values/lib/services/sentry_event_sanitizer.dart): tag-pass now iterates entries, drops PII-keyed ones, and redacts surviving values via `_redactMessage`.
- [test/services/sentry_event_sanitizer_test.dart](https://github.com/ElodinLaarz/walkie-talkie/blob/fix/304-redact-tag-values/test/services/sentry_event_sanitizer_test.dart): two new tests covering MAC-in-value and peerId-in-value cases.

## Why
The Data Safety attestation promises no app-controlled identifiers reach Sentry. A surviving tag value that interpolates a BT MAC or peerId would break that promise even though no obvious tag key looks PII-bearing.

## Test plan
- [x] `flutter analyze` — clean (0 issues)
- [x] `flutter test test/services/sentry_event_sanitizer_test.dart` — 43/43 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced privacy protection by ensuring all personally identifiable information—including embedded identifiers within error event metadata—is fully redacted before transmission to external error tracking systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->