### PR TITLE
fix(#361): fix Motorola BLE advertising overflow + remove cross-OEM UUID scan filter

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -203,23 +203,33 @@ class HostAdvertiser(private val context: Context) {
             }
         }
 
-        // The 31-byte legacy ADV_IND budget can't fit *all* of: flags (auto),
-        // 128-bit service UUID (18 bytes including header), 16-byte
-        // manufacturer payload (20 bytes including header), and the adapter
-        // device name. 18 + 20 alone overflows. Split across primary adv
-        // (service UUID — keeps passive scanners able to filter) and scan
-        // response (manufacturer payload + device name — only fetched on the
-        // SCAN_REQ that active scanners issue, which is what the Dart
-        // DiscoveryService does). The Android stack merges both records into
-        // ScanRecord, so DiscoveredSession.fromManufacturerData reassembles
-        // them transparently.
+        // Budget split across the two 31-byte legacy PDUs:
+        //
+        //   Primary ADV_IND (3 flags + 18 UUID = 21 bytes used, 10 remaining):
+        //     - Service UUID: keeps hardware scan filters working on Pixel/Qualcomm.
+        //     - Device name via setIncludeDeviceName(true): up to 8 chars fit in
+        //       the remaining 10 bytes; Android auto-uses Shortened Local Name
+        //       (AD 0x08) for longer names so they still advertise instead of
+        //       triggering ADVERTISE_FAILED_DATA_TOO_LARGE. Previously the name
+        //       lived in the scan response alongside the 20-byte manufacturer
+        //       payload; combined they overflowed 31 bytes on any device whose
+        //       BT name exceeded 9 chars (e.g. "moto g power (2022)"), silently
+        //       preventing advertising from starting on Motorola hosts.
+        //
+        //   Scan response SCAN_RSP (20 bytes used):
+        //     - Manufacturer payload only. The Android stack merges both PDUs
+        //       into ScanRecord, so DiscoveredSession.fromManufacturerData
+        //       reassembles them transparently.
+        val payloadHex = payload.joinToString("") { "%02x".format(it) }
+        Log.d(TAG, "adv payload: mfg_id=0x%04x bytes=%s".format(MANUFACTURER_ID, payloadHex))
+
         val advData = AdvertiseData.Builder()
             .addServiceUuid(ParcelUuid(SERVICE_UUID))
+            .setIncludeDeviceName(true)
             .build()
 
         val scanResponse = AdvertiseData.Builder()
             .addManufacturerData(MANUFACTURER_ID, payload)
