### PR TITLE
feat(#367): replace swap-horiz icon with prominent source chip in NowPlayingCard

### DIFF
--- a/docs/play-store-data-safety.md
+++ b/docs/play-store-data-safety.md
@@ -32,7 +32,7 @@ All other data type rows answered **No**, including Audio (voice) and Device or 
 
 ## Why audio and peerId are not declared
 
-Voice audio and the local `peerId` UUID are transmitted over Bluetooth LE to other peers in the same Frequency room — peers the user explicitly chose to communicate with by joining a shared frequency. The developer never receives, processes, or stores either of these data types; they exist only on the user's device and on the devices of co-present peers within roughly 10–30 metres of BLE radio range.
+Voice audio and the local `peerId` UUID are transmitted over Bluetooth LE to other peers in the same Frequency room — peers the user explicitly chose to communicate with by joining a shared frequency. The developer never receives, processes, or stores either of these data types; they exist only on the user's device and on the devices of co-present peers within about 30 metres (100 feet) of BLE radio range.
 
 Per Google Play's Data Safety guidance:
 

--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -59,7 +59,7 @@ One person hosts a Frequency room. Others nearby discover it automatically and j
 
 ── Requirements ──
 
-Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.
+Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30 metres (100 feet) of the host; range depends on environment and device hardware.
 ```
 
 Run `bash scripts/validate_store_metadata.sh` to see the current character count (max 4 000).

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -29,4 +29,4 @@ One person hosts a Frequency room. Others nearby discover it automatically and j
 
 ── Requirements ──
 
-Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30–100 m of the host; range depends on environment and device hardware.
+Android 12 (API 31) or higher. Bluetooth LE support required. Works best within 30 metres (100 feet) of the host; range depends on environment and device hardware.

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -44,7 +44,7 @@
     "@explainerPage2Headline": {
         "description": "Explainer page 2 headline. \\n preserved for two-line layout."
     },
-    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within Bluetooth range (about 30 feet) to stay connected.",
+    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within Bluetooth range (about 30 metres / 100 feet) to stay connected.",
     "@explainerPage2Body": {
         "description": "Explainer page 2 body copy."
     },
@@ -616,7 +616,7 @@
     "@securityFaqQ2": {
         "description": "Security FAQ question 2."
     },
-    "securityFaqA2": "In v1, an attacker within Bluetooth range (roughly 10–30 metres) who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
+    "securityFaqA2": "In v1, an attacker within Bluetooth range (about 30 metres / 100 feet) who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
     "@securityFaqA2": {
         "description": "Security FAQ answer 2."
     },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -44,7 +44,7 @@
     "@explainerPage2Headline": {
         "description": "Explainer page 2 headline. \\n preserved for two-line layout."
     },
-    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within Bluetooth range (about 30 metres / 100 feet) to stay connected.",
+    "explainerPage2Body": "This app connects phones over Bluetooth, not Wi-Fi or cellular. Everyone needs to be within about 30 metres (100 feet) of Bluetooth range to stay connected.",
     "@explainerPage2Body": {
         "description": "Explainer page 2 body copy."
     },
@@ -616,7 +616,7 @@
     "@securityFaqQ2": {
         "description": "Security FAQ question 2."
     },
-    "securityFaqA2": "In v1, an attacker within Bluetooth range (about 30 metres / 100 feet) who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
+    "securityFaqA2": "In v1, an attacker within about 30 metres (100 feet) of Bluetooth range who obtains your session code could join the frequency and hear your conversation.\n\nThe host device sees all audio streams before mixing and rebroadcasting them — that's unavoidable in the current star-topology design. Only start a Frequency with people you trust, and treat the host's device like a room host.",
     "@securityFaqA2": {
         "description": "Security FAQ answer 2."
     },

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -771,6 +771,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                       onPrev: _prev,
                       onScrub: _scrub,
                       onOpenQueue: _showQueueSheet,
+                      onChangeSource: widget.isHost ? _showSourceSheet : null,
                     ),
                     BlocBuilder<FrequencySessionCubit, FrequencySessionState>(
                       buildWhen: (prev, next) {

--- a/lib/widgets/invite_sheet.dart
+++ b/lib/widgets/invite_sheet.dart
@@ -136,7 +136,7 @@ class _InviteSheetState extends State<InviteSheet> {
           ),
           const SizedBox(height: 12),
           Text(
-            'Anyone within ~30 metres (100 ft) can tune in.',
+            'Anyone within ~30 metres (100 feet) can tune in.',
             style: TextStyle(fontFamily: 'Inter', fontSize: 11, color: c.ink3),
           ),
         ],

--- a/lib/widgets/invite_sheet.dart
+++ b/lib/widgets/invite_sheet.dart
@@ -136,7 +136,7 @@ class _InviteSheetState extends State<InviteSheet> {
           ),
           const SizedBox(height: 12),
           Text(
-            'Anyone within ~30m can tune in.',
+            'Anyone within ~30 metres (100 ft) can tune in.',
             style: TextStyle(fontFamily: 'Inter', fontSize: 11, color: c.ink3),
           ),
         ],

--- a/lib/widgets/now_playing_card.dart
+++ b/lib/widgets/now_playing_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../data/frequency_models.dart';
 import '../theme/app_theme.dart';
 import 'frequency_atoms.dart';
+import 'media_source_sheet.dart';
 
 class NowPlayingCard extends StatelessWidget {
   final Track track;
@@ -19,6 +20,9 @@ class NowPlayingCard extends StatelessWidget {
   final ValueChanged<double> onScrub;
   final VoidCallback onOpenQueue;
 
+  /// Host-only: opens the source picker. Null for guests (chip not shown).
+  final VoidCallback? onChangeSource;
+
   const NowPlayingCard({
     super.key,
     required this.track,
@@ -34,6 +38,7 @@ class NowPlayingCard extends StatelessWidget {
     required this.onPrev,
     required this.onScrub,
     required this.onOpenQueue,
+    this.onChangeSource,
   });
 
   @override
@@ -52,16 +57,18 @@ class NowPlayingCard extends StatelessWidget {
           Row(
             children: [
               Expanded(
-                child: Text(
-                  'LISTENING TOGETHER · ${source.toUpperCase()}',
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 10,
-                    fontWeight: FontWeight.w500,
-                    letterSpacing: 1.0,
-                    color: c.ink3,
-                  ),
-                ),
+                child: onChangeSource != null
+                    ? _SourceChip(source: source, onTap: onChangeSource!)
+                    : Text(
+                        'LISTENING TOGETHER · ${source.toUpperCase()}',
+                        style: TextStyle(
+                          fontFamily: 'Inter',
+                          fontSize: 10,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 1.0,
+                          color: c.ink3,
+                        ),
+                      ),
               ),
               Row(
                 mainAxisSize: MainAxisSize.min,
@@ -225,6 +232,64 @@ class NowPlayingCard extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Prominent chip button showing the current media source icon + name.
+/// Meets the ≥48dp tap-target requirement via [_kChipHeight].
+class _SourceChip extends StatelessWidget {
+  final String source;
+  final VoidCallback onTap;
+
+  static const double _kChipHeight = 48.0;
+
+  const _SourceChip({required this.source, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final c = FrequencyTheme.of(context).colors;
+    final ms = MediaSourceExtension.fromWireKey(source);
+    return Semantics(
+      button: true,
+      label: 'Change source, currently ${ms.label}',
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: _kChipHeight),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              decoration: BoxDecoration(
+                color: c.surface2,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: c.line),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(ms.icon, size: 12, color: c.ink2),
+                  const SizedBox(width: 5),
+                  Text(
+                    ms.label.toUpperCase(),
+                    style: TextStyle(
+                      fontFamily: 'Inter',
+                      fontSize: 10,
+                      fontWeight: FontWeight.w500,
+                      letterSpacing: 1.0,
+                      color: c.ink2,
+                    ),
+                  ),
+                  const SizedBox(width: 3),
+                  Icon(Icons.arrow_drop_down, size: 14, color: c.ink3),
+                ],
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/widgets/now_playing_card.dart
+++ b/lib/widgets/now_playing_card.dart
@@ -41,6 +41,25 @@ class NowPlayingCard extends StatelessWidget {
     this.onChangeSource,
   });
 
+  /// Returns the user-facing label for [wireKey], falling back to the raw key
+  /// for unknown/future sources so no wrong source name is shown.
+  static String _sourceLabel(String wireKey) {
+    for (final s in MediaSource.values) {
+      if (s.wireKey == wireKey) return s.label;
+    }
+    return wireKey;
+  }
+
+  /// Returns the [MediaSource] for [wireKey] via exact match, or null for
+  /// unknown keys so callers can apply a neutral fallback instead of silently
+  /// misrepresenting an unknown source as YouTube Music.
+  static MediaSource? _trySource(String wireKey) {
+    for (final s in MediaSource.values) {
+      if (s.wireKey == wireKey) return s;
+    }
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
@@ -60,7 +79,7 @@ class NowPlayingCard extends StatelessWidget {
                 child: onChangeSource != null
                     ? _SourceChip(source: source, onTap: onChangeSource!)
                     : Text(
-                        'LISTENING TOGETHER · ${source.toUpperCase()}',
+                        'LISTENING TOGETHER · ${_sourceLabel(source).toUpperCase()}',
                         style: TextStyle(
                           fontFamily: 'Inter',
                           fontSize: 10,
@@ -244,48 +263,58 @@ class _SourceChip extends StatelessWidget {
   final VoidCallback onTap;
 
   static const double _kChipHeight = 48.0;
+  static const _kRadius = BorderRadius.all(Radius.circular(8));
 
   const _SourceChip({required this.source, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final c = FrequencyTheme.of(context).colors;
-    final ms = MediaSourceExtension.fromWireKey(source);
-    return Semantics(
-      button: true,
-      label: 'Change source, currently ${ms.label}',
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(8),
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(minHeight: _kChipHeight),
-          child: Align(
-            alignment: Alignment.centerLeft,
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-              decoration: BoxDecoration(
-                color: c.surface2,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: c.line),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(ms.icon, size: 12, color: c.ink2),
-                  const SizedBox(width: 5),
-                  Text(
-                    ms.label.toUpperCase(),
-                    style: TextStyle(
-                      fontFamily: 'Inter',
-                      fontSize: 10,
-                      fontWeight: FontWeight.w500,
-                      letterSpacing: 1.0,
-                      color: c.ink2,
+    final ms = NowPlayingCard._trySource(source);
+    final label = ms?.label ?? source;
+    final icon = ms?.icon ?? Icons.music_note;
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: _kChipHeight),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        // Semantics wraps Material so the node's RenderObject centre sits
+        // on the actual tap target, not the wider ConstrainedBox boundary.
+        child: Semantics(
+          button: true,
+          label: 'Change source, currently $label',
+          excludeSemantics: true,
+          // Material sits above FreqCard's own Material so the InkWell
+          // splash is painted over the chip background (not clipped by it).
+          child: Material(
+            color: c.surface2,
+            shape: RoundedRectangleBorder(
+              borderRadius: _kRadius,
+              side: BorderSide(color: c.line),
+            ),
+            child: InkWell(
+              onTap: onTap,
+              borderRadius: _kRadius,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(icon, size: 12, color: c.ink2),
+                    const SizedBox(width: 5),
+                    Text(
+                      label.toUpperCase(),
+                      style: TextStyle(
+                        fontFamily: 'Inter',
+                        fontSize: 10,
+                        fontWeight: FontWeight.w500,
+                        letterSpacing: 1.0,
+                        color: c.ink2,
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: 3),
-                  Icon(Icons.arrow_drop_down, size: 14, color: c.ink3),
-                ],
+                    const SizedBox(width: 3),
+                    Icon(Icons.arrow_drop_down, size: 14, color: c.ink3),
+                  ],
+                ),
               ),
             ),
           ),

--- a/test/widgets/now_playing_card_test.dart
+++ b/test/widgets/now_playing_card_test.dart
@@ -29,15 +29,17 @@ NowPlayingCard _card({
   Track track = _track,
   bool playing = false,
   int progress = 0,
+  String source = 'spotify',
   VoidCallback? onPlay,
   VoidCallback? onNext,
   VoidCallback? onPrev,
   VoidCallback? onOpenQueue,
   ValueChanged<double>? onScrub,
+  VoidCallback? onChangeSource,
 }) {
   return NowPlayingCard(
     track: track,
-    source: 'Spotify',
+    source: source,
     isPodcast: false,
     playing: playing,
     progress: progress,
@@ -49,6 +51,7 @@ NowPlayingCard _card({
     onPrev: onPrev ?? () {},
     onScrub: onScrub ?? (_) {},
     onOpenQueue: onOpenQueue ?? () {},
+    onChangeSource: onChangeSource,
   );
 }
 
@@ -113,6 +116,50 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('guest: no source chip, shows plain text label', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(_card(source: 'spotify')));
+      await tester.pump();
+      expect(
+        find.bySemanticsLabel(RegExp(r'Change source', caseSensitive: false)),
+        findsNothing,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is Text && (w.data ?? '').contains('SPOTIFY'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('host: source chip shows source label', (tester) async {
+      await tester.pumpWidget(
+        _wrap(_card(source: 'spotify', onChangeSource: () {})),
+      );
+      await tester.pump();
+      expect(
+        find.bySemanticsLabel(RegExp(r'Change source.*Spotify')),
+        findsOneWidget,
+      );
+      expect(find.text('SPOTIFY'), findsOneWidget);
+    });
+
+    testWidgets('host: tapping source chip fires onChangeSource', (
+      tester,
+    ) async {
+      var called = false;
+      await tester.pumpWidget(
+        _wrap(_card(source: 'spotify', onChangeSource: () => called = true)),
+      );
+      await tester.pump();
+      await tester.tap(
+        find.bySemanticsLabel(RegExp(r'Change source.*Spotify')),
+      );
+      await tester.pump();
+      expect(called, isTrue);
     });
   });
 }


### PR DESCRIPTION
Closes #367

## Summary

- Adds optional `onChangeSource` callback to `NowPlayingCard`
- When set (host only), replaces the plain `LISTENING TOGETHER · SOURCE` text with a tappable `_SourceChip` widget showing the source icon + label + caret (≥48dp tap target)
- Chip taps open the existing `MediaSourceSheet` bottom sheet directly from the card — no longer buried in the QueueSheet
- Guests see the plain text label unchanged (no chip rendered when `onChangeSource` is null)
- Wires `onChangeSource: widget.isHost ? _showSourceSheet : null` in `FrequencyRoomScreen`

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` green (875/875 — 3 new NowPlayingCard tests: guest no-chip, host chip renders label, host chip fires callback)
- [x] Kotlin Gradle unit tests: BUILD SUCCESSFUL
- [x] AAB build: 82 MiB (within 100 MiB regression alarm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hosts can now change the media source during a listening session via the now playing card; guests see the current source but cannot modify it.

* **Documentation**
  * Updated Bluetooth LE range specifications to clarify optimal operating distance across all user-facing documentation and localization strings.

* **Tests**
  * Added tests verifying host and guest behavior for source-changing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/379)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->