### PR TITLE
docs(#371): standardize Bluetooth range to 30 metres (100 ft) across UI and docs

### DIFF
--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -32,7 +32,7 @@ All other data type rows answered **No**, including Audio (voice) and Device or 
 
 ## Why audio and peerId are not declared
 
-Voice audio and the local `peerId` UUID are transmitted over Bluetooth LE to other peers in the same Frequency room — peers the user explicitly chose to communicate with by joining a shared frequency. The developer never receives, processes, or stores either of these data types; they exist only on the user's device and on the devices of co-present peers within roughly 10–30 metres of BLE radio range.
+Voice audio and the local `peerId` UUID are transmitted over Bluetooth LE to other peers in the same Frequency room — peers the user explicitly chose to communicate with by joining a shared frequency. The developer never receives, processes, or stores either of these data types; they exist only on the user's device and on the devices of co-present peers within about 30 metres (100 feet) of BLE radio range.
 
 Per Google Play's Data Safety guidance:
 

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -59,7 +59,7 @@ One person hosts a Frequency room. Others nearby discover it automatically and j
 
 ── Requirements ──
 
-Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.
+Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30 metres (100 feet) of the host; range depends on environment and device hardware.
 ```
 
 Run `bash scripts/validate_store_metadata.sh` to see the current character count (max 4 000).

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -29,4 +29,4 @@ One person hosts a Frequency room. Others nearby discover it automatically and j
 
 ── Requirements ──
 
-Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.
+Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30 metres (100 feet) of the host; range depends on environment and device hardware.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -44,7 +44,7 @@
     "@explainerPage2Headline": {
         "description": "Explainer page 2 headline. \\n preserved for two-line layout."
     },
-    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within Bluetooth range (about 30 feet) to stay connected.",
+    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within Bluetooth range (about 30 metres / 100 feet) to stay connected.",
     "@explainerPage2Body": {
         "description": "Explainer page 2 body copy."
     },
@@ -616,7 +616,7 @@
     "@securityFaqQ2": {
         "description": "Security FAQ question 2."
     },
-    "securityFaqA2": "In v1, an attacker within Bluetooth range (roughly 10–30 metres) who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
+    "securityFaqA2": "In v1, an attacker within Bluetooth range (about 30 metres / 100 feet) who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
     "@securityFaqA2": {
         "description": "Security FAQ answer 2."
     },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -44,7 +44,7 @@
     "@explainerPage2Headline": {
         "description": "Explainer page 2 headline. \\n preserved for two-line layout."
     },
-    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within Bluetooth range (about 30 metres / 100 feet) to stay connected.",
+    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within about 30 metres (100 feet) of Bluetooth range to stay connected.",
     "@explainerPage2Body": {
         "description": "Explainer page 2 body copy."
     },
@@ -616,7 +616,7 @@
     "@securityFaqQ2": {
         "description": "Security FAQ question 2."
     },
-    "securityFaqA2": "In v1, an attacker within Bluetooth range (about 30 metres / 100 feet) who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
+    "securityFaqA2": "In v1, an attacker within about 30 metres (100 feet) of Bluetooth range who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
     "@securityFaqA2": {
         "description": "Security FAQ answer 2."
     },

--- a/lib/widgets/invite_sheet.dart
+++ b/lib/widgets/invite_sheet.dart
@@ -136,7 +136,7 @@ class _InviteSheetState extends State<InviteSheet> {
           ),
           const SizedBox(height: 12),
           Text(
-            'Anyone within ~30 metres (100 ft) can tune in.',
+            'Anyone within ~30 metres (100 feet) can tune in.',
             style: TextStyle(fontFamily: 'Inter', fontSize: 11, color: c.ink3),
           ),
         ],

--- a/lib/widgets/invite_sheet.dart
+++ b/lib/widgets/invite_sheet.dart
@@ -136,7 +136,7 @@ class _InviteSheetState extends State<InviteSheet> {
           ),
           const SizedBox(height: 12),
           Text(
-            'Anyone within ~30m can tune in.',
+            'Anyone within ~30 metres (100 ft) can tune in.',
             style: TextStyle(fontFamily: 'Inter', fontSize: 11, color: c.ink3),
           ),
         ],


### PR DESCRIPTION
Closes #371

## Summary

- Picks **30 metres (100 feet)** as the single canonical BLE range claim — the realistic Class 2 indoor upper bound
- Replaces inconsistent values found across the codebase: `"about 30 feet"`, `"roughly 10–30 metres"`, and `"30–100 m"`
- Uses metres as primary unit, feet in parentheses, consistently

## Files changed

| File | Before | After |
|------|--------|-------|
| `lib/l10n/app_en.arb` (onboarding) | "about 30 feet" | "about 30 metres / 100 feet" |
| `lib/l10n/app_en.arb` (security FAQ) | "roughly 10–30 metres" | "about 30 metres / 100 feet" |
| `lib/widgets/invite_sheet.dart` | "~30m" | "~30 metres (100 ft)" |
| `docs/play-store-data-safety.md` | "roughly 10–30 metres" | "about 30 metres (100 feet)" |
| `docs/play-store-listing.md` | "30–100 m" | "30 metres (100 feet)" |
| `fastlane/metadata/android/en-US/full_description.txt` | "30–100 m" | "30 metres (100 feet)" |

## Rationale

BLE Class 2 (the class Android devices use) has a nominal range of 10–30 m. 30 m is the defensible upper bound for indoor conditions. 100 m (the previous high end) is only realistic for Class 1 hardware in ideal open-air conditions — not representative of typical app use.

## Test plan

- [x] `git grep` finds no conflicting range numbers in first-party files
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 872 tests passed
- [x] Kotlin unit tests — BUILD SUCCESSFUL
- [x] Debug AAB — 79 MiB (within 100 MiB regression alarm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)