### PR TITLE
fix(#372): detect revoked BT/mic permissions on onboarding mount and app resume

### DIFF
--- a/lib/screens/frequency_onboarding_screen.dart
+++ b/lib/screens/frequency_onboarding_screen.dart
@@ -38,6 +38,12 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen>
   OnboardingPermissionStatus _micStatus = OnboardingPermissionStatus.denied;
   bool _btRequestInFlight = false;
   bool _micRequestInFlight = false;
+
+  // Monotonically increasing counter. Incremented at the start of every
+  // background check AND before every user-initiated request so a stale
+  // check result cannot overwrite a newer request result.
+  int _statusEpoch = 0;
+
   final TextEditingController _nameCtrl = TextEditingController();
   late final OnboardingPermissionGateway _gateway =
       widget.permissionGateway ?? const DefaultOnboardingPermissionGateway();
@@ -64,12 +70,15 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen>
   }
 
   Future<void> _checkCurrentStatuses() async {
-    final btStatus = await _gateway.checkBluetooth();
-    final micStatus = await _gateway.checkMicrophone();
-    if (!mounted) return;
+    final epoch = ++_statusEpoch;
+    final results = await Future.wait([
+      _gateway.checkBluetooth(),
+      _gateway.checkMicrophone(),
+    ]);
+    if (!mounted || epoch != _statusEpoch) return;
     setState(() {
-      _btStatus = btStatus;
-      _micStatus = micStatus;
+      _btStatus = results[0];
+      _micStatus = results[1];
     });
   }
 
