### PR TITLE
fix(#363): show actual frequency in room section label

### DIFF
--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -806,7 +806,8 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             SectionLabel(
-                              text: 'On this frequency · ${peers.length + 1}',
+                              text:
+                                  'On ${widget.freq} MHz · ${peers.length + 1}',
                               trailing: Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -264,7 +264,8 @@ void main() {
 
         // No mock peer roster — single-user room shows just the local user
         // (acceptance criterion for #105). SectionLabel uppercases its text.
-        expect(find.text('ON THIS FREQUENCY · 1'), findsOneWidget);
+        // freq is embedded in the label so users see the actual channel (#363).
+        expect(find.text('ON 104.3 MHZ · 1'), findsOneWidget);
       },
     );
 


### PR DESCRIPTION
## Summary

Resolves #363.

The in-room section label hardcoded `'On this frequency · N'` where `N` is the peer count. When only one person was in the room this rendered as `'ON THIS FREQUENCY · 1'`, which read as "frequency 1" — a placeholder rather than the actual channel.

Replace the generic label with `'On {freq} MHz · N'` so the section heading embeds the host-advertised `mhzDisplay` value (e.g. `'ON 104.3 MHZ · 1'`).

The chrome pill already showed the frequency (`'On air · 104.3'`), but the section label is the most prominent heading-level text on the peer list and the one a user reading the screen would interpret as the room title.

## Changes

- `lib/screens/frequency_room_screen.dart` — section label now reads `'On ${widget.freq} MHz · ${peers.length + 1}'`
- `test/screens/frequency_room_screen_test.dart` — assertion updated to `'ON 104.3 MHZ · 1'`

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 866/866 passed (including updated room screen test)
- [x] Kotlin unit tests pass
- [x] Debug AAB builds successfully (79 MiB ≤ 100 MiB budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)