-            .setIncludeDeviceName(true)
             .build()
 
         val settings = AdvertiseSettings.Builder()

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -206,7 +206,8 @@ class HostAdvertiser(private val context: Context) {
         // Budget split across the two 31-byte legacy PDUs:
         //
         //   Primary ADV_IND (3 flags + 18 UUID = 21 bytes used, 10 remaining):
-        //     - Service UUID: keeps hardware scan filters working on Pixel/Qualcomm.
+        //     - Service UUID: allows passive BLE scanners and third-party apps to
+        //       identify this as a Frequency host without decoding the payload.
         //     - Device name via setIncludeDeviceName(true): up to 8 chars fit in
         //       the remaining 10 bytes; Android auto-uses Shortened Local Name
         //       (AD 0x08) for longer names so they still advertise instead of
@@ -220,7 +221,7 @@ class HostAdvertiser(private val context: Context) {
         //     - Manufacturer payload only. The Android stack merges both PDUs
         //       into ScanRecord, so DiscoveredSession.fromManufacturerData
         //       reassembles them transparently.
-        val payloadHex = payload.joinToString("") { "%02x".format(it) }
+        val payloadHex = payload.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
         Log.d(TAG, "adv payload: mfg_id=0x%04x bytes=%s".format(MANUFACTURER_ID, payloadHex))
 
         val advData = AdvertiseData.Builder()

--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -73,11 +73,16 @@ class DiscoveryService {
     // 3. Start scanning without a hardware service-UUID filter.
     //
     // Some OEM BLE stacks (notably MediaTek-based Motorola devices) advertise
-    // 128-bit UUIDs in non-standard byte order or do not respond to hardware
-    // UUID scan filters from other vendors' chipsets. A withServices filter
-    // here silently drops those advertisements before parseResult ever sees
-    // them. parseResult already filters by protocol version and role, so
-    // software filtering is both safe and cross-OEM reliable.
+    // 128-bit UUIDs in non-standard byte order or do not honour hardware UUID
+    // scan filters from other vendors' chipsets. A withServices filter here
+    // silently drops those advertisements before parseResult ever sees them.
+    //
+    // parseResult already performs software filtering — it only accepts payloads
+    // whose first byte is protocol version 0x01 and second byte is role 0x01
+    // (see DiscoveredSession.fromManufacturerData). Content-based filtering is
+    // more reliable than UUID-based filtering because it checks the actual
+    // payload regardless of how the advertising metadata is encoded by the
+    // host's BLE stack.
     await FlutterBluePlus.startScan(
       // No timeout — user controls start/stop; avoids silent timeout failures.
     );

--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -70,12 +70,16 @@ class DiscoveryService {
     // (e.g. adapter turned off, or platform scan timeout).
     FlutterBluePlus.cancelWhenScanComplete(_scanSubscription!);
 
-    // 3. Start scanning.
-    // We filter by the service UUID defined in the protocol.
+    // 3. Start scanning without a hardware service-UUID filter.
+    //
+    // Some OEM BLE stacks (notably MediaTek-based Motorola devices) advertise
+    // 128-bit UUIDs in non-standard byte order or do not respond to hardware
+    // UUID scan filters from other vendors' chipsets. A withServices filter
+    // here silently drops those advertisements before parseResult ever sees
+    // them. parseResult already filters by protocol version and role, so
+    // software filtering is both safe and cross-OEM reliable.
     await FlutterBluePlus.startScan(
-      withServices: [Guid(kWalkieTalkieServiceUuid)],
-      // We remove the timeout to let the user control pausing/scanning
-      // and prevent silent timeout failures (Thread 5, 11).
+      // No timeout — user controls start/stop; avoids silent timeout failures.
     );
 
     // Start prune timer only after scan starts successfully. This prevents a

--- a/test/services/bluetooth_discovery_service_test.dart
+++ b/test/services/bluetooth_discovery_service_test.dart
@@ -241,6 +241,24 @@ void main() {
       expect(session2!.sessionUuidLow8, uuid2.toLowerCase());
     });
 
+    test('parseResult accepts production company ID 0xFFFF', () {
+      // HostAdvertiser uses MANUFACTURER_ID = 0xFFFF. parseResult iterates all
+      // manufacturer data entries and applies protocol-level filtering, so the
+      // company ID is irrelevant — any value that carries a valid v1 payload
+      // is accepted. This test pins the round-trip with the production ID.
+      final scanResult = makeScanResult(
+        manufacturerData: {0xFFFF: validV1Payload().toList()},
+        advName: 'Moto G',
+        rssi: -68,
+      );
+
+      final session = service.parseResult(scanResult);
+
+      expect(session, isNotNull);
+      expect(session!.hostName, 'Moto G');
+      expect(session.sessionUuidLow8, '0011223344556677');
+    });
+
     test(
       'parseResult returns first valid session from multiple mfg entries',
       () {

--- a/test/services/bluetooth_discovery_service_test.dart
+++ b/test/services/bluetooth_discovery_service_test.dart
@@ -241,11 +241,12 @@ void main() {
       expect(session2!.sessionUuidLow8, uuid2.toLowerCase());
     });
 
-    test('parseResult accepts production company ID 0xFFFF', () {
-      // HostAdvertiser uses MANUFACTURER_ID = 0xFFFF. parseResult iterates all
-      // manufacturer data entries and applies protocol-level filtering, so the
-      // company ID is irrelevant — any value that carries a valid v1 payload
-      // is accepted. This test pins the round-trip with the production ID.
+    test('parseResult accepts test/internal manufacturer ID 0xFFFF', () {
+      // HostAdvertiser uses MANUFACTURER_ID = 0xFFFF (Bluetooth SIG test/internal
+      // range). parseResult iterates all manufacturer data entries and applies
+      // protocol-level filtering, so the company ID is irrelevant — any value
+      // that carries a valid v1 payload is accepted. This test pins the
+      // round-trip with the actual HostAdvertiser ID.
       final scanResult = makeScanResult(
         manufacturerData: {0xFFFF: validV1Payload().toList()},
         advName: 'Moto G',


### PR DESCRIPTION
## Summary

Fixes two root causes that prevented Pixel from discovering frequencies hosted by Motorola devices.

### Root cause 1 — Scan response PDU overflow (HostAdvertiser.kt)

`setIncludeDeviceName(true)` was placed in the scan response builder alongside the 20-byte manufacturer payload. Combined, they exceed the 31-byte legacy PDU budget for any BT name longer than 9 chars (e.g. `"moto g power (2022)"` = 19 chars). The Android BLE stack responds with `ADVERTISE_FAILED_DATA_TOO_LARGE`, silently preventing advertising from starting on Motorola hosts.

**Fix:** Move `setIncludeDeviceName(true)` to the primary `ADV_IND` packet. After 3 bytes of flags + 18 bytes for the 128-bit UUID, 10 bytes remain — enough for names up to 8 chars. For longer names Android automatically uses the Shortened Local Name AD type (0x08) which truncates gracefully without failing.

**Bonus:** Add a `Log.d` line on every `start()` that logs the raw manufacturer payload hex bytes for future triage.

### Root cause 2 — Cross-OEM hardware UUID scan filter (bluetooth_discovery_service.dart)

`FlutterBluePlus.startScan(withServices: [Guid(kWalkieTalkieServiceUuid)])` uses Android hardware BLE scan filters. Some OEM chipsets (notably MediaTek-based Motorola devices) advertise 128-bit UUIDs in non-standard byte order or do not respond correctly to hardware UUID filters from other vendors' chipsets. These advertisements are dropped before `parseResult` ever sees them.

**Fix:** Remove the hardware filter. `parseResult` already filters by protocol version byte and role byte — specific enough to reject non-Frequency advertisements without help from the hardware layer.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — all 634 tests pass (includes new `parseResult accepts production company ID 0xFFFF`)
- [x] C++ unit tests — all pass
- [x] Kotlin unit tests (`./gradlew :app:testDebugUnitTest`) — BUILD SUCCESSFUL
- [x] Debug AAB build — 82 MB < 100 MiB budget
- [ ] On-device: Motorola hosting → Pixel discovers the frequency (requires hardware)

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)