### PR TITLE
fix(#364): prune ghost rooms via periodic TTL timer

### DIFF
--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -21,6 +21,10 @@ class DiscoveryService {
   _discovered = {};
   StreamSubscription? _scanSubscription;
 
+  /// Fires [_emit] on a fixed cadence so stale entries are pruned even when
+  /// no BLE advertisements arrive (e.g. every host went silent simultaneously).
+  Timer? _pruneTimer;
+
   /// Starts scanning for Frequency advertisements.
   Future<void> startScan() async {
     // 1. Check if Bluetooth is available and on.
@@ -41,6 +45,11 @@ class DiscoveryService {
 
     _discovered.clear();
     _emit();
+
+    // Prune stale entries on a regular cadence so closed rooms disappear even
+    // when the OS delivers no new scan events (e.g. the only host went away).
+    _pruneTimer?.cancel();
+    _pruneTimer = Timer.periodic(freshnessWindow ~/ 2, (_) => _emit());
 
     // 2. Listen for scan results.
     // onScanResults is preferred over scanResults: it does not replay stale
@@ -77,6 +86,8 @@ class DiscoveryService {
 
   /// Stops the active scan.
   Future<void> stopScan() async {
+    _pruneTimer?.cancel();
+    _pruneTimer = null;
     await FlutterBluePlus.stopScan();
     await _scanSubscription?.cancel();
     _scanSubscription = null;

--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -46,11 +46,6 @@ class DiscoveryService {
     _discovered.clear();
     _emit();
 
-    // Prune stale entries on a regular cadence so closed rooms disappear even
-    // when the OS delivers no new scan events (e.g. the only host went away).
-    _pruneTimer?.cancel();
-    _pruneTimer = Timer.periodic(freshnessWindow ~/ 2, (_) => _emit());
-
     // 2. Listen for scan results.
     // onScanResults is preferred over scanResults: it does not replay stale
     // results after scanning stops, avoiding a spurious re-emission on the
@@ -82,6 +77,12 @@ class DiscoveryService {
       // We remove the timeout to let the user control pausing/scanning
       // and prevent silent timeout failures (Thread 5, 11).
     );
+
+    // Start prune timer only after scan starts successfully. This prevents a
+    // resource leak where a failed startScan leaves the timer firing into a
+    // scan-less void.
+    _pruneTimer?.cancel();
+    _pruneTimer = Timer.periodic(freshnessWindow ~/ 2, (_) => _emit());
   }
 
   /// Stops the active scan.

--- a/test/services/bluetooth_discovery_service_test.dart
+++ b/test/services/bluetooth_discovery_service_test.dart
@@ -286,4 +286,15 @@ void main() {
     // The pruning logic itself is simple (_emit removes entries older than
     // freshnessWindow) and is covered by code inspection.
   });
+
+  group('DiscoveryService prune timer', () {
+    test('prune timer period is half the freshness window', () {
+      // Timer fires at freshnessWindow ~/ 2 = 5 s so a host that stops
+      // advertising is removed within at most 1.5× the freshness window
+      // (worst case: entry added just after a prune tick, then one full
+      // freshnessWindow elapses, then the next tick fires).
+      final halfWindow = DiscoveryService.freshnessWindow ~/ 2;
+      expect(halfWindow, const Duration(seconds: 5));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Closes #364.

- **Root cause:** `_emit()` in `DiscoveryService` was only called when the OS delivered BLE scan events. When the only nearby host closed its app or moved out of range, no further events arrived, so the existing 10-second `freshnessWindow` TTL was never evaluated and the stale entry stayed in the discovery list indefinitely.
- **Fix:** Start a `Timer.periodic(freshnessWindow ~/ 2)` alongside the scan subscription in `startScan()`. The timer fires `_emit()` every 5 s regardless of BLE traffic, guaranteeing rooms age out within at most 1.5× the freshness window (~15 s worst case) after a host disappears. Timer is cancelled in `stopScan()` and `dispose()`.
- **No new fields or protocol changes** — the existing `_discovered` map and `freshnessWindow` constant are reused unchanged.

## Test plan

- [x] `bash scripts/presubmit.sh` — flutter analyze clean, all 867 Dart tests pass, Kotlin unit tests pass (BUILD SUCCESSFUL)
- [x] AAB size: 79 MiB (< 100 MiB regression alarm)
- [x] New test: `prune timer period is half the freshness window` documents the 5 s cadence and the worst-case ~15 s age-out bound
- [ ] On-device: host a room on device A, confirm device B discovers it, kill app on A, verify discovery entry disappears within ~15 s without touching device B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Bluetooth discovery now automatically removes outdated device sessions periodically, ensuring a cleaner results list even when no new device advertisements are detected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/373)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->