### PR TITLE
feat(#365): add pull-to-refresh to discovery screen

### DIFF
--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -187,82 +187,91 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
               ],
             ),
             Expanded(
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
-                children: [
-                  _buildHero(context),
-                  const SizedBox(height: 24),
-                  _buildCreateCard(context),
-                  if (widget.recentHostedFrequencies.isNotEmpty) ...[
-                    SectionLabel(text: l10n.discoverySectionRecent),
-                    _buildRecentList(context),
-                  ],
-                  SectionLabel(
-                    text: l10n.discoverySectionNearby,
-                    trailing: _buildScanIndicator(context),
-                  ),
-                  _buildNearbyList(context),
-                  const SizedBox(height: 14),
-                  Center(
-                    child: Text(
-                      l10n.discoveryFooter,
-                      style: TextStyle(
-                        fontFamily: 'Inter',
-                        fontSize: 12,
-                        color: c.ink3,
+              child: RefreshIndicator(
+                onRefresh: _refreshDiscovery,
+                child: ListView(
+                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
+                  children: [
+                    _buildHero(context),
+                    const SizedBox(height: 24),
+                    _buildCreateCard(context),
+                    if (widget.recentHostedFrequencies.isNotEmpty) ...[
+                      SectionLabel(text: l10n.discoverySectionRecent),
+                      _buildRecentList(context),
+                    ],
+                    SectionLabel(
+                      text: l10n.discoverySectionNearby,
+                      trailing: _buildScanIndicator(context),
+                    ),
+                    _buildNearbyList(context),
+                    const SizedBox(height: 14),
+                    Center(
+                      child: Text(
+                        l10n.discoveryFooter,
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 12,
+                          color: c.ink3,
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 4),
-                  // Wrap instead of Row: three links + two separators may
-                  // overflow narrow viewports in a single row.
-                  Wrap(
-                    alignment: WrapAlignment.center,
-                    crossAxisAlignment: WrapCrossAlignment.center,
-                    children: [
-                      _FooterLink(
-                        label: l10n.discoveryFooterPrivacy,
-                        onPressed: _openPrivacyPolicy,
-                      ),
-                      // Visual separator only — TalkBack would otherwise
-                      // announce "dot" between the footer buttons.
-                      ExcludeSemantics(
-                        child: Text(
-                          '·',
-                          style: TextStyle(
-                            fontFamily: 'Inter',
-                            fontSize: 12,
-                            color: c.ink3,
+                    const SizedBox(height: 4),
+                    // Wrap instead of Row: three links + two separators may
+                    // overflow narrow viewports in a single row.
+                    Wrap(
+                      alignment: WrapAlignment.center,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        _FooterLink(
+                          label: l10n.discoveryFooterPrivacy,
+                          onPressed: _openPrivacyPolicy,
+                        ),
+                        // Visual separator only — TalkBack would otherwise
+                        // announce "dot" between the footer buttons.
+                        ExcludeSemantics(
+                          child: Text(
+                            '·',
+                            style: TextStyle(
+                              fontFamily: 'Inter',
+                              fontSize: 12,
+                              color: c.ink3,
+                            ),
                           ),
                         ),
-                      ),
-                      _FooterLink(
-                        label: l10n.discoveryFooterSecurity,
-                        onPressed: _openSecurityFaq,
-                      ),
-                      ExcludeSemantics(
-                        child: Text(
-                          '·',
-                          style: TextStyle(
-                            fontFamily: 'Inter',
-                            fontSize: 12,
-                            color: c.ink3,
+                        _FooterLink(
+                          label: l10n.discoveryFooterSecurity,
+                          onPressed: _openSecurityFaq,
+                        ),
+                        ExcludeSemantics(
+                          child: Text(
+                            '·',
+                            style: TextStyle(
+                              fontFamily: 'Inter',
+                              fontSize: 12,
+                              color: c.ink3,
+                            ),
                           ),
                         ),
-                      ),
-                      _FooterLink(
-                        label: l10n.discoveryFooterLicenses,
-                        onPressed: _openLicenses,
-                      ),
-                    ],
-                  ),
-                ],
+                        _FooterLink(
+                          label: l10n.discoveryFooterLicenses,
+                          onPressed: _openLicenses,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> _refreshDiscovery() async {
+    final cubit = context.read<DiscoveryCubit>();
+    await cubit.stopDiscovery();
+    await cubit.startDiscovery();
   }
 
   Widget _buildHero(BuildContext context) {

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -190,6 +190,7 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
               child: RefreshIndicator(
                 onRefresh: _refreshDiscovery,
                 child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
                   padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
                   children: [
                     _buildHero(context),
@@ -269,9 +270,9 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
   }
 
   Future<void> _refreshDiscovery() async {
-    final cubit = context.read<DiscoveryCubit>();
-    await cubit.stopDiscovery();
-    await cubit.startDiscovery();
+    await _cubit!.stopDiscovery();
+    if (!mounted) return;
+    await _cubit!.startDiscovery();
   }
 
   Widget _buildHero(BuildContext context) {

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -1000,4 +1000,57 @@ void main() {
       verify(() => mockCubit.stopDiscovery()).called(1);
     });
   });
+
+  group('pull-to-refresh', () {
+    testWidgets('discovery list has a RefreshIndicator', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          FrequencyDiscoveryScreen(
+            onPick: (_) {},
+            myName: 'Mo Ali',
+            onRename: (_) {},
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.byType(RefreshIndicator), findsOneWidget);
+    });
+
+    testWidgets('pull-to-refresh calls stopDiscovery then startDiscovery', (
+      tester,
+    ) async {
+      final mockCubit = MockDiscoveryCubit();
+      when(() => mockCubit.state).thenReturn(const DiscoveryScanning());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockCubit.startDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.stopDiscovery()).thenAnswer((_) async {});
+      when(() => mockCubit.close()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        _wrap(
+          FrequencyDiscoveryScreen(
+            onPick: (_) {},
+            myName: 'Mo Ali',
+            onRename: (_) {},
+          ),
+          cubit: mockCubit,
+        ),
+      );
+      await tester.pump();
+      clearInteractions(mockCubit);
+
+      // Trigger via fling — show() requires pump() calls while awaiting, so
+      // use a gesture-based approach that runs within the normal pump cycle.
+      await tester.fling(find.byType(ListView), const Offset(0, 300), 1000);
+      // One pump to start the overscroll animation, one to reach the trigger
+      // threshold, one to call onRefresh, one to dismiss the indicator.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(_settleWindow);
+
+      verify(() => mockCubit.stopDiscovery()).called(1);
+      verify(() => mockCubit.startDiscovery()).called(1);
+    });
+  });
 }

--- a/test/screens/frequency_discovery_screen_test.dart
+++ b/test/screens/frequency_discovery_screen_test.dart
@@ -1049,8 +1049,10 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
       await tester.pump(_settleWindow);
 
-      verify(() => mockCubit.stopDiscovery()).called(1);
-      verify(() => mockCubit.startDiscovery()).called(1);
+      verifyInOrder([
+        () => mockCubit.stopDiscovery(),
+        () => mockCubit.startDiscovery(),
+      ]);
     });
   });
 }


### PR DESCRIPTION
## Summary

Resolves #365.

- Wraps the discovery `ListView` in a `RefreshIndicator`
- Pull gesture calls `stopDiscovery()` then `startDiscovery()` in sequence
- `startScan()` already calls `_discovered.clear()` and restarts the prune timer, so stale ghost entries are pruned immediately on refresh without racing the timer (consistent with the #364 fix)
- Spinner stays visible until `startDiscovery()` resolves (scan setup completes)

## Changes

- `lib/screens/frequency_discovery_screen.dart` — wrap `ListView` in `RefreshIndicator`; add `_refreshDiscovery()` callback
- `test/screens/frequency_discovery_screen_test.dart` — add two tests: `RefreshIndicator` is present; fling triggers `stopDiscovery` then `startDiscovery`

## Test plan

- [x] `dart format` clean (0 files changed)
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 868/868 passed (including 2 new pull-to-refresh tests)
- [x] Kotlin unit tests — BUILD SUCCESSFUL
- [x] Debug AAB — 79 MiB ≤ 100 MiB budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now pull down on the discovery list to refresh the discovery results. The pull-to-refresh gesture remains responsive and functional even when the list content doesn't fill the entire screen, ensuring better accessibility across all device configurations.

* **Tests**
  * Added test coverage validating the pull-to-refresh gesture implementation and behavior during discovery scanning operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/375)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->