@@ -79,6 +88,7 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen>
 
   Future<void> _requestBluetooth() async {
     if (_btRequestInFlight) return;
+    _statusEpoch++;
     setState(() => _btRequestInFlight = true);
     try {
       final result = await _gateway.requestBluetooth();
@@ -91,6 +101,7 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen>
 
   Future<void> _requestMicrophone() async {
     if (_micRequestInFlight) return;
+    _statusEpoch++;
     setState(() => _micRequestInFlight = true);
     try {
       final result = await _gateway.requestMicrophone();

--- a/lib/screens/frequency_onboarding_screen.dart
+++ b/lib/screens/frequency_onboarding_screen.dart
@@ -31,7 +31,8 @@ class FrequencyOnboardingScreen extends StatefulWidget {
       _FrequencyOnboardingScreenState();
 }
 
-class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen> {
+class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen>
+    with WidgetsBindingObserver {
   int _step = 0;
   OnboardingPermissionStatus _btStatus = OnboardingPermissionStatus.denied;
   OnboardingPermissionStatus _micStatus = OnboardingPermissionStatus.denied;
@@ -42,9 +43,34 @@ class _FrequencyOnboardingScreenState extends State<FrequencyOnboardingScreen> {
       widget.permissionGateway ?? const DefaultOnboardingPermissionGateway();
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _checkCurrentStatuses();
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _nameCtrl.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _checkCurrentStatuses();
+    }
+  }
+
+  Future<void> _checkCurrentStatuses() async {
+    final btStatus = await _gateway.checkBluetooth();
+    final micStatus = await _gateway.checkMicrophone();
+    if (!mounted) return;
+    setState(() {
+      _btStatus = btStatus;
+      _micStatus = micStatus;
+    });
   }
 
   bool get _allGranted =>

--- a/lib/services/onboarding_permission_gateway.dart
+++ b/lib/services/onboarding_permission_gateway.dart
@@ -13,6 +13,13 @@ enum OnboardingPermissionStatus { denied, granted, permanentlyDenied }
 abstract class OnboardingPermissionGateway {
   Future<OnboardingPermissionStatus> requestBluetooth();
   Future<OnboardingPermissionStatus> requestMicrophone();
+
+  /// Query current status without showing a system permission dialog.
+  /// Used on screen mount and app-resume to reflect revoked permissions
+  /// immediately (e.g. show "Open settings" without requiring a tap first).
+  Future<OnboardingPermissionStatus> checkBluetooth();
+  Future<OnboardingPermissionStatus> checkMicrophone();
+
   Future<void> openAppSettings();
 }
 
@@ -39,6 +46,20 @@ class DefaultOnboardingPermissionGateway
   @override
   Future<OnboardingPermissionStatus> requestMicrophone() async {
     final status = await ph.Permission.microphone.request();
+    return reduce([status]);
+  }
+
+  @override
+  Future<OnboardingPermissionStatus> checkBluetooth() async {
+    final results = await Future.wait(
+      _bluetoothPermissions.map((p) => p.status),
+    );
+    return reduce(results);
+  }
+
+  @override
+  Future<OnboardingPermissionStatus> checkMicrophone() async {
+    final status = await ph.Permission.microphone.status;
     return reduce([status]);
   }
 

--- a/test/screens/frequency_onboarding_screen_test.dart
+++ b/test/screens/frequency_onboarding_screen_test.dart
@@ -32,6 +32,12 @@ class _FakeGateway implements OnboardingPermissionGateway {
   }
 
   @override
+  Future<OnboardingPermissionStatus> checkBluetooth() async => btResult;
+
+  @override
+  Future<OnboardingPermissionStatus> checkMicrophone() async => micResult;
+
+  @override
   Future<void> openAppSettings() async {
     settingsOpens++;
   }
@@ -218,6 +224,82 @@ void main() {
       expect(doneName, isNull);
     });
 
+    testWidgets(
+      'permanently-denied BT shows Open settings on mount without tapping Allow',
+      (tester) async {
+        final gateway = _FakeGateway(
+          btResult: OnboardingPermissionStatus.permanentlyDenied,
+        );
+
+        await tester.pumpWidget(
+          _wrap(
+            FrequencyOnboardingScreen(
+              permissionGateway: gateway,
+              onDone: (_) {},
+            ),
+          ),
+        );
+        await tester.tap(find.text('Get started'));
+        await tester.pumpAndSettle();
+
+        // Skip through explainer
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Get started'));
+        await tester.pumpAndSettle();
+
+        // No Allow tap needed — check() on mount detected permanentlyDenied.
+        expect(find.text('Open settings'), findsOneWidget);
+        expect(
+          find.text('Blocked — re-enable in system settings'),
+          findsOneWidget,
+        );
+        expect(gateway.btRequests, 0);
+      },
+    );
+
+    testWidgets(
+      'app resume after settings re-checks and updates denied → granted',
+      (tester) async {
+        final gateway = _FakeGateway(
+          btResult: OnboardingPermissionStatus.denied,
+        );
+
+        await tester.pumpWidget(
+          _wrap(
+            FrequencyOnboardingScreen(
+              permissionGateway: gateway,
+              onDone: (_) {},
+            ),
+          ),
+        );
+        await tester.tap(find.text('Get started'));
+        await tester.pumpAndSettle();
+
+        // Skip through explainer
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Next'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Get started'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Allow'), findsNWidgets(2));
+
+        // User goes to system settings, grants BT, returns to app.
+        gateway.btResult = OnboardingPermissionStatus.granted;
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Allowed'), findsOneWidget);
+        expect(gateway.btRequests, 0);
+      },
+    );
+
     testWidgets('in-flight request label shows while gateway is pending', (
       tester,
     ) async {
@@ -262,6 +344,14 @@ class _SlowGateway implements OnboardingPermissionGateway {
 
   @override
   Future<OnboardingPermissionStatus> requestMicrophone() async =>
+      OnboardingPermissionStatus.granted;
+
+  @override
+  Future<OnboardingPermissionStatus> checkBluetooth() async =>
+      OnboardingPermissionStatus.denied;
+
+  @override
+  Future<OnboardingPermissionStatus> checkMicrophone() async =>
       OnboardingPermissionStatus.granted;
 
   @override

--- a/test/screens/frequency_onboarding_screen_test.dart
+++ b/test/screens/frequency_onboarding_screen_test.dart
@@ -239,6 +239,7 @@ void main() {
       (tester) async {
         final gateway = _FakeGateway(
           btCheckResult: OnboardingPermissionStatus.permanentlyDenied,
+          micCheckResult: OnboardingPermissionStatus.denied,
         );
 
         await tester.pumpWidget(

--- a/test/screens/frequency_onboarding_screen_test.dart
+++ b/test/screens/frequency_onboarding_screen_test.dart
@@ -8,8 +8,16 @@ import 'package:walkie_talkie/services/onboarding_permission_gateway.dart';
 import 'package:walkie_talkie/theme/app_theme.dart';
 
 class _FakeGateway implements OnboardingPermissionGateway {
+  /// Returned by requestBluetooth / requestMicrophone (simulates dialog result).
   OnboardingPermissionStatus btResult;
   OnboardingPermissionStatus micResult;
+
+  /// Returned by checkBluetooth / checkMicrophone (simulates current OS state
+  /// without prompting). Defaults to denied so existing tests start in the
+  /// "not yet requested" state; override to test revoked-permission paths.
+  OnboardingPermissionStatus btCheckResult;
+  OnboardingPermissionStatus micCheckResult;
+
   int btRequests = 0;
   int micRequests = 0;
   int settingsOpens = 0;
@@ -17,6 +25,8 @@ class _FakeGateway implements OnboardingPermissionGateway {
   _FakeGateway({
     this.btResult = OnboardingPermissionStatus.granted,
     this.micResult = OnboardingPermissionStatus.granted,
+    this.btCheckResult = OnboardingPermissionStatus.denied,
+    this.micCheckResult = OnboardingPermissionStatus.denied,
   });
 
   @override
@@ -32,10 +42,10 @@ class _FakeGateway implements OnboardingPermissionGateway {
   }
 
   @override
-  Future<OnboardingPermissionStatus> checkBluetooth() async => btResult;
+  Future<OnboardingPermissionStatus> checkBluetooth() async => btCheckResult;
 
   @override
-  Future<OnboardingPermissionStatus> checkMicrophone() async => micResult;
+  Future<OnboardingPermissionStatus> checkMicrophone() async => micCheckResult;
 
   @override
   Future<void> openAppSettings() async {
@@ -228,7 +238,7 @@ void main() {
       'permanently-denied BT shows Open settings on mount without tapping Allow',
       (tester) async {
         final gateway = _FakeGateway(
-          btResult: OnboardingPermissionStatus.permanentlyDenied,
+          btCheckResult: OnboardingPermissionStatus.permanentlyDenied,
         );
 
         await tester.pumpWidget(
@@ -289,7 +299,7 @@ void main() {
         expect(find.text('Allow'), findsNWidgets(2));
 
         // User goes to system settings, grants BT, returns to app.
-        gateway.btResult = OnboardingPermissionStatus.granted;
+        gateway.btCheckResult = OnboardingPermissionStatus.granted;
         tester.binding.handleAppLifecycleStateChanged(
           AppLifecycleState.resumed,
         );
@@ -352,7 +362,7 @@ class _SlowGateway implements OnboardingPermissionGateway {
 
   @override
   Future<OnboardingPermissionStatus> checkMicrophone() async =>
-      OnboardingPermissionStatus.granted;
+      OnboardingPermissionStatus.denied;
 
   @override
   Future<void> openAppSettings() async {}

--- a/test/services/onboarding_permission_gateway_test.dart
+++ b/test/services/onboarding_permission_gateway_test.dart
@@ -118,6 +118,50 @@ void main() {
       await const DefaultOnboardingPermissionGateway().openAppSettings();
       expect(log.any((c) => c.method == 'openAppSettings'), isTrue);
     });
+
+    test('checkBluetooth reads status without requesting', () async {
+      install(
+        permsToStatus: {
+          ph.Permission.bluetoothScan.value: 1,
+          ph.Permission.bluetoothConnect.value: 1,
+          ph.Permission.bluetoothAdvertise.value: 1,
+        },
+      );
+      final result =
+          await const DefaultOnboardingPermissionGateway().checkBluetooth();
+      expect(result, OnboardingPermissionStatus.granted);
+      expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
+    });
+
+    test('checkBluetooth returns permanentlyDenied without requesting', () async {
+      install(
+        permsToStatus: {
+          ph.Permission.bluetoothScan.value: 4, // permanentlyDenied
+          ph.Permission.bluetoothConnect.value: 1,
+          ph.Permission.bluetoothAdvertise.value: 1,
+        },
+      );
+      final result =
+          await const DefaultOnboardingPermissionGateway().checkBluetooth();
+      expect(result, OnboardingPermissionStatus.permanentlyDenied);
+      expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
+    });
+
+    test('checkMicrophone reads status without requesting', () async {
+      install(permsToStatus: {ph.Permission.microphone.value: 1});
+      final result =
+          await const DefaultOnboardingPermissionGateway().checkMicrophone();
+      expect(result, OnboardingPermissionStatus.granted);
+      expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
+    });
+
+    test('checkMicrophone returns denied without requesting', () async {
+      install(permsToStatus: {ph.Permission.microphone.value: 0});
+      final result =
+          await const DefaultOnboardingPermissionGateway().checkMicrophone();
+      expect(result, OnboardingPermissionStatus.denied);
+      expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
+    });
   });
 
   group('OnboardingPermissionGateway.reduce', () {

--- a/test/services/onboarding_permission_gateway_test.dart
+++ b/test/services/onboarding_permission_gateway_test.dart
@@ -127,38 +127,41 @@ void main() {
           ph.Permission.bluetoothAdvertise.value: 1,
         },
       );
-      final result =
-          await const DefaultOnboardingPermissionGateway().checkBluetooth();
+      final result = await const DefaultOnboardingPermissionGateway()
+          .checkBluetooth();
       expect(result, OnboardingPermissionStatus.granted);
       expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
     });
 
-    test('checkBluetooth returns permanentlyDenied without requesting', () async {
-      install(
-        permsToStatus: {
-          ph.Permission.bluetoothScan.value: 4, // permanentlyDenied
-          ph.Permission.bluetoothConnect.value: 1,
-          ph.Permission.bluetoothAdvertise.value: 1,
-        },
-      );
-      final result =
-          await const DefaultOnboardingPermissionGateway().checkBluetooth();
-      expect(result, OnboardingPermissionStatus.permanentlyDenied);
-      expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
-    });
+    test(
+      'checkBluetooth returns permanentlyDenied without requesting',
+      () async {
+        install(
+          permsToStatus: {
+            ph.Permission.bluetoothScan.value: 4, // permanentlyDenied
+            ph.Permission.bluetoothConnect.value: 1,
+            ph.Permission.bluetoothAdvertise.value: 1,
+          },
+        );
+        final result = await const DefaultOnboardingPermissionGateway()
+            .checkBluetooth();
+        expect(result, OnboardingPermissionStatus.permanentlyDenied);
+        expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
+      },
+    );
 
     test('checkMicrophone reads status without requesting', () async {
       install(permsToStatus: {ph.Permission.microphone.value: 1});
-      final result =
-          await const DefaultOnboardingPermissionGateway().checkMicrophone();
+      final result = await const DefaultOnboardingPermissionGateway()
+          .checkMicrophone();
       expect(result, OnboardingPermissionStatus.granted);
       expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
     });
 
     test('checkMicrophone returns denied without requesting', () async {
       install(permsToStatus: {ph.Permission.microphone.value: 0});
-      final result =
-          await const DefaultOnboardingPermissionGateway().checkMicrophone();
+      final result = await const DefaultOnboardingPermissionGateway()
+          .checkMicrophone();
       expect(result, OnboardingPermissionStatus.denied);
       expect(log.any((c) => c.method == 'requestPermissions'), isFalse);
     });


### PR DESCRIPTION
## Summary

Fixes #372 — Bluetooth permission re-request flow when permissions revoked.

- Add `checkBluetooth()` / `checkMicrophone()` to `OnboardingPermissionGateway` that query current OS status **without** showing a system dialog (uses `.status` instead of `.request`)
- `_FrequencyOnboardingScreenState` now mixes in `WidgetsBindingObserver` and calls `_checkCurrentStatuses()` on:
  - `initState` — so permanently-denied users see "Open settings" immediately instead of a silent no-op "Allow" tap
  - `didChangeAppLifecycleState(resumed)` — so returning from system settings after granting/revoking permissions refreshes the UI without requiring a manual tap

### Before
- User with permanently-denied BT permissions would land on the permissions step and see "Allow"; tapping it would silently do nothing (OS won't show the dialog). Only after that wasted tap would "Open settings" appear.
- Returning from system settings after granting permissions showed stale "Allow" until user tapped again.

### After
- On mount, the screen probes current permission state; permanently-denied shows "Open settings" immediately.
- On app resume, statuses are re-probed; freshly granted permissions update the UI instantly.

## Test plan

- [x] `flutter analyze` clean
- [x] New gateway tests: `checkBluetooth` / `checkMicrophone` call `checkPermissionStatus` (not `requestPermissions`) and return correct states
- [x] New screen tests:
  - `permanently-denied BT shows Open settings on mount without tapping Allow`
  - `app resume after settings re-checks and updates denied → granted`
- [x] All existing onboarding screen tests pass (7 total)
- [x] Full `flutter test` green (878 tests)
- [x] `bash scripts/presubmit.sh` exits 0
- [x] Kotlin `./gradlew :app:testDebugUnitTest` exits 0
- [x] Debug AAB builds (~79 MiB, within 100 MiB budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)