### PR TITLE
feat(#370): wire Pocket Casts MediaSession bridge

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
@@ -61,6 +61,27 @@ class MediaSessionBridge(
         }
 
         override fun onPlaybackStateChanged(state: PlaybackState?) {
+            // OnActiveSessionsChangedListener does not fire for in-place play/pause
+            // toggles. When the active session leaves STATE_PLAYING, check whether
+            // another supported app is currently playing and switch to it so the
+            // bridge doesn't stay locked on a paused session.
+            if (isListenerRegistered &&
+                state?.state != PlaybackState.STATE_PLAYING &&
+                activeController != null) {
+                val notifComponent = ComponentName(context, WalkieTalkieNotificationListener::class.java)
+                try {
+                    val playing = sessionManager.getActiveSessions(notifComponent)
+                        ?.firstOrNull {
+                            PKG_TO_WIRE_KEY.containsKey(it.packageName) &&
+                                it.sessionToken != activeController?.sessionToken &&
+                                it.playbackState?.state == PlaybackState.STATE_PLAYING
+                        }
+                    if (playing != null) {
+                        switchTo(playing)
+                        return
+                    }
+                } catch (_: SecurityException) {}
+            }
             dispatchMetadata(activeController, activeController?.metadata)
         }
 
@@ -164,12 +185,16 @@ class MediaSessionBridge(
     /**
      * Pick the best controller from [controllers]: prefers a supported app that is
      * actively playing; falls back to the first supported app in the list.
+     * Single-pass: tracks the first supported controller while scanning for a playing one.
      */
     private fun bestController(controllers: List<MediaController>?): MediaController? {
-        val supported = controllers?.filter { PKG_TO_WIRE_KEY.containsKey(it.packageName) }
-            ?: return null
-        return supported.firstOrNull { it.playbackState?.state == PlaybackState.STATE_PLAYING }
-            ?: supported.firstOrNull()
+        var first: MediaController? = null
+        controllers?.forEach { c ->
+            if (!PKG_TO_WIRE_KEY.containsKey(c.packageName)) return@forEach
+            if (c.playbackState?.state == PlaybackState.STATE_PLAYING) return c
+            if (first == null) first = c
+        }
+        return first
     }
 
     private fun scanForBestSession() {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
@@ -12,7 +12,8 @@ import android.util.Log
 
 /**
  * Bridges the Android MediaSessionManager to Flutter by subscribing to the active
- * YouTube Music MediaController and dispatching track metadata via [onMetadata].
+ * MediaController for a supported music/podcast app and dispatching track metadata
+ * via [onMetadata]. Supported apps: YouTube Music, Pocket Casts.
  *
  * Requires the user to have granted notification listener access for this app
  * (Settings → Apps → Special app access → Notification access). If access has
@@ -34,6 +35,13 @@ class MediaSessionBridge(
     companion object {
         private const val TAG = "MediaSessionBridge"
         private const val YT_MUSIC_PKG = "com.google.android.apps.youtube.music"
+        private const val POCKET_CASTS_PKG = "au.com.shiftyjelly.pocketcasts"
+
+        /** Maps package name → Flutter wire key (must match MediaSource.wireKey in Dart). */
+        private val PKG_TO_WIRE_KEY = mapOf(
+            YT_MUSIC_PKG to "YouTube Music",
+            POCKET_CASTS_PKG to "pocket_casts",
+        )
     }
 
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -57,24 +65,24 @@ class MediaSessionBridge(
         }
 
         override fun onSessionDestroyed() {
-            Log.i(TAG, "YouTube Music session destroyed")
+            val pkg = activeController?.packageName ?: "unknown"
+            Log.i(TAG, "$pkg session destroyed")
             activeController?.unregisterCallback(this)
             activeController = null
             emit(mapOf("type" to "mediaMetadata", "available" to false))
-            // Scan remaining active sessions in case another YT Music instance exists.
-            if (isListenerRegistered) scanForYtMusic()
+            if (isListenerRegistered) scanForBestSession()
         }
     }
 
     private val sessionsListener = MediaSessionManager.OnActiveSessionsChangedListener { controllers ->
         Log.d(TAG, "Active sessions changed: ${controllers?.size ?: 0}")
-        val ytMusic = controllers?.firstOrNull { it.packageName == YT_MUSIC_PKG }
+        val best = bestController(controllers)
         when {
-            ytMusic != null && ytMusic.sessionToken != activeController?.sessionToken -> {
-                switchTo(ytMusic)
+            best != null && best.sessionToken != activeController?.sessionToken -> {
+                switchTo(best)
             }
-            ytMusic == null && activeController != null -> {
-                Log.i(TAG, "YouTube Music session no longer active")
+            best == null && activeController != null -> {
+                Log.i(TAG, "${activeController?.packageName} session no longer active")
                 activeController?.unregisterCallback(controllerCallback)
                 activeController = null
                 emit(mapOf("type" to "mediaMetadata", "available" to false))
@@ -83,13 +91,13 @@ class MediaSessionBridge(
     }
 
     /**
-     * Scan for active YouTube Music sessions and dispatch metadata if found.
+     * Scan for active sessions from supported apps and dispatch metadata if found.
      * Registers the sessions-changed listener only on the first successful call
      * (guarded by [isListenerRegistered]).
      *
      * Safe to call from Activity.onResume() — re-registers nothing, but always
-     * re-scans so a YT Music session that appeared while backgrounded is picked
-     * up, and a SecurityException after a permission revoke cleans up state.
+     * re-scans so a session that appeared while backgrounded is picked up, and a
+     * SecurityException after a permission revoke cleans up state.
      */
     fun attach() {
         val notifComponent = ComponentName(context, WalkieTalkieNotificationListener::class.java)
@@ -104,15 +112,14 @@ class MediaSessionBridge(
                 isListenerRegistered = true
             }
 
-            // Always re-scan: a YT Music session may have started while we were backgrounded,
-            // or an existing session may have changed identity (new MediaSession token).
-            val ytMusic = controllers.firstOrNull { it.packageName == YT_MUSIC_PKG }
+            // Always re-scan: a session may have started while backgrounded, or an existing
+            // session may have changed identity (new MediaSession token).
+            val best = bestController(controllers)
             when {
-                ytMusic != null && ytMusic.sessionToken != activeController?.sessionToken -> {
-                    switchTo(ytMusic)
+                best != null && best.sessionToken != activeController?.sessionToken -> {
+                    switchTo(best)
                 }
-                ytMusic == null && activeController != null -> {
-                    // YT Music disappeared while backgrounded.
+                best == null && activeController != null -> {
                     activeController?.unregisterCallback(controllerCallback)
                     activeController = null
                     emit(mapOf("type" to "mediaMetadata", "available" to false))
@@ -154,12 +161,23 @@ class MediaSessionBridge(
         lastMetadata?.let { onMetadata(it) }
     }
 
-    private fun scanForYtMusic() {
+    /**
+     * Pick the best controller from [controllers]: prefers a supported app that is
+     * actively playing; falls back to the first supported app in the list.
+     */
+    private fun bestController(controllers: List<MediaController>?): MediaController? {
+        val supported = controllers?.filter { PKG_TO_WIRE_KEY.containsKey(it.packageName) }
+            ?: return null
+        return supported.firstOrNull { it.playbackState?.state == PlaybackState.STATE_PLAYING }
+            ?: supported.firstOrNull()
+    }
+
+    private fun scanForBestSession() {
         val notifComponent = ComponentName(context, WalkieTalkieNotificationListener::class.java)
         try {
             val controllers = sessionManager.getActiveSessions(notifComponent)
-            val ytMusic = controllers.firstOrNull { it.packageName == YT_MUSIC_PKG }
-            if (ytMusic != null) switchTo(ytMusic)
+            val best = bestController(controllers)
+            if (best != null) switchTo(best)
         } catch (_: SecurityException) {}
     }
 
@@ -167,7 +185,7 @@ class MediaSessionBridge(
         activeController?.unregisterCallback(controllerCallback)
         activeController = controller
         controller.registerCallback(controllerCallback, mainHandler)
-        Log.i(TAG, "Subscribed to YouTube Music MediaSession")
+        Log.i(TAG, "Subscribed to ${controller.packageName} MediaSession")
         dispatchMetadata(controller, controller.metadata)
     }
 
@@ -182,11 +200,13 @@ class MediaSessionBridge(
             ?: ""
         val durationMs = metadata?.getLong(MediaMetadata.METADATA_KEY_DURATION)
             ?.takeIf { it > 0 } ?: 0L
+        val sourceWireKey = PKG_TO_WIRE_KEY[controller.packageName] ?: return
 
         emit(
             mapOf(
                 "type" to "mediaMetadata",
                 "available" to true,
+                "sourceWireKey" to sourceWireKey,
                 "title" to title,
                 "artist" to artist,
                 "durationMs" to durationMs,

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -128,9 +128,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   late MediaSourceLib _lib;
   Track get _track => _lib.queue[_trackIdx];
 
-  /// Live track metadata from the native MediaSession bridge (YouTube Music only).
-  /// Non-null only when notification listener access is granted and YT Music is active.
-  ({String title, String artist, int durationMs})? _liveYtMusicMeta;
+  /// Live track metadata from the native MediaSession bridge.
+  /// Non-null only when notification listener access is granted and a supported app is active.
+  ({String title, String artist, int durationMs})? _liveSourceMeta;
+
+  /// Wire key of the app supplying [_liveSourceMeta] (e.g. 'YouTube Music', 'pocket_casts').
+  String? _liveSourceKey;
 
   bool get _meEffectivelyMuted => widget.pttMode ? !_holdingPtt : _meMuted;
 
@@ -302,15 +305,17 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           unawaited(cubit.recheckPermissions());
         }
       } else if (type == 'mediaMetadata') {
-        // Live playback metadata from the native MediaSessionBridge (YouTube Music).
+        // Live playback metadata from the native MediaSessionBridge.
         // Only surfaces on the host device when notification listener access is
         // granted; guests still see placeholder track data.
         final available = event['available'] as bool? ?? false;
         if (!available) {
-          if (_liveYtMusicMeta != null) {
+          if (_liveSourceMeta != null) {
             setState(() {
-              _liveYtMusicMeta = null;
-              if (_source == 'YouTube Music') {
+              _liveSourceMeta = null;
+              final key = _liveSourceKey;
+              _liveSourceKey = null;
+              if (_source == key) {
                 _lib = _buildPlaceholderLib(
                   source: _source,
                   trackIdx: _trackIdx,
@@ -321,18 +326,21 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           }
           return;
         }
+        final sourceWireKey = event['sourceWireKey'] as String? ?? '';
+        if (sourceWireKey.isEmpty) return;
         final title = event['title'] as String? ?? '';
         final artist = event['artist'] as String? ?? '';
         final durationMs = (event['durationMs'] as num?)?.toInt() ?? 0;
         final positionMs = (event['positionMs'] as num?)?.toInt() ?? 0;
         final playing = event['playing'] as bool? ?? false;
         setState(() {
-          _liveYtMusicMeta = (
+          _liveSourceMeta = (
             title: title,
             artist: artist,
             durationMs: durationMs,
           );
-          if (_source == 'YouTube Music') {
+          _liveSourceKey = sourceWireKey;
+          if (_source == sourceWireKey) {
             _lib = _buildPlaceholderLib(source: _source, trackIdx: _trackIdx);
             _progress = (positionMs / 1000).floor().clamp(
               0,
@@ -459,13 +467,12 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // surfaces ("From Spotify", "Open Spotify") are user-facing rather than
     // showing raw wire keys like "spotify" or "pocket_casts". Unknown future
     // keys fall back to the raw wireKey string rather than defaulting to
-    // "YouTube Music" (which fromWireKey does for backward compat).
+    // the YouTube Music fallback that fromWireKey returns for backward compat.
     final displayName = _sourceDisplayName(source);
 
-    // When the native MediaSession bridge has live YouTube Music metadata,
-    // substitute real title/artist/duration for the current track so the host
-    // sees actual playback info rather than "Track N / YouTube Music".
-    final meta = (source == 'YouTube Music') ? _liveYtMusicMeta : null;
+    // When the native MediaSession bridge has live metadata for the current source,
+    // substitute real title/artist/duration so the host sees actual playback info.
+    final meta = (source == _liveSourceKey) ? _liveSourceMeta : null;
     if (meta != null) {
       // Fall back to the placeholder heuristic when the MediaSession doesn't
       // expose duration (durationMs=0) — a 1-second clamp would break the


### PR DESCRIPTION
Closes #370

## Summary

- Extends `MediaSessionBridge` to subscribe to Pocket Casts (`au.com.shiftyjelly.pocketcasts`) alongside YouTube Music, using the same `MediaSessionManager` / notification-listener route
- `bestController()` prefers the actively-playing session; falls back to first supported app — prevents silent slot-stealing when both apps are open
- `dispatchMetadata()` now emits `sourceWireKey` (matches `MediaSource.wireKey` in Dart) so Flutter knows which app supplied the metadata
- `frequency_room_screen`: rename `_liveYtMusicMeta` → `_liveSourceMeta`, add `_liveSourceKey`; source-equality guards now compare against `_liveSourceKey` so any supported source gets live metadata when selected as the room source

No crashes / blank state when Pocket Casts is not installed — `bestController()` simply returns null and Flutter falls back to placeholder tracks.

No manifest or enum changes needed — `au.com.shiftyjelly.pocketcasts` and `pca.st` were already declared in prior commits.

## Test plan

- [ ] Install Pocket Casts, play an episode, select Pocket Casts as room source → real episode title/artist/duration shown in NowPlayingCard
- [ ] Pause Pocket Casts → `playing` flag goes false, progress bar stops
- [ ] Pocket Casts not installed → no crash, placeholder tracks shown
- [ ] YouTube Music still works when selected as source (no regression)
- [ ] Both apps open simultaneously → bridge subscribes to the playing one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended live playback metadata support to multiple media sources, including Pocket Casts—previously limited to YouTube Music.
  * Improved media session selection to automatically switch to the best available active media source.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/382)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->