### PR TITLE
feat(#368): wire YouTube Music MediaSession bridge

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -72,6 +72,18 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="microphone|connectedDevice" />
+        <!-- Notification Listener: grants permission to call MediaSessionManager.getActiveSessions()
+             so the host can read live playback metadata from YouTube Music (and future sources).
+             The user must enable this in Settings → Apps → Special app access → Notification access. -->
+        <service
+            android:name=".WalkieTalkieNotificationListener"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -544,6 +544,10 @@ class MainActivity : FlutterActivity() {
             override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
                 Log.i(TAG, "EventChannel listener attached")
                 eventSink = events
+                // Replay the last known media metadata in case it was dispatched
+                // before Flutter attached its listener (bridge attaches at engine start
+                // but Flutter's EventChannel listen() call comes later).
+                mediaSessionBridge?.replayLastMetadata()
             }
 
             override fun onCancel(arguments: Any?) {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity : FlutterActivity() {
     private var eventChannel: EventChannel? = null
     private var controlBytesEventChannel: EventChannel? = null
     private var bluetoothManager: BluetoothLeAudioManager? = null
+    private var mediaSessionBridge: MediaSessionBridge? = null
     private var audioRoutingManager: AudioRoutingManager? = null
     private var gattServerManager: GattServerManager? = null
     private var gattClientManager: GattClientManager? = null
@@ -564,6 +565,14 @@ class MainActivity : FlutterActivity() {
                 controlBytesSink = null
             }
         })
+
+        // Wire the MediaSession bridge so the host sees real YouTube Music metadata
+        // when notification listener access is granted.
+        mediaSessionBridge = MediaSessionBridge(applicationContext) { metadata ->
+            @Suppress("UNCHECKED_CAST")
+            sendEventToFlutter(metadata as Map<String, Any>)
+        }
+        mediaSessionBridge?.attach()
     }
 
     // Parse the 8-byte VoiceFrame header and push the Opus payload into the
@@ -635,6 +644,13 @@ class MainActivity : FlutterActivity() {
         ))
     }
 
+    // Re-attach the MediaSession bridge on resume so a notification-access grant
+    // that happened while the user was in system settings takes effect immediately.
+    override fun onResume() {
+        super.onResume()
+        mediaSessionBridge?.attach()
+    }
+
     // Called when the notification's Leave action brings this activity back
     // to the foreground (singleTop launchMode prevents a new instance). PTT
     // and Mute go through [WalkieTalkieService] → [dispatchEventFromService]
@@ -668,6 +684,8 @@ class MainActivity : FlutterActivity() {
             instance = null
         }
         nativeUnregisterCallbacks()
