### PR TITLE
feat(#366): wire invite-link copy button + deep-link handler

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -57,6 +57,13 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Deep-link handler for invite links: walkietalkie://join?freq=<name> -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="walkietalkie" android:host="join"/>
+            </intent-filter>
         </activity>
         
         <!-- Foreground Service for Audio Management -->

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -3,6 +3,7 @@ package com.elodin.walkie_talkie
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -523,6 +524,13 @@ class MainActivity : FlutterActivity() {
                         result.success(applied)
                     }
                 }
+                "getInitialLink" -> {
+                    // Called by Flutter once the engine is ready to receive the
+                    // launch-intent deep link (cold-start path). Returns the
+                    // freq query param from a walkietalkie://join?freq=<name>
+                    // URI, or null when the app was not opened via an invite link.
+                    result.success(extractInviteFreq(intent))
+                }
                 else -> {
                     result.notImplemented()
                 }
@@ -636,7 +644,19 @@ class MainActivity : FlutterActivity() {
         if (intent.getStringExtra(WalkieTalkieService.EXTRA_ACTION) == WalkieTalkieService.ACTION_LEAVE) {
             Log.i(TAG, "Leave action received via notification intent")
             sendEventToFlutter(mapOf("type" to "leaveRoom"))
+            return
         }
+        val freq = extractInviteFreq(intent)
+        if (freq != null) {
+            Log.i(TAG, "Invite deep link received (warm start): freq=$freq")
+            sendEventToFlutter(mapOf("type" to "openInviteLink", "freq" to freq))
+        }
+    }
+
+    private fun extractInviteFreq(intent: Intent): String? {
+        val uri: Uri = intent.data ?: return null
+        if (uri.scheme != "walkietalkie" || uri.host != "join") return null
+        return uri.getQueryParameter("freq")
     }
     override fun onDestroy() {
         super.onDestroy()

--- a/docs/invite-links.md
+++ b/docs/invite-links.md
@@ -1,0 +1,61 @@
+---
+permalink: /invite-links/
+---
+
+# Invite Links
+
+Walkie-Talkie uses a custom URI scheme so users can share a frequency with nearby friends before they open the app.
+
+## Format
+
+```
+walkietalkie://join?freq=<mhzDisplay>
+```
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `freq` | The MHz display string of the frequency (URL-encoded) | `104.3` |
+
+Example link:
+
+```
+walkietalkie://join?freq=104.3
+```
+
+## How it works
+
+**Sender (host device)**
+
+1. Open a frequency room.
+2. Tap the invite icon to open the invite sheet.
+3. Tap **Copy invite link** — the link is copied to the clipboard and a confirmation snackbar appears.
+4. Share the link via any messaging app.
+
+**Receiver (guest device)**
+
+1. Tap the link. Android resolves `walkietalkie://` to the app and opens it.
+2. If the app was closed, it opens to the discovery screen.
+3. A banner ("Looking for X MHz…") appears while BLE scanning is active.
+4. When the host's frequency appears in the nearby list the user can tap it to join normally.
+
+## Why a custom scheme instead of App Links?
+
+App Links (HTTPS universal links) require a hosted `.well-known/assetlinks.json` file, which conflicts with the app's offline-first, no-account design. The custom `walkietalkie://` scheme works entirely on-device with no internet dependency.
+
+## Android manifest
+
+The intent filter is declared in `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<intent-filter android:autoVerify="false">
+    <action android:name="android.intent.action.VIEW"/>
+    <category android:name="android.intent.category.DEFAULT"/>
+    <category android:name="android.intent.category.BROWSABLE"/>
+    <data android:scheme="walkietalkie" android:host="join"/>
+</intent-filter>
+```
+
+## Native → Flutter bridge
+
+- **Cold start** — Flutter calls `getInitialLink()` via `MethodChannel` once the engine is ready. The native side reads `Activity.getIntent().getData()` and returns the `freq` query parameter (or `null`).
+- **Warm start** — `onNewIntent` fires; the native side sends `{"type": "openInviteLink", "freq": "..."}` through the existing `audio_events` EventChannel.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -656,5 +656,28 @@
     "securityFaqCloseIcon": "Close Privacy & Security FAQ",
     "@securityFaqCloseIcon": {
         "description": "Accessibility label for the top-right close icon on the security FAQ screen. Distinct from the bottom 'Got it' CTA so screen readers announce different labels for the two controls."
+    },
+
+    "inviteSheetCopyButton": "Copy invite link",
+    "@inviteSheetCopyButton": {
+        "description": "Label on the copy-invite-link button in the invite sheet (pre-copy state)."
+    },
+
+    "inviteSheetCopiedButton": "Copied invite",
+    "@inviteSheetCopiedButton": {
+        "description": "Label on the copy-invite-link button after the link has been copied (post-copy confirmation state, reverts after 1600 ms)."
+    },
+
+    "inviteSheetCopiedSnackbar": "Invite link copied",
+    "@inviteSheetCopiedSnackbar": {
+        "description": "SnackBar message shown after the invite link is copied to the clipboard."
+    },
+
+    "discoveryInviteBanner": "Looking for {freq} MHz…",
+    "@discoveryInviteBanner": {
+        "description": "Banner shown on the discovery screen while scanning for a frequency that was opened via an invite deep link. {freq} is the MHz display string (e.g. \"104.3\").",
+        "placeholders": {
+            "freq": { "type": "String", "example": "104.3" }
+        }
     }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -258,17 +258,40 @@ class FrequencyApp extends StatefulWidget {
 class _FrequencyAppState extends State<FrequencyApp>
     with WidgetsBindingObserver {
   bool _pttMode = false;
+  String? _pendingInviteFreq;
+  StreamSubscription<Map<String, dynamic>>? _inviteLinkSub;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     // Post-frame callback so context.read is available.
-    WidgetsBinding.instance.addPostFrameCallback((_) => _reloadSettings());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _reloadSettings();
+      _initInviteLinks();
+    });
+  }
+
+  void _initInviteLinks() {
+    final audio = context.read<AudioService>();
+    // Cold-start: check whether the app was launched via an invite link.
+    audio.getInitialLink().then((freq) {
+      if (freq != null && mounted) setState(() => _pendingInviteFreq = freq);
+    });
+    // Warm-start: listen for invite links delivered while the app is running.
+    _inviteLinkSub = audio.audioEvents
+        .where((e) => e['type'] == 'openInviteLink')
+        .listen((e) {
+          final freq = e['freq'] as String?;
+          if (freq != null && mounted) {
+            setState(() => _pendingInviteFreq = freq);
+          }
+        });
   }
 
   @override
   void dispose() {
+    _inviteLinkSub?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -323,6 +346,7 @@ class _FrequencyAppState extends State<FrequencyApp>
         FrequencyDiscoveryScreen(
           myName: myName,
           recentHostedFrequencies: recentHostedFrequencies,
+          pendingInviteFreq: _pendingInviteFreq,
           onRename: (name) {
             cubit.rename(name);
           },
@@ -339,6 +363,9 @@ class _FrequencyAppState extends State<FrequencyApp>
           // tolerates a fire-and-forget call (the user has already
           // committed to entering the room).
           onPick: (result) {
+            if (_pendingInviteFreq != null) {
+              setState(() => _pendingInviteFreq = null);
+            }
             unawaited(
               cubit.joinRoom(
                 isHost: result.isHost,

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -107,6 +107,11 @@ class FrequencyDiscoveryScreen extends StatefulWidget {
   /// disappears from the UI immediately on success.
   final void Function(String freq)? onDeleteRecent;
 
+  /// When non-null the discovery screen shows a banner prompting the user
+  /// to wait for the named frequency to appear in the scan results. Set by
+  /// the invite-link deep-link handler in [FrequencyApp].
+  final String? pendingInviteFreq;
+
   const FrequencyDiscoveryScreen({
     super.key,
     required this.onPick,
@@ -116,6 +121,7 @@ class FrequencyDiscoveryScreen extends StatefulWidget {
     this.onSetRecentNickname,
     this.onSetRecentPinned,
     this.onDeleteRecent,
+    this.pendingInviteFreq,
   });
 
   @override
@@ -193,6 +199,20 @@ class _FrequencyDiscoveryScreenState extends State<FrequencyDiscoveryScreen> {
                   physics: const AlwaysScrollableScrollPhysics(),
                   padding: const EdgeInsets.fromLTRB(20, 16, 20, 28),
                   children: [
+                    if (widget.pendingInviteFreq != null)
+                      BlocBuilder<DiscoveryCubit, DiscoveryState>(
+                        buildWhen: (p, n) =>
+                            (p is DiscoveryScanning) !=
+                            (n is DiscoveryScanning),
+                        builder: (context, state) {
+                          if (state is! DiscoveryScanning) {
+                            return const SizedBox.shrink();
+                          }
+                          return _InviteLinkBanner(
+                            freq: widget.pendingInviteFreq!,
+                          );
+                        },
+                      ),
                     _buildHero(context),
                     const SizedBox(height: 24),
                     _buildCreateCard(context),
@@ -1348,6 +1368,43 @@ class _RenameSheetState extends State<_RenameSheet> {
             padding: const EdgeInsets.symmetric(vertical: 14),
             fontSize: 15,
             onPressed: hasName ? _submit : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InviteLinkBanner extends StatelessWidget {
+  final String freq;
+
+  const _InviteLinkBanner({required this.freq});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: c.accent.withAlpha(20),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: c.accent.withAlpha(60)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.wifi_tethering, size: 16, color: c.accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Looking for $freq MHz…',
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 13,
+                color: c.accent,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/screens/frequency_discovery_screen.dart
+++ b/lib/screens/frequency_discovery_screen.dart
@@ -1383,6 +1383,7 @@ class _InviteLinkBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
     return Container(
       margin: const EdgeInsets.only(bottom: 16),
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
@@ -1397,7 +1398,7 @@ class _InviteLinkBanner extends StatelessWidget {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              'Looking for $freq MHz…',
+              l10n.discoveryInviteBanner(freq),
               style: TextStyle(
                 fontFamily: 'Inter',
                 fontSize: 13,

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -702,4 +702,16 @@ class AudioService {
       return false;
     }
   }
+
+  /// Returns the freq query param from a cold-start invite deep link
+  /// (`walkietalkie://join?freq=<name>`), or null when the app was not
+  /// opened via an invite link. Call once after engine startup.
+  Future<String?> getInitialLink() async {
+    try {
+      return await _methodChannel.invokeMethod<String>('getInitialLink');
+    } catch (e) {
+      if (kDebugMode) debugPrint('Error reading initial link: $e');
+      return null;
+    }
+  }
 }

--- a/lib/widgets/invite_sheet.dart
+++ b/lib/widgets/invite_sheet.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../l10n/generated/app_localizations.dart';
 import '../theme/app_theme.dart';
 import 'frequency_atoms.dart';
 
@@ -28,6 +29,7 @@ class _InviteSheetState extends State<InviteSheet> {
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
+    final l10n = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 8, 20, 28),
       child: Column(
@@ -103,7 +105,9 @@ class _InviteSheetState extends State<InviteSheet> {
           FreqButton(
             block: true,
             icon: _copied ? Icons.check : Icons.copy,
-            label: _copied ? 'Copied invite' : 'Copy invite link',
+            label: _copied
+                ? l10n.inviteSheetCopiedButton
+                : l10n.inviteSheetCopyButton,
             padding: const EdgeInsets.symmetric(vertical: 12),
             onPressed: () {
               final link =
@@ -111,16 +115,21 @@ class _InviteSheetState extends State<InviteSheet> {
               final messenger = ScaffoldMessenger.of(context);
               // Fire-and-forget: clipboard writes rarely fail and the UX
               // confirmation (label + snackbar) should be instantaneous.
-              unawaited(Clipboard.setData(ClipboardData(text: link)));
+              // Log errors rather than letting them surface as unhandled.
+              unawaited(
+                Clipboard.setData(ClipboardData(text: link)).catchError((e) {
+                  debugPrint('Clipboard.setData failed: $e');
+                }),
+              );
               setState(() => _copied = true);
               _copiedReset?.cancel();
               _copiedReset = Timer(const Duration(milliseconds: 1600), () {
                 if (mounted) setState(() => _copied = false);
               });
               messenger.showSnackBar(
-                const SnackBar(
-                  content: Text('Invite link copied'),
-                  duration: Duration(milliseconds: 1600),
+                SnackBar(
+                  content: Text(l10n.inviteSheetCopiedSnackbar),
+                  duration: const Duration(milliseconds: 1600),
                 ),
               );
             },

--- a/lib/widgets/invite_sheet.dart
+++ b/lib/widgets/invite_sheet.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../theme/app_theme.dart';
 import 'frequency_atoms.dart';
@@ -105,11 +106,23 @@ class _InviteSheetState extends State<InviteSheet> {
             label: _copied ? 'Copied invite' : 'Copy invite link',
             padding: const EdgeInsets.symmetric(vertical: 12),
             onPressed: () {
+              final link =
+                  'walkietalkie://join?freq=${Uri.encodeComponent(widget.freq)}';
+              final messenger = ScaffoldMessenger.of(context);
+              // Fire-and-forget: clipboard writes rarely fail and the UX
+              // confirmation (label + snackbar) should be instantaneous.
+              unawaited(Clipboard.setData(ClipboardData(text: link)));
               setState(() => _copied = true);
               _copiedReset?.cancel();
               _copiedReset = Timer(const Duration(milliseconds: 1600), () {
                 if (mounted) setState(() => _copied = false);
               });
+              messenger.showSnackBar(
+                const SnackBar(
+                  content: Text('Invite link copied'),
+                  duration: Duration(milliseconds: 1600),
+                ),
+              );
             },
           ),
           const SizedBox(height: 12),

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -655,6 +655,11 @@ void main() {
         installFailing();
         expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
       });
+
+      test('getInitialLink returns null on error', () async {
+        installFailing();
+        expect(await audioService.getInitialLink(), isNull);
+      });
     });
 
     group('happy-path coverage for missing methods', () {
@@ -824,6 +829,21 @@ void main() {
           expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
         },
       );
+
+      test('getInitialLink returns freq string from native', () async {
+        handler = (call) async {
+          if (call.method == 'getInitialLink') return '104.3';
+          return null;
+        };
+        final result = await audioService.getInitialLink();
+        expect(result, '104.3');
+        expect(log.last, isMethodCall('getInitialLink', arguments: null));
+      });
+
+      test('getInitialLink returns null when native returns null', () async {
+        handler = (call) async => null;
+        expect(await audioService.getInitialLink(), isNull);
+      });
     });
 
     group('LinkTelemetrySnapshot equality + hashCode', () {

--- a/test/widgets/invite_sheet_test.dart
+++ b/test/widgets/invite_sheet_test.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/l10n/generated/app_localizations.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/invite_sheet.dart';
 
 Widget _wrap(Widget child) {
   return MaterialApp(
     theme: AppTheme.light(),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
     home: Scaffold(body: child),
   );
 }
@@ -17,6 +20,14 @@ void _mockClipboard() {
         const MethodChannel('flutter/clipboard'),
         (MethodCall call) async => null,
       );
+  // Clear after the test so the mock doesn't leak into later tests.
+  addTearDown(
+    () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('flutter/clipboard'),
+          null,
+        ),
+  );
 }
 
 void main() {

--- a/test/widgets/invite_sheet_test.dart
+++ b/test/widgets/invite_sheet_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 import 'package:walkie_talkie/widgets/invite_sheet.dart';
@@ -8,6 +9,14 @@ Widget _wrap(Widget child) {
     theme: AppTheme.light(),
     home: Scaffold(body: child),
   );
+}
+
+void _mockClipboard() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('flutter/clipboard'),
+        (MethodCall call) async => null,
+      );
 }
 
 void main() {
@@ -27,6 +36,7 @@ void main() {
     testWidgets('tapping copy button changes label to "Copied invite"', (
       tester,
     ) async {
+      _mockClipboard();
       await tester.pumpWidget(_wrap(const InviteSheet(freq: '91.5')));
       await tester.tap(find.text('Copy invite link'));
       await tester.pump();
@@ -35,6 +45,7 @@ void main() {
     });
 
     testWidgets('"Copied invite" reverts after 1600ms', (tester) async {
+      _mockClipboard();
       await tester.pumpWidget(_wrap(const InviteSheet(freq: '91.5')));
       await tester.tap(find.text('Copy invite link'));
       await tester.pump();


### PR DESCRIPTION
## Summary

Resolves #366.

- **Copy button now works**: generates `walkietalkie://join?freq=<encoded_name>` URL, writes to clipboard via `Clipboard.setData`, shows a SnackBar confirmation. Fire-and-forget clipboard write so the label/snackbar feedback is instantaneous.
- **Android deep-link intent filter**: `walkietalkie://join` custom URI scheme registered in `AndroidManifest.xml` (no hosted domain required — fits the offline-first design).
- **Cold-start handling**: `getInitialLink` MethodChannel method reads the launch intent's URI and returns the `freq` param; Flutter calls it once on startup.
- **Warm-start handling**: `onNewIntent` parses the URI and dispatches `{"type": "openInviteLink", "freq": "..."}` through the existing `audio_events` EventChannel.
- **Discovery-screen banner**: `_InviteLinkBanner` widget shows "Looking for X MHz…" while BLE scanning is active when a pending invite link is set. Cleared when the user joins a room.
- **Docs**: `docs/invite-links.md` covers link format, UX flow, why custom scheme over App Links, and the native→Flutter bridge.

## Link format

```
walkietalkie://join?freq=104.3
```

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — 867/867 passed (including updated `invite_sheet_test.dart` with clipboard mock)
- [x] Kotlin unit tests — BUILD SUCCESSFUL
- [x] Debug AAB — 79 MiB (< 100 MiB regression alarm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)