### PR TITLE
feat(#369): add Spotify to MediaSession bridge

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt
@@ -13,7 +13,7 @@ import android.util.Log
 /**
  * Bridges the Android MediaSessionManager to Flutter by subscribing to the active
  * MediaController for a supported music/podcast app and dispatching track metadata
- * via [onMetadata]. Supported apps: YouTube Music, Pocket Casts.
+ * via [onMetadata]. Supported apps: YouTube Music, Spotify, Pocket Casts.
  *
  * Requires the user to have granted notification listener access for this app
  * (Settings → Apps → Special app access → Notification access). If access has
@@ -35,11 +35,13 @@ class MediaSessionBridge(
     companion object {
         private const val TAG = "MediaSessionBridge"
         private const val YT_MUSIC_PKG = "com.google.android.apps.youtube.music"
+        private const val SPOTIFY_PKG = "com.spotify.music"
         private const val POCKET_CASTS_PKG = "au.com.shiftyjelly.pocketcasts"
 
         /** Maps package name → Flutter wire key (must match MediaSource.wireKey in Dart). */
         private val PKG_TO_WIRE_KEY = mapOf(
             YT_MUSIC_PKG to "YouTube Music",
+            SPOTIFY_PKG to "spotify",
             POCKET_CASTS_PKG to "pocket_casts",
         )
     }

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -807,7 +807,7 @@ void main() {
           hostPeerId: 'p-host',
           roster: const [],
           mediaState: const MediaState(
-            source: 'Spotify',
+            source: 'spotify',
             trackIdx: 1,
             playing: false,
             positionMs: 91000,
@@ -884,7 +884,7 @@ void main() {
               // 91s into the 2nd track on the wire — trackIdx must ride
               // through so outgoing media commands keep referencing the
               // same index the host published.
-              source: 'Spotify',
+              source: 'spotify',
               trackIdx: 1,
               playing: true,
               positionMs: 91000,
@@ -1485,7 +1485,7 @@ void main() {
           hostPeerId: 'p-host',
           roster: const [],
           mediaState: const MediaState(
-            source: 'Spotify',
+            source: 'spotify',
             trackIdx: 2,
             playing: true,
             positionMs: 0,
@@ -1523,7 +1523,7 @@ void main() {
             hostPeerId: 'p-host',
             roster: const [],
             mediaState: const MediaState(
-              source: 'Spotify',
+              source: 'spotify',
               trackIdx: 2,
               playing: true,
               positionMs: 0,

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -1542,6 +1542,107 @@ void main() {
         expect(find.text('Track 3'), findsNothing);
       },
     );
+
+    // --- Spotify MediaSession bridge (#369) ---
+
+    testWidgets(
+      'mediaMetadata event with sourceWireKey=spotify surfaces live title/artist (#369)',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        final cubit = _seededCubit();
+        addTearDown(cubit.close);
+
+        await tester.pumpWidget(_wrap(_room(), cubit: cubit));
+        await tester.pump();
+
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [],
+            mediaState: const MediaState(
+              source: 'spotify',
+              trackIdx: 0,
+              playing: true,
+              positionMs: 0,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        eventEmitter.emit({
+          'type': 'mediaMetadata',
+          'available': true,
+          'sourceWireKey': 'spotify',
+          'title': 'Blinding Lights',
+          'artist': 'The Weeknd',
+          'durationMs': 200000,
+          'positionMs': 10000,
+          'playing': true,
+        });
+        await tester.pump();
+
+        expect(find.text('Blinding Lights'), findsOneWidget);
+        expect(find.text('The Weeknd'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'mediaMetadata available=false clears live Spotify metadata (#369)',
+      (tester) async {
+        final eventEmitter = _EventChannelEmitter(
+          'com.elodin.walkie_talkie/audio_events',
+        );
+        addTearDown(eventEmitter.dispose);
+
+        final cubit = _seededCubit();
+        addTearDown(cubit.close);
+
+        await tester.pumpWidget(_wrap(_room(), cubit: cubit));
+        await tester.pump();
+
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [],
+            mediaState: const MediaState(
+              source: 'spotify',
+              trackIdx: 0,
+              playing: true,
+              positionMs: 0,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        eventEmitter.emit({
+          'type': 'mediaMetadata',
+          'available': true,
+          'sourceWireKey': 'spotify',
+          'title': 'Blinding Lights',
+          'artist': 'The Weeknd',
+          'durationMs': 200000,
+          'positionMs': 0,
+          'playing': true,
+        });
+        await tester.pump();
+        expect(find.text('Blinding Lights'), findsOneWidget);
+
+        eventEmitter.emit({'type': 'mediaMetadata', 'available': false});
+        await tester.pump();
+
+        expect(find.text('Blinding Lights'), findsNothing);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- Add `com.spotify.music` → `'spotify'` wire-key to `PKG_TO_WIRE_KEY` in `MediaSessionBridge.kt`, enabling the bridge to track Spotify's active `MediaSession` alongside YouTube Music and Pocket Casts.
- The Flutter room screen already dispatches on the generic `_liveSourceKey` / `_liveSourceMeta` path (added when multi-provider support landed); no Dart changes needed for that path.
- Add two widget tests: one verifies a `sourceWireKey='spotify'` event surfaces real title/artist in `NowPlayingCard`; the other verifies `available=false` clears the live metadata.

Closes #369.

## How it works

When the user selects Spotify as source, the room screen sets `_source = 'spotify'`. The native bridge (which already has `OnActiveSessionsChangedListener` watching all entries in `PKG_TO_WIRE_KEY`) will now match `com.spotify.music`, call `switchTo()`, and emit `{type: mediaMetadata, available: true, sourceWireKey: 'spotify', title: …, …}`. The room screen's `_source == _liveSourceKey` check then substitutes real track info into the `NowPlayingCard`.

Graceful fallback: when Spotify is not installed or not authenticated, the bridge simply never finds a matching session and the room screen continues showing placeholder track data — same behavior as before.

## Test plan

- [x] `bash scripts/presubmit.sh` — exit 0
- [x] `cd android && ./gradlew :app:testDebugUnitTest --no-daemon` — BUILD SUCCESSFUL (173 tasks)
- [x] Debug AAB build — 79.03 MiB (< 100 MiB regression alarm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spotify as a supported media source, enabling live metadata display (title and artist) through MediaSession integration with proper handling of availability states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/383)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->