### PR TITLE
docs: align README, protocol, and permissions rationale with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ handles BLE radio, L2CAP sockets, mic capture, and Opus.
       dedicated `controlBytes` EventChannel; Dart decodes them into typed
       `FrequencyMessage`s via [`BleControlTransport`](lib/services/ble_control_transport.dart).
       A second `audio_events` EventChannel carries native lifecycle
-      events: `firstDecodedFrame`, `gattError`, `leaveRoom`,
-      `openInviteLink`, `error`. Implemented in
-      [#44](https://github.com/ElodinLaarz/walkie-talkie/issues/44).
+      events. Examples (non-exhaustive — the exhaustive list lives in
+      [MainActivity.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt)
+      / [MediaSessionBridge.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/MediaSessionBridge.kt)):
+      `deviceDiscovered` / `deviceConnected` / `deviceDisconnected`,
+      `l2capOpen`, `voiceClientConnected`, `firstEncodedFrame` /
+      `firstDecodedFrame`, `talkingPeers` / `localTalking`, `pttToggle` /
+      `muteToggle`, `audioOutputChanged`, `mediaMetadata`, `leaveRoom`,
+      `openInviteLink`, `gattError` / `audioError` / `error`. Implemented
+      in [#44](https://github.com/ElodinLaarz/walkie-talkie/issues/44).
     * Voice transport bridge: `startVoiceServer` / `connectVoiceClient` /
       `stopVoiceTransport` / `getLinkTelemetry` / `setPeerBitrate` /
       `startVoice` / `stopVoice` / `startLoopbackTest`.

--- a/README.md
+++ b/README.md
@@ -54,15 +54,24 @@ handles BLE radio, L2CAP sockets, mic capture, and Opus.
 3.  **Bridge Layer (MethodChannels & EventChannels):**
     * Communication pipe between Dart and Kotlin
       ([MainActivity.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt)).
-    * Today: `scanDevices` / `connectDevice` / `disconnectDevice` methods
-      and `deviceDiscovered` events drive the headset-routing manager.
+    * Headset-routing surface: `scanDevices` / `connectDevice` /
+      `disconnectDevice` methods and `deviceDiscovered` /
+      `deviceConnected` / `deviceDisconnected` events.
       [audio_service.dart](lib/services/audio_service.dart) is the Dart
       side of that surface.
-    * Phase 2 ✅ code-complete, stabilizing: the BLE control-plane bridge —
-      Frequency-shaped methods like `startAdvertising`, `connectToHost`,
-      and `setMuted`, plus events like `onPeerDiscovered` and
-      `onJoinAccepted`. Implemented in
+    * BLE control-plane bridge: Frequency-shaped methods like
+      `startAdvertising`, `stopAdvertising`, `startGattServer`,
+      `connectToHost`, `writeRequest`, `writeControlBytes`,
+      `getNegotiatedMtu`, and `setMuted`. Control bytes flow back over a
+      dedicated `controlBytes` EventChannel; Dart decodes them into typed
+      `FrequencyMessage`s via [`BleControlTransport`](lib/services/ble_control_transport.dart).
+      A second `audio_events` EventChannel carries native lifecycle
+      events: `firstDecodedFrame`, `gattError`, `leaveRoom`,
+      `openInviteLink`, `error`. Implemented in
       [#44](https://github.com/ElodinLaarz/walkie-talkie/issues/44).
+    * Voice transport bridge: `startVoiceServer` / `connectVoiceClient` /
+      `stopVoiceTransport` / `getLinkTelemetry` / `setPeerBitrate` /
+      `startVoice` / `stopVoice` / `startLoopbackTest`.
 4.  **Service Layer (Android Native — Kotlin):**
     * **Foreground Service**
       ([WalkieTalkieService.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt))
@@ -193,13 +202,23 @@ graph TD
 
 1.  **`flutter_bloc`** — state management for Discovery and the Frequency
     session cubits.
-2.  **`sqflite`** — local-only persistence for `peerId` and display name.
-    No cloud sync (intentional). Hive is retained only as a one-shot
-    migration source (see
+2.  **`sqflite`** — local-only persistence for `peerId`, display name,
+    recent frequencies, blocked peers, and settings (incl. the Sentry
+    opt-in toggle). No cloud sync (intentional). Hive is retained only
+    as a one-shot migration source (see
     [lib/services/storage_migration.dart](lib/services/storage_migration.dart)).
-3.  **`permission_handler`** — Bluetooth scan / connect / advertise + mic
+3.  **`flutter_blue_plus`** — guest-side LE scanner. The host side does
+    **not** use it — LE advertising, GATT server, and L2CAP CoC are all
+    on the native Kotlin path because flutter_blue_plus exposes neither
+    advertising nor L2CAP. See
+    [lib/services/bluetooth_discovery_service.dart](lib/services/bluetooth_discovery_service.dart).
+4.  **`permission_handler`** — Bluetooth scan / connect / advertise + mic
     permissions. The runtime asks happen during onboarding
     ([lib/services/onboarding_permission_gateway.dart](lib/services/onboarding_permission_gateway.dart)).
+5.  **`sentry_flutter`** — opt-in crash reporting (off by default), DSN
+    baked at build time via `--dart-define=SENTRY_DSN=…`. Events are
+    sanitised before send (peerId, display names, user block stripped);
+    see [docs/sentry-setup.md](docs/sentry-setup.md).
 
 ### Android Native (Kotlin / C++)
 
@@ -214,7 +233,11 @@ The libraries / APIs below are the native surface for Phases 2-3
     **API 29+ / Android 10+**). The voice plane is L2CAP CoC + Opus,
     **not** LE Audio CIS / BIS — see the transport note above.
 2.  **`libopus`** (C / NDK) *(Phase 3)* — voice codec, narrowband /
-    wideband, 20-ms frames at 24 kbps. Per-peer encode on guests, decode +
+    wideband, 20-ms frames at an adaptive 8 / 16 / 24 kbps (default 16
+    kbps; see `kBitrateLow`/`Mid`/`High` in
+    [audio_config.h](android/app/src/main/cpp/audio_config.h)). The host
+    steers each guest's bitrate via `bitrate_hint` in response to that
+    guest's `link_quality` telemetry. Per-peer encode on guests, decode +
     re-encode on the host's mix-minus.
 3.  **`Oboe`** (C++) *(Phase 3)* — low-latency mic capture and playback.
     Java-side `AudioRecord` / `AudioTrack` introduce too much latency for
@@ -268,6 +291,12 @@ real radios.
 * [#55](https://github.com/ElodinLaarz/walkie-talkie/issues/55) Android Audio Focus management (phone calls + Spotify clashes).
 * [#56](https://github.com/ElodinLaarz/walkie-talkie/issues/56) Graceful auto-reconnect for transient drops (≤30s).
 * [#57](https://github.com/ElodinLaarz/walkie-talkie/issues/57) Permissions revocation handling (mic / BT revoked while in-room).
+* Host handover (`host_transfer`) — when the current host leaves a
+  populated room it nominates a successor that promotes itself; see
+  [docs/protocol.md § Host handover](docs/protocol.md#host-handover).
+* Adaptive Opus bitrate (`link_quality` / `bitrate_hint`) — guests report
+  receive-side telemetry, host steers per-link bitrate between the
+  Low/Mid/High operating points.
 
 ### Phase 5 — Release polish ✅ code-complete, stabilizing
 
@@ -288,8 +317,9 @@ actions are documented in the submission guide below.
 * [#120](https://github.com/ElodinLaarz/walkie-talkie/issues/120) ✅ Crash + error reporting (Sentry, opt-in, no PII, on-device queue).
 * [#126](https://github.com/ElodinLaarz/walkie-talkie/issues/126) ⏳ Play Store listing prep: store metadata, screenshots, content rating, closed testing. See [`docs/play-store-submission-guide.md`](docs/play-store-submission-guide.md) for the step-by-step checklist.
 
-Out of scope for v1: encryption beyond LE pairing, host handover, mesh
-topology, > 12 peers per room. See
+Out of scope for v1: encryption beyond LE pairing, mesh topology, > 12
+peers per room. (Host handover, originally listed here, now ships — see
+Phase 4 above.) See
 [docs/protocol.md § Out of scope](docs/protocol.md#out-of-scope).
 
 -----

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ handles BLE radio, L2CAP sockets, mic capture, and Opus.
       in [#44](https://github.com/ElodinLaarz/walkie-talkie/issues/44).
     * Voice transport bridge: `startVoiceServer` / `connectVoiceClient` /
       `stopVoiceTransport` / `getLinkTelemetry` / `setPeerBitrate` /
-      `startVoice` / `stopVoice` / `startLoopbackTest`.
+      `startVoice` / `stopVoice` / `startLoopbackTest` / `stopLoopbackTest`.
 4.  **Service Layer (Android Native — Kotlin):**
     * **Foreground Service**
       ([WalkieTalkieService.kt](android/app/src/main/kotlin/com/elodin/walkie_talkie/WalkieTalkieService.kt))

--- a/docs/play-store-permissions-rationale.md
+++ b/docs/play-store-permissions-rationale.md
@@ -102,8 +102,10 @@ effectively making the app non-functional while backgrounded.
 
 **Why needed:** The Sentry SDK requires `INTERNET` to upload sanitised crash
 envelopes when the user has opted in. Stripped of `peerId`, display names,
-and the Sentry user block via `SentryEventSanitizer` before send. The
-permission has no other consumer in the codebase.
+and the Sentry user block via `sanitizeSentryEvent` (top-level function in
+`lib/services/sentry_event_sanitizer.dart`, wired through `options.beforeSend`
+in `main.dart`) before send. The permission has no other consumer in the
+codebase.
 
 ---
 

--- a/docs/play-store-permissions-rationale.md
+++ b/docs/play-store-permissions-rationale.md
@@ -93,6 +93,20 @@ effectively making the app non-functional while backgrounded.
 
 ---
 
+## INTERNET
+
+> *"Used exclusively for opt-in crash reporting (Sentry). The app's voice and
+> control planes travel over Bluetooth LE only — there is no internet path for
+> any user content. Crash reporting is disabled by default; the user must
+> enable it in Settings → Privacy."*
+
+**Why needed:** The Sentry SDK requires `INTERNET` to upload sanitised crash
+envelopes when the user has opted in. Stripped of `peerId`, display names,
+and the Sentry user block via `SentryEventSanitizer` before send. The
+permission has no other consumer in the codebase.
+
+---
+
 ## Summary table
 
 | Permission | Runtime prompt? | User can deny? | Impact if denied |
@@ -104,3 +118,4 @@ effectively making the app non-functional while backgrounded.
 | MODIFY_AUDIO_SETTINGS | No (normal) | N/A | No headset routing |
 | FOREGROUND_SERVICE (+ _MICROPHONE, + _CONNECTED_DEVICE) | No (normal) | N/A | OS does not allow mic/BLE BG |
 | POST_NOTIFICATIONS | Yes (Android 13+) | Yes | On API 33+: prevents FGS from starting, app non-functional while backgrounded |
+| INTERNET | No (normal) | N/A | Sentry envelopes cannot upload (opt-in feature; no other effect) |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -431,16 +431,27 @@ addressed elsewhere. Mirrors the `remove_peer` targeting pattern.
 ```
 
 Sent by the current host immediately before it leaves a populated room.
-The peer named in `newHostPeerId` promotes itself to host: stops guest-only
-reporters, starts the LE advertiser + GATT server + L2CAP CoC server using
-the supplied `sessionUuid` so the room frequency stays stable. All other
-peers update their `hostPeerId` so a subsequent `leave` from the old host
-isn't mistaken for a room-killing event, and they re-tune to the new host
-through the usual reconnect path.
+Behaviour by recipient:
+
+- **The peer named in `newHostPeerId`** promotes itself to host: stops
+  guest-only reporters, starts the LE advertiser + GATT server + L2CAP
+  CoC server using the supplied `sessionUuid` so the room frequency stays
+  stable.
+- **All other guests** update their in-memory `hostPeerId` (so the old
+  host's subsequent `leave` is not mistaken for a room-killing event) and
+  transition to the *reconnecting* UI phase. They do **not** tear down
+  the existing GATT / L2CAP links on receipt — they cannot, since the
+  promoted peer's GATT server is brand new on a different BLE endpoint
+  and the old links are owned by the departing host. The heartbeat
+  timeout on the old host's links (~15 s of missed pings — see
+  [§ Health](#ping-peer--host)) drives the physical teardown, and the
+  guest then re-tunes to `newHostPeerId` through the normal Discovery →
+  `join_request` path.
 
 `sessionUuid` is the **full** UUID so the promoted peer can pass it
 verbatim to `startAdvertising`; this avoids the cosmetic-mhz collision
-case the discovery layer would otherwise hit during the cut-over.
+case the discovery layer would otherwise hit during the cut-over, and
+guarantees re-tuning guests see the same room identity they were on.
 
 ## Voice plane
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -209,6 +209,7 @@ Guest **MUST** wait for the response before sending any further messages.
 {
   "kind": "join_accepted", "peerId": "<host>", "seq": 7, "atMs": ..., "v": 1,
   "hostPeerId": "<host>",
+  "recipientPeerId": "<joining-guest>", // optional, targeted accept
   "voicePsm": 129, // optional
   "roster": [ { "peerId": "...", "displayName": "Maya", "btDevice": "AirPods Pro",
                 "muted": false, "talking": false }, ... ],
@@ -222,6 +223,11 @@ Guest **MUST** wait for the response before sending any further messages.
   room is right now (track + playback + position) without waiting for the
   next manual command. Doubles as the [reconnect reconciliation
   payload](#reconnect-and-reconciliation).
+- **recipientPeerId** *(optional)* — peerId of the intended recipient. The
+  host sets this when accepting a single joining guest; existing guests that
+  see a `recipientPeerId` not matching their own peerId **MUST** silently
+  ignore the message so they don't reset their `lastSeq` counter table when
+  a new peer joins. Legacy hosts may omit it (treated as broadcast).
 - **voicePsm** *(optional)* — the dynamic L2CAP PSM the host's voice server is
   bound to. If present, the guest opens an L2CAP CoC to this PSM after
   `JoinAccepted` lands; see [§ Voice plane](#voice-plane). If absent, join still
@@ -370,6 +376,72 @@ Clean disconnects (the `Leave` / `RemovePeer` flow) remain the happy
 path; this is the safety net for distance, interference, or a phone
 going into a tunnel.
 
+### Adaptive bitrate
+
+These messages let the host steer per-link Opus bitrate in response to
+observed packet loss / jitter / mixer underruns. The encoder operating
+points (`kBitrateLow=8000`, `kBitrateMid=16000`, `kBitrateHigh=24000`) live
+in `android/app/src/main/cpp/audio_config.h`; values outside that set are
+clamped by the native encoder.
+
+#### `link_quality` (guest → host)
+
+```json
+{ "kind": "link_quality", "peerId": "<sender>", "seq": ..., "atMs": ..., "v": 1,
+  "lossPct": 1.4, "jitterMs": 80, "underrunsPerSec": 0.0 }
+```
+
+A guest's view of the receive-side voice link from the host. Sampled from
+the native `PeerAudioManager` telemetry every few seconds (`LinkQualityReporter`
+in the Dart layer). Fields:
+
+- `lossPct` — number in `[0, 100]`. Fraction of expected frames the jitter
+  buffer rejected as too late to play.
+- `jitterMs` — int ≥ 0. Current jitter buffer fill in ms (depth × 20 ms).
+  Observability only; the adapter doesn't use it.
+- `underrunsPerSec` — number ≥ 0. Rate of mixer-tick underruns in the
+  sampled window. Non-zero means the buffer drained faster than the wire
+  could refill.
+
+The host runs its own send-side telemetry locally and does **not** emit
+`link_quality` over the wire.
+
+#### `bitrate_hint` (host → specific guest)
+
+```json
+{ "kind": "bitrate_hint", "peerId": "<host>", "seq": ..., "atMs": ..., "v": 1,
+  "target": "<guest peerId>", "bps": 16000 }
+```
+
+Host-to-guest advisory: "set your outbound encoder bitrate to `bps`." The
+host writes `bitrate_hint` over the GATT RESPONSE characteristic (which
+fans out to every subscribed guest, same as `roster_update`); guests
+**MUST** filter on receive by `target == localPeerId` and ignore hints
+addressed elsewhere. Mirrors the `remove_peer` targeting pattern.
+
+`bps` must be positive; the native layer clamps it to {Low, Mid, High}.
+
+### Host handover
+
+#### `host_transfer` (current host → all)
+
+```json
+{ "kind": "host_transfer", "peerId": "<host>", "seq": ..., "atMs": ..., "v": 1,
+  "newHostPeerId": "<promoted guest>", "sessionUuid": "<full UUID>" }
+```
+
+Sent by the current host immediately before it leaves a populated room.
+The peer named in `newHostPeerId` promotes itself to host: stops guest-only
+reporters, starts the LE advertiser + GATT server + L2CAP CoC server using
+the supplied `sessionUuid` so the room frequency stays stable. All other
+peers update their `hostPeerId` so a subsequent `leave` from the old host
+isn't mistaken for a room-killing event, and they re-tune to the new host
+through the usual reconnect path.
+
+`sessionUuid` is the **full** UUID so the promoted peer can pass it
+verbatim to `startAdvertising`; this avoids the cosmetic-mhz collision
+case the discovery layer would otherwise hit during the cut-over.
+
 ## Voice plane
 
 Voice rides on **L2CAP CoC** (Connection-oriented Channel) — a stream-shaped
@@ -396,38 +468,40 @@ The guest opens its CoC to that PSM after `JoinAccepted` lands. A `voicePsm`
 outside the valid range or with the LSB clear is a protocol violation;
 guests should treat it as `version_mismatch`-equivalent and disconnect.
 
-### Codec parameters (recommended)
+### Codec parameters
 
 | parameter   | value                                                |
 | ----------- | ---------------------------------------------------- |
 | codec       | Opus                                                 |
 | application | `OPUS_APPLICATION_VOIP`                              |
-| sample rate | 16 kHz (wideband)                                    |
+| sample rate | 16 kHz wideband (codec / mix); 48 kHz at the Oboe stream, downsampled 3:1 |
 | channels    | 1 (mono)                                             |
-| frame size  | 20 ms (320 samples per frame)                        |
-| bitrate     | 24 kbps                                              |
+| frame size  | 20 ms (320 samples per codec frame, 960 per Oboe callback) |
+| bitrate     | adaptive — three operating points at 8, 16, 24 kbps; default 16 kbps (`kBitrateMid` in `audio_config.h`) |
 
-24 kbps × 1 stream per peer × ≤12 peers ≈ 290 kbps aggregate at the host.
-Comfortably under L2CAP throughput on any LE 4.2+ device.
+The host nudges per-link bitrate via [`bitrate_hint`](#bitrate_hint-host--specific-guest)
+in response to [`link_quality`](#link_quality-guest--host) telemetry; out-of-range
+values are clamped to the {Low, Mid, High} operating points by the native
+encoder. At worst-case 24 kbps × ≤12 peers ≈ 290 kbps aggregate, comfortably
+under L2CAP throughput on any LE 4.2+ device.
 
 ### Voice frame format
 
-Each L2CAP write is one VoiceFrame, framed by a 2-byte big-endian length
-prefix so the receiver can recover frame boundaries even when the kernel
-coalesces multiple SDUs into a single userspace `read` (observed on some
-Samsung and Pixel kernels). MTU **MUST** be ≥ 130 bytes (128 voice + 2
-prefix):
+Each L2CAP write is one VoiceFrame with a fixed 8-byte header followed by the
+Opus payload (big-endian). MTU **MUST** be ≥ 128 bytes (`kVoiceMtu` in
+`lib/protocol/voice_frame.dart`):
 
 | offset | bytes | meaning                                                       |
 | ------ | ----- | ------------------------------------------------------------- |
-| 0      | 2     | `frameLen` — uint16, big-endian; size of the VoiceFrame that follows (does **not** include this prefix) |
-| 2      | 4     | `seq` — per-link monotonic uint32, big-endian                 |
-| 6      | 4     | `senderTsMs` — sender's ms-since-epoch low 32 bits, big-endian |
-| 10     | N     | Opus frame payload                                            |
+| 0      | 4     | `seq` — per-link monotonic uint32, big-endian                 |
+| 4      | 4     | `senderTsMs` — sender's ms-since-epoch low 32 bits, big-endian |
+| 8      | N     | Opus frame payload (at least one byte; Opus never emits zero) |
 
-`frameLen` is the size of the inner VoiceFrame (`seq` + `senderTsMs` +
-payload). Receivers that observe a `frameLen` of 0 or > 4096 close the
-channel — both indicate a malformed peer.
+There is **no length prefix** in v1. Each L2CAP SDU carries exactly one
+VoiceFrame; if your platform coalesces SDUs into a single userspace read,
+fix the read side rather than reading across boundaries. Receivers that
+observe a buffer shorter than 8 bytes or a zero-length payload drop the
+frame (the L2CAP CoC stays open).
 
 `peerId` is **not** in the header — each L2CAP CoC is dedicated to a single
 peer (the connection identifies the sender). On the receive side, the host
@@ -559,8 +633,6 @@ This handles BLE's at-least-once write semantics without app-level acks.
 
 - **Encryption / authentication.** Link-layer LE pairing is enough for v1.
   App-level signing of messages is a v2 concern.
-- **Host handover.** v1: host leaves → channel ends, all guests return to
-  Discovery. v2 will pick the longest-connected guest as new host.
 - **Jitter buffer sizing, FEC, stereo voice.** The voice plane specifies
   the wire (Opus over L2CAP) but leaves the receive-side reconstruction
   details to the implementation. The README's "incredibly user-friendly"

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -379,10 +379,14 @@ going into a tunnel.
 ### Adaptive bitrate
 
 These messages let the host steer per-link Opus bitrate in response to
-observed packet loss / jitter / mixer underruns. The encoder operating
+observed packet loss / jitter / mixer underruns. The named operating
 points (`kBitrateLow=8000`, `kBitrateMid=16000`, `kBitrateHigh=24000`) live
-in `android/app/src/main/cpp/audio_config.h`; values outside that set are
-clamped by the native encoder.
+in `android/app/src/main/cpp/audio_config.h`. The native
+`OpusEncoder::setBitrate` clamps to the closed range
+`[kBitrateLow, kBitrateHigh]` = `[8000, 24000]` bps — any value inside
+that range is honoured verbatim; values outside are clamped to the nearer
+endpoint. The Low / Mid / High constants are the *recommended* working
+points, not a discrete set the encoder snaps to.
 
 #### `link_quality` (guest → host)
 
@@ -419,7 +423,10 @@ fans out to every subscribed guest, same as `roster_update`); guests
 **MUST** filter on receive by `target == localPeerId` and ignore hints
 addressed elsewhere. Mirrors the `remove_peer` targeting pattern.
 
-`bps` must be positive; the native layer clamps it to {Low, Mid, High}.
+`bps` must be positive; the native layer clamps it to the closed range
+`[8000, 24000]` (see [§ Adaptive bitrate](#adaptive-bitrate)). Values
+inside the range are honoured as-is; the Low / Mid / High constants are
+suggested operating points, not a snap-to set.
 
 ### Host handover
 
@@ -439,19 +446,22 @@ Behaviour by recipient:
   stable.
 - **All other guests** update their in-memory `hostPeerId` (so the old
   host's subsequent `leave` is not mistaken for a room-killing event) and
-  transition to the *reconnecting* UI phase. They do **not** tear down
-  the existing GATT / L2CAP links on receipt — they cannot, since the
-  promoted peer's GATT server is brand new on a different BLE endpoint
-  and the old links are owned by the departing host. The heartbeat
-  timeout on the old host's links (~15 s of missed pings — see
-  [§ Health](#ping-peer--host)) drives the physical teardown, and the
-  guest then re-tunes to `newHostPeerId` through the normal Discovery →
-  `join_request` path.
+  transition to the *reconnecting* UI phase. The existing GATT / L2CAP
+  links are still pointed at the *old* host's BLE endpoint — the v1
+  cubit does not rewrite `SessionRoom.macAddress` on receipt of
+  `host_transfer`. Concretely: when the heartbeat watchdog fires (~15 s
+  of missed pings — see [§ Health](#ping-peer--host)) the reconnect
+  controller dials the old host's MAC, fails after exhausting its retry
+  budget, and the guest drops to Discovery. Re-tuning to the promoted
+  peer is then a fresh `Tune in` against the new advertiser. (A future
+  revision that wires the new host's MAC into the cubit on receipt of
+  `host_transfer` can collapse this back to a seamless reconnect; the
+  wire format is forward-compatible.)
 
 `sessionUuid` is the **full** UUID so the promoted peer can pass it
-verbatim to `startAdvertising`; this avoids the cosmetic-mhz collision
-case the discovery layer would otherwise hit during the cut-over, and
-guarantees re-tuning guests see the same room identity they were on.
+verbatim to `startAdvertising`; this guarantees the new advertiser carries
+the same cosmetic mhz / sessionCode as the room the guests left, so a
+manual re-tune lands on the same row in Discovery.
 
 ## Voice plane
 
@@ -491,16 +501,32 @@ guests should treat it as `version_mismatch`-equivalent and disconnect.
 | bitrate     | adaptive — three operating points at 8, 16, 24 kbps; default 16 kbps (`kBitrateMid` in `audio_config.h`) |
 
 The host nudges per-link bitrate via [`bitrate_hint`](#bitrate_hint-host--specific-guest)
-in response to [`link_quality`](#link_quality-guest--host) telemetry; out-of-range
-values are clamped to the {Low, Mid, High} operating points by the native
-encoder. At worst-case 24 kbps × ≤12 peers ≈ 290 kbps aggregate, comfortably
-under L2CAP throughput on any LE 4.2+ device.
+in response to [`link_quality`](#link_quality-guest--host) telemetry; the
+native encoder clamps to the closed range `[8000, 24000]` bps (Low and
+High are endpoints, not a discrete set). At worst-case 24 kbps × ≤12
+peers ≈ 290 kbps aggregate, comfortably under L2CAP throughput on any
+LE 4.2+ device.
 
 ### Voice frame format
 
-Each L2CAP write is one VoiceFrame with a fixed 8-byte header followed by the
-Opus payload (big-endian). MTU **MUST** be ≥ 128 bytes (`kVoiceMtu` in
-`lib/protocol/voice_frame.dart`):
+Each L2CAP write is a 2-byte big-endian length prefix followed by one
+VoiceFrame. The prefix is a *transport-layer* framer that L2CAP CoC
+needs because some OEM kernels coalesce multiple SDUs into a single
+userspace `read`; it carries only the size of the VoiceFrame that
+follows and is **not** counted in that size. The VoiceFrame itself is
+an 8-byte big-endian header followed by the Opus payload. MTU **MUST**
+be ≥ 130 bytes (the 2-byte prefix plus the 128-byte VoiceFrame floor —
+`LENGTH_PREFIX_SIZE` + `kVoiceMtu` in [`L2capVoiceTransport.kt`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt) /
+[`lib/protocol/voice_frame.dart`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/lib/protocol/voice_frame.dart)).
+
+Wire layout of one L2CAP write:
+
+```text
+[ frameLen: uint16 BE ]   <-- transport prefix, not part of the VoiceFrame
+[ VoiceFrame of frameLen bytes ]
+```
+
+VoiceFrame layout (the inner `frameLen` bytes):
 
 | offset | bytes | meaning                                                       |
 | ------ | ----- | ------------------------------------------------------------- |
@@ -508,11 +534,13 @@ Opus payload (big-endian). MTU **MUST** be ≥ 128 bytes (`kVoiceMtu` in
 | 4      | 4     | `senderTsMs` — sender's ms-since-epoch low 32 bits, big-endian |
 | 8      | N     | Opus frame payload (at least one byte; Opus never emits zero) |
 
-There is **no length prefix** in v1. Each L2CAP SDU carries exactly one
-VoiceFrame; if your platform coalesces SDUs into a single userspace read,
-fix the read side rather than reading across boundaries. Receivers that
-observe a buffer shorter than 8 bytes or a zero-length payload drop the
-frame (the L2CAP CoC stays open).
+`frameLen` of 0 or > 4096 closes the channel (both indicate a malformed
+peer; see `MAX_FRAME_SIZE` in the Kotlin transport). A VoiceFrame
+shorter than 8 bytes after reassembly is dropped — the L2CAP CoC stays
+open. Note: the Dart `VoiceFrame.encode()` helper produces *only* the
+inner 8-byte-header + payload bytes — the 2-byte transport prefix is
+added by `L2capVoiceTransport.writeFramed` at the wire boundary, not by
+the codec layer.
 
 `peerId` is **not** in the header — each L2CAP CoC is dedicated to a single
 peer (the connection identifies the sender). On the receive side, the host

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -75,7 +75,7 @@ The following data **is** included in crash reports:
 - Device model, OS version, app version
 
 The following data **is NOT** included:
-- `peerId` and display names (both stripped by `SentryEventSanitizer` from contexts, tags, and breadcrumbs before transmission)
+- `peerId` and display names (both stripped by `sanitizeSentryEvent` from contexts, tags, and breadcrumbs before transmission)
 - IP addresses (can be disabled in Sentry project settings)
 - Bluetooth MAC addresses
 - Any content from the frequency room (audio, messages, etc.)


### PR DESCRIPTION
## Summary

Audit of the docs against the actual implementation surfaced several drift points. This PR is **docs-only** — no code changes.

### `docs/protocol.md`
- **Voice frame layout** — corrected to match the shipping wire format: each L2CAP write is a 2-byte big-endian length prefix (transport-layer framer in [`L2capVoiceTransport.kt`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt)) followed by one VoiceFrame (8-byte header + Opus payload from [`lib/protocol/voice_frame.dart`](https://github.com/ElodinLaarz/walkie-talkie/blob/main/lib/protocol/voice_frame.dart)). MTU floor is 130 bytes (prefix + 128-byte VoiceFrame floor). Note that the Dart codec helper emits only the inner bytes — the prefix is added at the wire boundary by `writeFramed`.
- **Codec parameters** — switch from flat 24 kbps to adaptive 8–24 kbps. The native `OpusEncoder::setBitrate` clamps to the closed range `[8000, 24000]` bps; Low/Mid/High constants in `audio_config.h` are recommended operating points, not a discrete snap-to set.
- **New message kinds documented**: `link_quality` (guest → host telemetry) and `bitrate_hint` (host → specific guest advisory). Both already ship in [lib/protocol/messages.dart](https://github.com/ElodinLaarz/walkie-talkie/blob/main/lib/protocol/messages.dart).
- **Host handover** — `host_transfer` was listed as out-of-scope but is wired through `frequency_session_cubit.dart`. New section split by recipient: the promoted peer promotes synchronously; other guests update `hostPeerId` and enter the reconnecting phase, but because the cubit does not rewrite `SessionRoom.macAddress`, the reconnect controller dials the old host's MAC and times out — the user re-tunes via a fresh `Tune in` against the new advertiser. Forward-compat note: the wire format is unchanged once the cubit is fixed.
- **`join_accepted`** — document the optional `recipientPeerId` field so existing guests filter targeted accepts and do not reset their `lastSeq` tables.

### `README.md`
- Bridge-layer description named `onPeerDiscovered` / `onJoinAccepted` events that do not exist. Replaced with the real surface: control bytes flow via the `controlBytes` EventChannel; the `audio_events` channel carries an open-ended set of native lifecycle events (`l2capOpen`, `voiceClientConnected`, `firstEncodedFrame` / `firstDecodedFrame`, `talkingPeers` / `localTalking`, `pttToggle` / `muteToggle`, `audioOutputChanged`, `mediaMetadata`, `leaveRoom`, `openInviteLink`, `gattError` / `audioError` / `error`, etc.) — listed as non-exhaustive examples with a pointer to `MainActivity.kt` / `MediaSessionBridge.kt` as the source of truth. Added the voice-transport MethodChannel methods that already exist in `MainActivity.kt`.
- Tech stack — added `flutter_blue_plus` (guest-side scanner) and `sentry_flutter`; expanded sqflite scope to include settings, recents, and blocked peers.
- `libopus` bullet — adaptive 8–24 kbps with a `bitrate_hint` / `link_quality` reference instead of 24 kbps.
- Phase 4 — host handover and adaptive bitrate listed as shipped capabilities.
- Removed host handover from the out-of-scope footer.

### `docs/play-store-permissions-rationale.md`
- Added an `INTERNET` section + summary-table row. The manifest declares it for opt-in Sentry uploads but it was missing from the Play Console rationale doc.
- Reference the actual top-level function `sanitizeSentryEvent` (was incorrectly named `SentryEventSanitizer`); same fix in `docs/sentry-setup.md`.

### Verified consistent (no edits)
`docs/smoke-test.md`, `docs/privacy-policy.md`, `docs/play-store-data-safety.md`, `docs/invite-links.md`, `scripts/README.md`, `docs/index.md`.

## Test plan

- [ ] Read through the new `docs/protocol.md` voice-frame section against `L2capVoiceTransport.kt` (`writeFramed` / `readFramed`) and `lib/protocol/voice_frame.dart` — prefix + header offsets and the 130-byte MTU floor must match.
- [ ] Confirm the new `link_quality` / `bitrate_hint` / `host_transfer` message schemas in `docs/protocol.md` match the JSON shape in `lib/protocol/messages.dart`, and that the bitrate clamp text matches `OpusEncoder::setBitrate` in `opus_codec.cpp`.
- [ ] Verify the host_transfer recipient-behaviour bullets against the `HostTransfer` branch in `lib/bloc/frequency_session_cubit.dart` and the `notifyDrop` reconnect path.
- [ ] Verify the README's bridge-layer method/event names match what `MainActivity.kt` actually exposes (incl. `stopLoopbackTest`).
- [ ] Sanity-check the INTERNET rationale matches the manifest comment in `android/app/src/main/AndroidManifest.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)