+        mediaSessionBridge?.detach()
+        mediaSessionBridge = null
         audioRoutingManager?.cleanup()
         bluetoothManager?.cleanup()
         peerAudioManager?.clear()

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
@@ -1,0 +1,151 @@
+package com.elodin.walkie_talkie
+
+import android.content.ComponentName
+import android.content.Context
+import android.media.MediaMetadata
+import android.media.session.MediaController
+import android.media.session.MediaSessionManager
+import android.media.session.PlaybackState
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+
+/**
+ * Bridges the Android MediaSessionManager to Flutter by subscribing to the active
+ * YouTube Music MediaController and dispatching track metadata via [onMetadata].
+ *
+ * Requires the user to have granted notification listener access for this app
+ * (Settings → Apps → Special app access → Notification access). If access has
+ * not been granted yet, [attach] logs a warning and returns without crashing;
+ * the host falls back to placeholder track data.
+ *
+ * Call [attach] on Activity start/resume (idempotent), [detach] on destroy.
+ */
+class MediaSessionBridge(
+    private val context: Context,
+    private val onMetadata: (Map<String, Any?>) -> Unit,
+) {
+    companion object {
+        private const val TAG = "MediaSessionBridge"
+        private const val YT_MUSIC_PKG = "com.google.android.apps.youtube.music"
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var activeController: MediaController? = null
+    private var isAttached = false
+
+    private val sessionManager: MediaSessionManager by lazy {
+        context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager
+    }
+
+    private val controllerCallback = object : MediaController.Callback() {
+        override fun onMetadataChanged(metadata: MediaMetadata?) {
+            dispatchMetadata(activeController, metadata)
+        }
+
+        override fun onPlaybackStateChanged(state: PlaybackState?) {
+            dispatchMetadata(activeController, activeController?.metadata)
+        }
+
+        override fun onSessionDestroyed() {
+            Log.i(TAG, "YouTube Music session destroyed")
+            activeController?.unregisterCallback(this)
+            activeController = null
+            onMetadata(mapOf("type" to "mediaMetadata", "available" to false))
+            // Scan remaining active sessions in case another YT Music instance exists
+            if (isAttached) scanForYtMusic()
+        }
+    }
+
+    private val sessionsListener = MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
+        Log.d(TAG, "Active sessions changed: ${controllers?.size ?: 0}")
+        val ytMusic = controllers?.firstOrNull { it.packageName == YT_MUSIC_PKG }
+        when {
+            ytMusic != null && ytMusic.sessionToken != activeController?.sessionToken -> {
+                switchTo(ytMusic)
+            }
+            ytMusic == null && activeController != null -> {
+                Log.i(TAG, "YouTube Music session no longer active")
+                activeController?.unregisterCallback(controllerCallback)
+                activeController = null
+                onMetadata(mapOf("type" to "mediaMetadata", "available" to false))
+            }
+        }
+    }
+
+    /**
+     * Subscribe to MediaSessionManager. Safe to call multiple times — only attaches once.
+     * Call on Activity resume so permission grants that happened while backgrounded are picked up.
+     */
+    fun attach() {
+        if (isAttached) return
+        val notifComponent = ComponentName(context, WalkieTalkieNotificationListener::class.java)
+        try {
+            val controllers = sessionManager.getActiveSessions(notifComponent)
+            sessionManager.addOnActiveSessionsChangedListener(
+                sessionsListener, notifComponent, mainHandler
+            )
+            isAttached = true
+            val ytMusic = controllers.firstOrNull { it.packageName == YT_MUSIC_PKG }
+            if (ytMusic != null) switchTo(ytMusic)
+        } catch (e: SecurityException) {
+            // User hasn't granted notification access yet — graceful degradation, placeholder shown.
+            Log.w(TAG, "Notification listener not enabled: ${e.message}")
+        }
+    }
+
+    /**
+     * Unsubscribe from MediaSessionManager and release the active controller.
+     * Call from Activity.onDestroy().
+     */
+    fun detach() {
+        isAttached = false
+        try {
+            sessionManager.removeOnActiveSessionsChangedListener(sessionsListener)
+        } catch (_: Exception) {}
+        activeController?.unregisterCallback(controllerCallback)
+        activeController = null
+    }
+
+    private fun scanForYtMusic() {
+        val notifComponent = ComponentName(context, WalkieTalkieNotificationListener::class.java)
+        try {
+            val controllers = sessionManager.getActiveSessions(notifComponent)
+            val ytMusic = controllers.firstOrNull { it.packageName == YT_MUSIC_PKG }
+            if (ytMusic != null) switchTo(ytMusic)
+        } catch (_: SecurityException) {}
+    }
+
+    private fun switchTo(controller: MediaController) {
+        activeController?.unregisterCallback(controllerCallback)
+        activeController = controller
+        controller.registerCallback(controllerCallback, mainHandler)
+        Log.i(TAG, "Subscribed to YouTube Music MediaSession")
+        dispatchMetadata(controller, controller.metadata)
+    }
+
+    private fun dispatchMetadata(controller: MediaController?, metadata: MediaMetadata?) {
+        if (controller == null) return
+        val state = controller.playbackState
+        val playing = state?.state == PlaybackState.STATE_PLAYING
+        val positionMs = state?.position ?: 0L
+        val title = metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: ""
+        val artist = metadata?.getString(MediaMetadata.METADATA_KEY_ARTIST)
+            ?: metadata?.getString(MediaMetadata.METADATA_KEY_ALBUM_ARTIST)
+            ?: ""
+        val durationMs = metadata?.getLong(MediaMetadata.METADATA_KEY_DURATION)
+            ?.takeIf { it > 0 } ?: 0L
+
+        onMetadata(
+            mapOf(
+                "type" to "mediaMetadata",
+                "available" to true,
+                "title" to title,
+                "artist" to artist,
+                "durationMs" to durationMs,
+                "positionMs" to positionMs,
+                "playing" to playing,
+            )
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
@@ -19,7 +19,13 @@ import android.util.Log
  * not been granted yet, [attach] logs a warning and returns without crashing;
  * the host falls back to placeholder track data.
  *
- * Call [attach] on Activity start/resume (idempotent), [detach] on destroy.
+ * Call [attach] on Activity start/resume — it is safe to call repeatedly.
+ * The sessions-changed listener is registered only once; the scan+dispatch runs
+ * on every call so that a permission grant or session change that occurred while
+ * backgrounded is picked up immediately on resume. Call [detach] on destroy.
+ *
+ * Call [replayLastMetadata] when the Flutter EventChannel listener first attaches
+ * so any metadata that was dispatched before Flutter started listening is replayed.
  */
 class MediaSessionBridge(
     private val context: Context,
@@ -32,7 +38,10 @@ class MediaSessionBridge(
 
     private val mainHandler = Handler(Looper.getMainLooper())
     private var activeController: MediaController? = null
-    private var isAttached = false
+    private var isListenerRegistered = false
+
+    /** Last dispatched event; replayed to late Flutter listeners via [replayLastMetadata]. */
+    private var lastMetadata: Map<String, Any?>? = null
 
     private val sessionManager: MediaSessionManager by lazy {
         context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager
@@ -51,9 +60,9 @@ class MediaSessionBridge(
             Log.i(TAG, "YouTube Music session destroyed")
             activeController?.unregisterCallback(this)
             activeController = null
-            onMetadata(mapOf("type" to "mediaMetadata", "available" to false))
-            // Scan remaining active sessions in case another YT Music instance exists
-            if (isAttached) scanForYtMusic()
+            emit(mapOf("type" to "mediaMetadata", "available" to false))
+            // Scan remaining active sessions in case another YT Music instance exists.
+            if (isListenerRegistered) scanForYtMusic()
         }
     }
 
@@ -68,29 +77,57 @@ class MediaSessionBridge(
                 Log.i(TAG, "YouTube Music session no longer active")
                 activeController?.unregisterCallback(controllerCallback)
                 activeController = null
-                onMetadata(mapOf("type" to "mediaMetadata", "available" to false))
+                emit(mapOf("type" to "mediaMetadata", "available" to false))
             }
         }
     }
 
     /**
-     * Subscribe to MediaSessionManager. Safe to call multiple times — only attaches once.
-     * Call on Activity resume so permission grants that happened while backgrounded are picked up.
+     * Scan for active YouTube Music sessions and dispatch metadata if found.
+     * Registers the sessions-changed listener only on the first successful call
+     * (guarded by [isListenerRegistered]).
+     *
+     * Safe to call from Activity.onResume() — re-registers nothing, but always
+     * re-scans so a YT Music session that appeared while backgrounded is picked
+     * up, and a SecurityException after a permission revoke cleans up state.
      */
     fun attach() {
-        if (isAttached) return
         val notifComponent = ComponentName(context, WalkieTalkieNotificationListener::class.java)
         try {
             val controllers = sessionManager.getActiveSessions(notifComponent)
-            sessionManager.addOnActiveSessionsChangedListener(
-                sessionsListener, notifComponent, mainHandler
-            )
-            isAttached = true
+
+            // Register the listener only once — repeated calls must not stack listeners.
+            if (!isListenerRegistered) {
+                sessionManager.addOnActiveSessionsChangedListener(
+                    sessionsListener, notifComponent, mainHandler
+                )
+                isListenerRegistered = true
+            }
+
+            // Always re-scan: a YT Music session may have started while we were backgrounded,
+            // or an existing session may have changed identity (new MediaSession token).
             val ytMusic = controllers.firstOrNull { it.packageName == YT_MUSIC_PKG }
-            if (ytMusic != null) switchTo(ytMusic)
+            when {
+                ytMusic != null && ytMusic.sessionToken != activeController?.sessionToken -> {
+                    switchTo(ytMusic)
+                }
+                ytMusic == null && activeController != null -> {
+                    // YT Music disappeared while backgrounded.
+                    activeController?.unregisterCallback(controllerCallback)
+                    activeController = null
+                    emit(mapOf("type" to "mediaMetadata", "available" to false))
+                }
+            }
         } catch (e: SecurityException) {
-            // User hasn't granted notification access yet — graceful degradation, placeholder shown.
             Log.w(TAG, "Notification listener not enabled: ${e.message}")
+            // Permission revoked while attached — tear down the registered listener and controller.
+            if (isListenerRegistered) {
+                isListenerRegistered = false
+                try { sessionManager.removeOnActiveSessionsChangedListener(sessionsListener) } catch (_: Exception) {}
+                activeController?.unregisterCallback(controllerCallback)
+                activeController = null
+                emit(mapOf("type" to "mediaMetadata", "available" to false))
+            }
         }
     }
 
@@ -99,12 +136,22 @@ class MediaSessionBridge(
      * Call from Activity.onDestroy().
      */
     fun detach() {
-        isAttached = false
+        isListenerRegistered = false
         try {
             sessionManager.removeOnActiveSessionsChangedListener(sessionsListener)
         } catch (_: Exception) {}
         activeController?.unregisterCallback(controllerCallback)
         activeController = null
+        lastMetadata = null
+    }
+
+    /**
+     * Re-dispatch the last known metadata event to a newly-attached Flutter listener.
+     * Call this from EventChannel.StreamHandler.onListen() so that metadata dispatched
+     * before Flutter started listening is not permanently lost.
+     */
+    fun replayLastMetadata() {
+        lastMetadata?.let { onMetadata(it) }
     }
 
     private fun scanForYtMusic() {
@@ -136,7 +183,7 @@ class MediaSessionBridge(
         val durationMs = metadata?.getLong(MediaMetadata.METADATA_KEY_DURATION)
             ?.takeIf { it > 0 } ?: 0L
 
-        onMetadata(
+        emit(
             mapOf(
                 "type" to "mediaMetadata",
                 "available" to true,
@@ -147,5 +194,10 @@ class MediaSessionBridge(
                 "playing" to playing,
             )
         )
+    }
+
+    private fun emit(event: Map<String, Any?>) {
+        lastMetadata = event
+        onMetadata(event)
     }
 }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieNotificationListener.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieNotificationListener.kt
@@ -1,0 +1,12 @@
+package com.elodin.walkie_talkie
+
+import android.service.notification.NotificationListenerService
+
+/**
+ * Minimal NotificationListenerService that grants this app permission to call
+ * MediaSessionManager.getActiveSessions(). The service itself does nothing —
+ * all MediaSession work is in MediaSessionBridge.
+ *
+ * Enabled by the user in Settings → Apps → Special app access → Notification access.
+ */
+class WalkieTalkieNotificationListener : NotificationListenerService()

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -128,6 +128,10 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   late MediaSourceLib _lib;
   Track get _track => _lib.queue[_trackIdx];
 
+  /// Live track metadata from the native MediaSession bridge (YouTube Music only).
+  /// Non-null only when notification listener access is granted and YT Music is active.
+  ({String title, String artist, int durationMs})? _liveYtMusicMeta;
+
   bool get _meEffectivelyMuted => widget.pttMode ? !_holdingPtt : _meMuted;
 
   late final AudioService _audio;
@@ -297,6 +301,46 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
             reason.contains('AUTHORIZATION_DENIED')) {
           unawaited(cubit.recheckPermissions());
         }
+      } else if (type == 'mediaMetadata') {
+        // Live playback metadata from the native MediaSessionBridge (YouTube Music).
+        // Only surfaces on the host device when notification listener access is
+        // granted; guests still see placeholder track data.
+        final available = event['available'] as bool? ?? false;
+        if (!available) {
+          if (_liveYtMusicMeta != null) {
+            setState(() {
+              _liveYtMusicMeta = null;
+              if (_source == 'YouTube Music') {
+                _lib = _buildPlaceholderLib(
+                  source: _source,
+                  trackIdx: _trackIdx,
+                  positionSec: _progress,
+                );
+              }
+            });
+          }
+          return;
+        }
+        final title = event['title'] as String? ?? '';
+        final artist = event['artist'] as String? ?? '';
+        final durationMs = (event['durationMs'] as num?)?.toInt() ?? 0;
+        final positionMs = (event['positionMs'] as num?)?.toInt() ?? 0;
+        final playing = event['playing'] as bool? ?? false;
+        setState(() {
+          _liveYtMusicMeta = (
+            title: title,
+            artist: artist,
+            durationMs: durationMs,
+          );
+          if (_source == 'YouTube Music') {
+            _lib = _buildPlaceholderLib(source: _source, trackIdx: _trackIdx);
+            _progress = (positionMs / 1000).round().clamp(
+              0,
+              _lib.queue[_trackIdx].durationSeconds,
+            );
+            _playing = playing;
+          }
+        });
       }
     });
 
@@ -411,13 +455,43 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     int positionSec = 0,
   }) {
     final clampedIdx = trackIdx < 0 ? 0 : trackIdx;
-    final placeholderDurationSec = positionSec * 2 < 60 ? 60 : positionSec * 2;
     // Use the human-readable display label for MediaSourceLib.name so UI
     // surfaces ("From Spotify", "Open Spotify") are user-facing rather than
     // showing raw wire keys like "spotify" or "pocket_casts". Unknown future
     // keys fall back to the raw wireKey string rather than defaulting to
     // "YouTube Music" (which fromWireKey does for backward compat).
     final displayName = _sourceDisplayName(source);
+
+    // When the native MediaSession bridge has live YouTube Music metadata,
+    // substitute real title/artist/duration for the current track so the host
+    // sees actual playback info rather than "Track N / YouTube Music".
+    final meta = (source == 'YouTube Music') ? _liveYtMusicMeta : null;
+    if (meta != null) {
+      final durationSec = (meta.durationMs / 1000).ceil().clamp(1, 86400);
+      return MediaSourceLib(
+        name: displayName,
+        kind: emptyMediaLib.kind,
+        queue: [
+          for (var i = 0; i < clampedIdx; i++)
+            Track(
+              title: 'Track ${i + 1}',
+              artist: displayName,
+              durationSeconds: durationSec,
+              tag: '',
+            ),
+          Track(
+            title: meta.title.isNotEmpty
+                ? meta.title
+                : 'Track ${clampedIdx + 1}',
+            artist: meta.artist.isNotEmpty ? meta.artist : displayName,
+            durationSeconds: durationSec,
+            tag: '',
+          ),
+        ],
+      );
+    }
+
+    final placeholderDurationSec = positionSec * 2 < 60 ? 60 : positionSec * 2;
     return MediaSourceLib(
       name: displayName,
       kind: emptyMediaLib.kind,

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -334,7 +334,7 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           );
           if (_source == 'YouTube Music') {
             _lib = _buildPlaceholderLib(source: _source, trackIdx: _trackIdx);
-            _progress = (positionMs / 1000).round().clamp(
+            _progress = (positionMs / 1000).floor().clamp(
               0,
               _lib.queue[_trackIdx].durationSeconds,
             );
@@ -467,7 +467,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // sees actual playback info rather than "Track N / YouTube Music".
     final meta = (source == 'YouTube Music') ? _liveYtMusicMeta : null;
     if (meta != null) {
-      final durationSec = (meta.durationMs / 1000).ceil().clamp(1, 86400);
+      // Fall back to the placeholder heuristic when the MediaSession doesn't
+      // expose duration (durationMs=0) — a 1-second clamp would break the
+      // progress slider and timer (Copilot review on PR #380).
+      final durationSec = meta.durationMs > 0
+          ? (meta.durationMs / 1000).ceil().clamp(1, 86400)
+          : (positionSec * 2 < 60 ? 60 : positionSec * 2);
       return MediaSourceLib(
         name: displayName,
         kind: emptyMediaLib.kind,


### PR DESCRIPTION
## Summary

Closes #368 — implements the MediaSession bridge that lets the host device show real YouTube Music playback metadata (track title, artist, duration, position, play/pause state) instead of the placeholder "Track N / YouTube Music" entries.

- **`WalkieTalkieNotificationListener`** — minimal `NotificationListenerService` stub that grants `MediaSessionManager.getActiveSessions()` permission. User enables it once in Settings → Apps → Special app access → Notification access.
- **`MediaSessionBridge`** — finds the active YouTube Music `MediaController`, subscribes to its callbacks (`onMetadataChanged`, `onPlaybackStateChanged`, `onSessionDestroyed`), and dispatches `type=mediaMetadata` events through the existing `audioEvents` EventChannel. Falls back silently when notification access is not granted (`SecurityException` → placeholder retained, no crash).
- **`MainActivity`** — instantiates the bridge, calls `attach()` on engine start and every `onResume()` (so a permission grant that happened in system settings takes effect immediately without a full restart), and `detach()` on destroy.
- **`AndroidManifest.xml`** — declares `WalkieTalkieNotificationListener` with `BIND_NOTIFICATION_LISTENER_SERVICE` permission and `NotificationListenerService` intent-filter.
- **`frequency_room_screen.dart`** — adds `_liveYtMusicMeta` field; handles `mediaMetadata` events in `_audioEventsSub`; `_buildPlaceholderLib` uses real title/artist/durationMs for the YouTube Music source when metadata is available. Guests still see placeholder text (metadata is not on the wire protocol yet — host-only for this PR).

## Acceptance

- ✅ Live title/artist/duration when YouTube Music is playing on the host device (requires notification access grant)
- ✅ No crash / graceful fallback when YT Music is not installed or not playing
- ✅ No crash when notification access is not yet granted (SecurityException handled)

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 878/878 passed
- [x] `bash scripts/presubmit.sh` exits 0 (includes Kotlin gate)
- [x] `./gradlew :app:testDebugUnitTest --no-daemon` — BUILD SUCCESSFUL
- [x] `flutter build appbundle --debug` — ~79 MiB, within 100 MiB alarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)