### PR TITLE
fix: auto-restart Oboe on disconnect, gate advertising on GATT server ready

### DIFF
--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -297,45 +297,10 @@ public:
         }
     }
 
-    void onErrorAfterClose(oboe::AudioStream* stream, oboe::Result error) override {
-        if (error != oboe::Result::ErrorDisconnected) {
-            // Non-disconnect errors were already reported in onErrorBeforeClose.
-            LOGE("Oboe stream error after close: %s", oboe::convertToText(error));
-            return;
-        }
-
-        // Only one of the two streams should trigger the restart.
-        bool expected = false;
-        if (!g_restartScheduled.compare_exchange_strong(
-                expected, true, std::memory_order_acq_rel)) {
-            return;
-        }
-
-        LOGI("Audio device disconnected — scheduling auto-restart");
-        // No `this` capture: the callback object may be destroyed while this
-        // thread blocks on g_engineMutex (e.g. nativeStop runs concurrently).
-        // All state the thread needs is in the static globals above.
-        std::thread([]() {
-            std::lock_guard<std::mutex> lock(g_engineMutex);
-            if (g_audioEngine != nullptr) {
-                // stop() is idempotent on already-closed streams; it resets
-                // the worker thread and shared_ptrs before start() reopens them.
-                g_audioEngine->stop();
-                const bool ok = g_audioEngine->start();
-                g_restartScheduled.store(false, std::memory_order_release);
-                if (!ok) {
-                    LOGE("Auto-restart after disconnect failed — reporting to Flutter");
-                    emitAudioErrorEvent(oboe::Result::ErrorDisconnected);
-                } else {
-                    LOGI("Auto-restart after disconnect succeeded");
-                }
-            } else {
-                // Engine was intentionally stopped (nativeStop); not an error.
-                g_restartScheduled.store(false, std::memory_order_release);
-                LOGI("Auto-restart skipped — engine already stopped");
-            }
-        }).detach();
-    }
+    // Defined out-of-line (after AudioEngine) because the restart lambda calls
+    // g_audioEngine->stop() and g_audioEngine->start(), which require AudioEngine
+    // to be fully defined — not just forward-declared.
+    void onErrorAfterClose(oboe::AudioStream* stream, oboe::Result error) override;
 };
 
 class AudioEngine : public oboe::AudioStreamDataCallback {
@@ -653,6 +618,50 @@ public:
         return oboe::DataCallbackResult::Continue;
     }
 };
+
+// Out-of-line definition of AudioEngineErrorCallback::onErrorAfterClose.
+// Placed here, after AudioEngine is fully defined, so the restart lambda can
+// call g_audioEngine->stop() and g_audioEngine->start() on the complete type.
+void AudioEngineErrorCallback::onErrorAfterClose(oboe::AudioStream* /*stream*/,
+                                                  oboe::Result error) {
+    if (error != oboe::Result::ErrorDisconnected) {
+        // Non-disconnect errors were already reported in onErrorBeforeClose.
+        LOGE("Oboe stream error after close: %s", oboe::convertToText(error));
+        return;
+    }
+
+    // Only one of the two streams should trigger the restart.
+    bool expected = false;
+    if (!g_restartScheduled.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel)) {
+        return;
+    }
+
+    LOGI("Audio device disconnected — scheduling auto-restart");
+    // No `this` capture: the callback object may be destroyed while this
+    // thread blocks on g_engineMutex (e.g. nativeStop runs concurrently).
+    // All state the thread needs is in the static globals above.
+    std::thread([]() {
+        std::lock_guard<std::mutex> lock(g_engineMutex);
+        if (g_audioEngine != nullptr) {
+            // stop() is idempotent on already-closed streams; it resets
+            // the worker thread and shared_ptrs before start() reopens them.
+            g_audioEngine->stop();
+            const bool ok = g_audioEngine->start();
+            g_restartScheduled.store(false, std::memory_order_release);
+            if (!ok) {
+                LOGE("Auto-restart after disconnect failed — reporting to Flutter");
+                emitAudioErrorEvent(oboe::Result::ErrorDisconnected);
+            } else {
+                LOGI("Auto-restart after disconnect succeeded");
+            }
+        } else {
+            // Engine was intentionally stopped (nativeStop); not an error.
+            g_restartScheduled.store(false, std::memory_order_release);
+            LOGI("Auto-restart skipped — engine already stopped");
+        }
+    }).detach();
+}
 
 // g_engineMutex and g_audioEngine are defined above AudioEngineErrorCallback
 // so the error callback's detached restart thread can reference them.

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -255,23 +255,60 @@ static void stopTalkingEventWorker() {
     g_talkingWorkerThread.join();
 }
 
-// Error callback for Oboe streams. Emits structured events to Flutter rather
-// than crashing the foreground service. Handles permission revocation (which
-// presents as ErrorDisconnected or ErrorInternal) and other stream errors.
+// Error callback for Oboe streams. For ErrorDisconnected (audio route change,
+// e.g. BT headset connect/disconnect) we attempt a transparent auto-restart in
+// onErrorAfterClose; the Flutter error event fires only when restart fails.
+// All other errors are reported immediately in onErrorBeforeClose.
 //
-// Note: Oboe invokes both onErrorBeforeClose and onErrorAfterClose for the same
-// failure. We emit only in onErrorBeforeClose to avoid duplicate Flutter events.
+// Both the recording and playback streams share a single instance of this
+// callback (see AudioEngine ctor). restartScheduled_ is an atomic guard so
+// the first stream to lose the device wins the restart race and the second
+// stream's onErrorAfterClose becomes a no-op.
 class AudioEngineErrorCallback : public oboe::AudioStreamErrorCallback {
+    std::atomic<bool> restartScheduled_{false};
 public:
     void onErrorBeforeClose(oboe::AudioStream* stream, oboe::Result error) override {
         LOGE("Oboe stream error: %s", oboe::convertToText(error));
-        emitAudioErrorEvent(error);
+        // ErrorDisconnected gets a restart attempt first; emit is deferred.
+        if (error != oboe::Result::ErrorDisconnected) {
+            emitAudioErrorEvent(error);
+        }
     }
 
     void onErrorAfterClose(oboe::AudioStream* stream, oboe::Result error) override {
-        LOGE("Oboe stream error after close: %s (event already emitted)",
-             oboe::convertToText(error));
-        // Do not emit — onErrorBeforeClose already sent the event.
+        if (error != oboe::Result::ErrorDisconnected) {
+            // Non-disconnect errors were already reported in onErrorBeforeClose.
+            LOGE("Oboe stream error after close: %s", oboe::convertToText(error));
+            return;
+        }
+
+        // Only one of the two streams should trigger the restart.
+        bool expected = false;
+        if (!restartScheduled_.compare_exchange_strong(
+                expected, true, std::memory_order_acq_rel)) {
+            return;
+        }
+
+        LOGI("Audio device disconnected — scheduling auto-restart");
+        // Restart must happen off the Oboe error-callback thread to avoid
+        // potential deadlocks inside the Oboe internals.
+        std::thread([this]() {
+            std::lock_guard<std::mutex> lock(g_engineMutex);
+            bool ok = false;
+            if (g_audioEngine != nullptr) {
+                // stop() is idempotent on already-closed streams; it resets
+                // the worker thread and shared_ptrs before start() reopens them.
+                g_audioEngine->stop();
+                ok = g_audioEngine->start();
+            }
+            restartScheduled_.store(false, std::memory_order_release);
+            if (!ok) {
+                LOGE("Auto-restart after disconnect failed — reporting to Flutter");
+                emitAudioErrorEvent(oboe::Result::ErrorDisconnected);
+            } else {
+                LOGI("Auto-restart after disconnect succeeded");
+            }
+        }).detach();
     }
 };
 

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -48,8 +48,9 @@ static std::mutex g_jniMutex;
 static JavaVM* g_jvm = nullptr;
 static jobject g_mainActivity = nullptr;
 
-// Forward declaration for the error callback class
+// Forward declarations
 class AudioEngineErrorCallback;
+class AudioEngine;
 
 // Emit audio error event to Flutter via JNI.
 // Called from Oboe's error callback when a stream error occurs (e.g., permission
@@ -255,17 +256,38 @@ static void stopTalkingEventWorker() {
     g_talkingWorkerThread.join();
 }
 
+// Global audio engine instance + mutex. Defined here (before
+// AudioEngineErrorCallback) so the error callback's detached restart thread can
+// reference them without a forward use of an undeclared identifier.
+//
+// nativeStop deletes the engine and nulls the pointer; nativePauseStreams /
+// nativeResumeStreams read the pointer and dispatch to it. Without
+// serialization a stop racing with pause/resume can either tear down the
+// engine mid-call (use-after-free) or null the pointer between the load and
+// the dereference. In practice the JNI calls usually serialize on the
+// service / main thread, but Android focus-change listeners can be
+// dispatched on other threads; the mutex makes the contract explicit so
+// future call sites can't introduce a UAF by accident.
+static std::mutex g_engineMutex;
+static AudioEngine* g_audioEngine = nullptr;
+
+// Restart guard for ErrorDisconnected auto-recovery. Static (not a member of
+// AudioEngineErrorCallback) so the detached restart thread does not capture a
+// pointer to the callback instance — the engine can destroy the callback while
+// the thread blocks on g_engineMutex, and any member access after the lock is
+// acquired would be a use-after-free. There is only one AudioEngine, so one
+// static bool is the right scope.
+static std::atomic<bool> g_restartScheduled{false};
+
 // Error callback for Oboe streams. For ErrorDisconnected (audio route change,
 // e.g. BT headset connect/disconnect) we attempt a transparent auto-restart in
 // onErrorAfterClose; the Flutter error event fires only when restart fails.
 // All other errors are reported immediately in onErrorBeforeClose.
 //
-// Both the recording and playback streams share a single instance of this
-// callback (see AudioEngine ctor). restartScheduled_ is an atomic guard so
-// the first stream to lose the device wins the restart race and the second
-// stream's onErrorAfterClose becomes a no-op.
+// Both recording and playback streams share a single instance (see AudioEngine
+// ctor). g_restartScheduled is the deduplicate guard; the lambda captures
+// nothing so the thread has no lifetime dependency on the callback object.
 class AudioEngineErrorCallback : public oboe::AudioStreamErrorCallback {
-    std::atomic<bool> restartScheduled_{false};
 public:
     void onErrorBeforeClose(oboe::AudioStream* stream, oboe::Result error) override {
         LOGE("Oboe stream error: %s", oboe::convertToText(error));
@@ -284,29 +306,33 @@ public:
 
         // Only one of the two streams should trigger the restart.
         bool expected = false;
-        if (!restartScheduled_.compare_exchange_strong(
+        if (!g_restartScheduled.compare_exchange_strong(
                 expected, true, std::memory_order_acq_rel)) {
             return;
         }
 
         LOGI("Audio device disconnected — scheduling auto-restart");
-        // Restart must happen off the Oboe error-callback thread to avoid
-        // potential deadlocks inside the Oboe internals.
-        std::thread([this]() {
+        // No `this` capture: the callback object may be destroyed while this
+        // thread blocks on g_engineMutex (e.g. nativeStop runs concurrently).
+        // All state the thread needs is in the static globals above.
+        std::thread([]() {
             std::lock_guard<std::mutex> lock(g_engineMutex);
-            bool ok = false;
             if (g_audioEngine != nullptr) {
                 // stop() is idempotent on already-closed streams; it resets
                 // the worker thread and shared_ptrs before start() reopens them.
                 g_audioEngine->stop();
-                ok = g_audioEngine->start();
-            }
-            restartScheduled_.store(false, std::memory_order_release);
-            if (!ok) {
-                LOGE("Auto-restart after disconnect failed — reporting to Flutter");
-                emitAudioErrorEvent(oboe::Result::ErrorDisconnected);
+                const bool ok = g_audioEngine->start();
+                g_restartScheduled.store(false, std::memory_order_release);
+                if (!ok) {
+                    LOGE("Auto-restart after disconnect failed — reporting to Flutter");
+                    emitAudioErrorEvent(oboe::Result::ErrorDisconnected);
+                } else {
+                    LOGI("Auto-restart after disconnect succeeded");
+                }
             } else {
-                LOGI("Auto-restart after disconnect succeeded");
+                // Engine was intentionally stopped (nativeStop); not an error.
+                g_restartScheduled.store(false, std::memory_order_release);
+                LOGI("Auto-restart skipped — engine already stopped");
             }
         }).detach();
     }
@@ -628,18 +654,8 @@ public:
     }
 };
 
-// Global audio engine instance + mutex.
-//
-// nativeStop deletes the engine and nulls the pointer; nativePauseStreams /
-// nativeResumeStreams read the pointer and dispatch to it. Without
-// serialization a stop racing with pause/resume can either tear down the
-// engine mid-call (use-after-free) or null the pointer between the load and
-// the dereference. In practice the JNI calls usually serialize on the
-// service / main thread, but Android focus-change listeners can be
-// dispatched on other threads; the mutex makes the contract explicit so
-// future call sites can't introduce a UAF by accident.
-static std::mutex g_engineMutex;
-static AudioEngine* g_audioEngine = nullptr;
+// g_engineMutex and g_audioEngine are defined above AudioEngineErrorCallback
+// so the error callback's detached restart thread can reference them.
 
 extern "C" {
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattServerManager.kt
@@ -19,7 +19,8 @@ import java.util.concurrent.ConcurrentHashMap
 class GattServerManager(
     private val context: Context,
     private val onBytesReceived: (deviceAddress: String, bytes: ByteArray) -> Unit,
-    private val onError: ((String) -> Unit)? = null
+    private val onError: ((String) -> Unit)? = null,
+    private val onServerReady: (() -> Unit)? = null
 ) {
     companion object {
         private const val TAG = "GattServerManager"
@@ -134,6 +135,16 @@ class GattServerManager(
                         null
                     )
                 }
+            }
+        }
+
+        override fun onServiceAdded(status: Int, service: BluetoothGattService?) {
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                Log.i(TAG, "GATT service registered — server ready for connections")
+                onServerReady?.invoke()
+            } else {
+                Log.e(TAG, "GATT service registration failed: status=$status")
+                onError?.invoke("GATT_SERVICE_ADD_FAILED")
             }
         }
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -264,6 +264,9 @@ class MainActivity : FlutterActivity() {
                                     "type" to "gattError",
                                     "reason" to reason
                                 ))
+                            },
+                            onServerReady = {
+                                sendEventToFlutter(mapOf("type" to "gattServerReady"))
                             }
                         )
                     }

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1182,7 +1182,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       unawaited(audio.startGattServerAndAdvertise(
         sessionUuid: sessionUuid,
         displayName: current.myName,
-        shouldProceed: () => !isClosed,
+        shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
       ));
       // Close the guest-side voice client before opening the host server.
       // Awaited so the native layer tears down the client transport before
@@ -1441,7 +1441,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         unawaited(audio.startGattServerAndAdvertise(
           sessionUuid: sessionUuid,
           displayName: myName,
-          shouldProceed: () => !isClosed,
+          shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
         ));
         // Open the L2CAP voice server. Store the future so _sendJoinAccepted
         // can await it if a guest arrives before the native call returns.

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1179,13 +1179,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Start host BLE surfaces so remaining guests can reconnect.
     final audio = _audio;
     if (audio != null) {
-      unawaited(
-        audio.startAdvertising(
-          sessionUuid: sessionUuid,
-          displayName: current.myName,
-        ),
-      );
-      unawaited(audio.startGattServer());
+      unawaited(audio.startGattServerAndAdvertise(
+        sessionUuid: sessionUuid,
+        displayName: current.myName,
+      ));
       // Close the guest-side voice client before opening the host server.
       // Awaited so the native layer tears down the client transport before
       // startVoiceServer() runs; without this, the native code reuses the
@@ -1440,10 +1437,10 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // happens in [leaveRoom] and [close].
       final audio = _audio;
       if (audio != null) {
-        unawaited(
-          audio.startAdvertising(sessionUuid: sessionUuid, displayName: myName),
-        );
-        unawaited(audio.startGattServer());
+        unawaited(audio.startGattServerAndAdvertise(
+          sessionUuid: sessionUuid,
+          displayName: myName,
+        ));
         // Open the L2CAP voice server. Store the future so _sendJoinAccepted
         // can await it if a guest arrives before the native call returns.
         final gen = ++_voiceGeneration;

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1182,6 +1182,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       unawaited(audio.startGattServerAndAdvertise(
         sessionUuid: sessionUuid,
         displayName: current.myName,
+        shouldProceed: () => !isClosed,
       ));
       // Close the guest-side voice client before opening the host server.
       // Awaited so the native layer tears down the client transport before
@@ -1440,6 +1441,7 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         unawaited(audio.startGattServerAndAdvertise(
           sessionUuid: sessionUuid,
           displayName: myName,
+          shouldProceed: () => !isClosed,
         ));
         // Open the L2CAP voice server. Store the future so _sendJoinAccepted
         // can await it if a guest arrives before the native call returns.

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -413,6 +413,45 @@ class AudioService {
     }
   }
 
+  /// Start the GATT server and begin advertising only after the service is
+  /// fully registered.
+  ///
+  /// [BluetoothGattServer.addService] is asynchronous — the service isn't
+  /// visible to connecting guests until [onServiceAdded] fires on the native
+  /// side. Calling [startAdvertising] before that callback means a fast-
+  /// scanning guest can connect, run service discovery, find nothing, and
+  /// silently disconnect (GATT_SETUP_FAILED) before the service is ready.
+  ///
+  /// This method awaits the 'gattServerReady' native event (with a 3 s
+  /// timeout) before invoking [startAdvertising], eliminating that race.
+  Future<void> startGattServerAndAdvertise({
+    required String sessionUuid,
+    required String displayName,
+    Duration serverReadyTimeout = const Duration(seconds: 3),
+  }) async {
+    final serverStarted = await startGattServer();
+    if (!serverStarted) {
+      if (kDebugMode) debugPrint('startGattServer returned false; skipping advertising');
+      return;
+    }
+
+    try {
+      final event = await audioEvents
+          .firstWhere(
+            (e) => e['type'] == 'gattServerReady' || e['type'] == 'gattError',
+          )
+          .timeout(serverReadyTimeout);
+      if (event['type'] != 'gattServerReady') {
+        if (kDebugMode) debugPrint('GATT server error before ready; skipping advertising');
+        return;
+      }
+    } on TimeoutException {
+      if (kDebugMode) debugPrint('Timed out waiting for gattServerReady; advertising anyway');
+    }
+
+    await startAdvertising(sessionUuid: sessionUuid, displayName: displayName);
+  }
+
   /// Snapshot the current RSSI for each peer connected over the GATT
   /// link. Returns one entry per neighbor `(peerId, rssi)`; `rssi` is in
   /// dBm (negative values; closer to 0 is stronger). Empty list when no

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -424,50 +424,69 @@ class AudioService {
   ///
   /// This method awaits the 'gattServerReady' native event (with a 3 s
   /// timeout) before invoking [startAdvertising], eliminating that race.
+  /// On timeout the method aborts — advertising without confirmed server
+  /// readiness would reopen the race this method exists to close.
   ///
   /// [shouldProceed] is called just before [startAdvertising] is invoked.
   /// Callers that may be torn down while waiting (e.g. a cubit that closes
-  /// before [onServiceAdded] fires) can pass `() => !isClosed` to prevent
-  /// advertising for a dead session.
+  /// before [onServiceAdded] fires) can pass a guard to prevent advertising
+  /// for a dead session.
   Future<void> startGattServerAndAdvertise({
     required String sessionUuid,
     required String displayName,
     Duration serverReadyTimeout = const Duration(seconds: 3),
     bool Function()? shouldProceed,
   }) async {
-    // Subscribe before calling startGattServer so we cannot miss a fast
-    // onServiceAdded callback that fires before this isolate resumes.
-    final readyFuture = audioEvents
-        .firstWhere(
-          // Only treat gattError events that originated from the server startup
-          // path ('GATT_SERVICE_ADD_FAILED') as a failure signal. Other gattError
-          // events (GATT auth failures, write errors, etc.) are unrelated and
-          // must not abort the advertising attempt.
-          (e) =>
-              e['type'] == 'gattServerReady' ||
-              (e['type'] == 'gattError' &&
-                  e['reason'] == 'GATT_SERVICE_ADD_FAILED'),
-        )
-        .timeout(serverReadyTimeout);
-
-    final serverStarted = await startGattServer();
-    if (!serverStarted) {
-      if (kDebugMode) debugPrint('startGattServer returned false; skipping advertising');
-      return;
-    }
+    // Use a Completer + explicit StreamSubscription so we can cancel the
+    // listener on every exit path. Stream.firstWhere().timeout() does NOT
+    // cancel the underlying subscription when the timeout fires, which leaks
+    // a broadcast listener for the rest of the session.
+    final readyCompleter = Completer<Map<String, dynamic>>();
+    final readySub = audioEvents.listen((e) {
+      if (readyCompleter.isCompleted) return;
+      // Only treat gattError events from the server startup path as a failure
+      // signal. Other gattError events (auth failures, write errors, etc.) are
+      // unrelated and must not abort the advertising attempt.
+      final isReady = e['type'] == 'gattServerReady';
+      final isServiceAddFailed =
+          e['type'] == 'gattError' && e['reason'] == 'GATT_SERVICE_ADD_FAILED';
+      if (isReady || isServiceAddFailed) readyCompleter.complete(e);
+    });
 
     try {
-      final event = await readyFuture;
-      if (event['type'] != 'gattServerReady') {
-        if (kDebugMode) debugPrint('GATT server error before ready; skipping advertising');
+      final serverStarted = await startGattServer();
+      if (!serverStarted) {
+        if (kDebugMode) {
+          debugPrint('startGattServer returned false; skipping advertising');
+        }
         return;
       }
-    } on TimeoutException {
-      if (kDebugMode) debugPrint('Timed out waiting for gattServerReady; advertising anyway');
-    }
 
-    if (shouldProceed != null && !shouldProceed()) return;
-    await startAdvertising(sessionUuid: sessionUuid, displayName: displayName);
+      final Map<String, dynamic> event;
+      try {
+        event = await readyCompleter.future.timeout(serverReadyTimeout);
+      } on TimeoutException {
+        if (kDebugMode) {
+          debugPrint(
+            'Timed out waiting for gattServerReady; skipping advertising '
+            'to avoid the GATT service registration race',
+          );
+        }
+        return;
+      }
+
+      if (event['type'] != 'gattServerReady') {
+        if (kDebugMode) {
+          debugPrint('GATT server error before ready; skipping advertising');
+        }
+        return;
+      }
+
+      if (shouldProceed != null && !shouldProceed()) return;
+      await startAdvertising(sessionUuid: sessionUuid, displayName: displayName);
+    } finally {
+      await readySub.cancel();
+    }
   }
 
   /// Snapshot the current RSSI for each peer connected over the GATT

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -424,11 +424,32 @@ class AudioService {
   ///
   /// This method awaits the 'gattServerReady' native event (with a 3 s
   /// timeout) before invoking [startAdvertising], eliminating that race.
+  ///
+  /// [shouldProceed] is called just before [startAdvertising] is invoked.
+  /// Callers that may be torn down while waiting (e.g. a cubit that closes
+  /// before [onServiceAdded] fires) can pass `() => !isClosed` to prevent
+  /// advertising for a dead session.
   Future<void> startGattServerAndAdvertise({
     required String sessionUuid,
     required String displayName,
     Duration serverReadyTimeout = const Duration(seconds: 3),
+    bool Function()? shouldProceed,
   }) async {
+    // Subscribe before calling startGattServer so we cannot miss a fast
+    // onServiceAdded callback that fires before this isolate resumes.
+    final readyFuture = audioEvents
+        .firstWhere(
+          // Only treat gattError events that originated from the server startup
+          // path ('GATT_SERVICE_ADD_FAILED') as a failure signal. Other gattError
+          // events (GATT auth failures, write errors, etc.) are unrelated and
+          // must not abort the advertising attempt.
+          (e) =>
+              e['type'] == 'gattServerReady' ||
+              (e['type'] == 'gattError' &&
+                  e['reason'] == 'GATT_SERVICE_ADD_FAILED'),
+        )
+        .timeout(serverReadyTimeout);
+
     final serverStarted = await startGattServer();
     if (!serverStarted) {
       if (kDebugMode) debugPrint('startGattServer returned false; skipping advertising');
@@ -436,11 +457,7 @@ class AudioService {
     }
 
     try {
-      final event = await audioEvents
-          .firstWhere(
-            (e) => e['type'] == 'gattServerReady' || e['type'] == 'gattError',
-          )
-          .timeout(serverReadyTimeout);
+      final event = await readyFuture;
       if (event['type'] != 'gattServerReady') {
         if (kDebugMode) debugPrint('GATT server error before ready; skipping advertising');
         return;
@@ -449,6 +466,7 @@ class AudioService {
       if (kDebugMode) debugPrint('Timed out waiting for gattServerReady; advertising anyway');
     }
 
+    if (shouldProceed != null && !shouldProceed()) return;
     await startAdvertising(sessionUuid: sessionUuid, displayName: displayName);
   }
 

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -560,18 +560,52 @@ void main() {
       // intercept the underlying MethodChannel rather than mocking the
       // service so this test stays anchored on the contract callers
       // depend on (the platform method names + arg map).
+      //
+      // startGattServerAndAdvertise now awaits a 'gattServerReady' event on
+      // the audio EventChannel before calling startAdvertising. We mock the
+      // EventChannel so the mock startGattServer handler can emit that event
+      // and unblock the advertising call within the test.
       TestWidgetsFlutterBinding.ensureInitialized();
       const channel = MethodChannel('com.elodin.walkie_talkie/audio');
+      const eventChan = EventChannel('com.elodin.walkie_talkie/audio_events');
       final calls = <MethodCall>[];
+
+      // Sink used to push events into the mocked EventChannel.
+      final eventController = StreamController<dynamic>.broadcast();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+        eventChan,
+        MockStreamHandler.inline(
+          onListen: (_, events) {
+            eventController.stream.listen(
+              events.success,
+              onError: (Object e) =>
+                  events.error(code: 'ERR', message: e.toString()),
+            );
+          },
+        ),
+      );
+
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (call) async {
             calls.add(call);
-            // Both methods nominally return bool on the native side.
+            if (call.method == 'startGattServer') {
+              // Simulate native onServiceAdded firing; unblocks the
+              // gattServerReady wait inside startGattServerAndAdvertise.
+              scheduleMicrotask(
+                () => eventController.add({'type': 'gattServerReady'}),
+              );
+            }
             return true;
           });
-      addTearDown(() {
+
+      addTearDown(() async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(channel, null);
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockStreamHandler(eventChan, null);
+        await eventController.close();
       });
 
       const sessionUuid = '00000000-0000-4000-8000-0000000000a3';
@@ -582,7 +616,10 @@ void main() {
       cubit.emit(const SessionDiscovery(myName: 'Maya'));
 
       await cubit.joinRoom(isHost: true);
-      // The cubit fires both calls unawaited; let the event loop drain.
+      // Allow the async chain to settle:
+      //   startGattServer → gattServerReady event → startAdvertising.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
       await Future<void>.delayed(Duration.zero);
       await Future<void>.delayed(Duration.zero);
 

--- a/test/integration/handshake_audio_contract_test.dart
+++ b/test/integration/handshake_audio_contract_test.dart
@@ -167,6 +167,22 @@ class _RecordingAudioService extends AudioService {
     return true;
   }
 
+  // Override to bypass the gattServerReady event wait. The base class awaits
+  // a native event that never arrives in this test stub (audioEvents is
+  // Stream.empty()). The ordering contract (server before advertising) is
+  // verified by the unit test in frequency_session_cubit_test.dart.
+  @override
+  Future<void> startGattServerAndAdvertise({
+    required String sessionUuid,
+    required String displayName,
+    Duration serverReadyTimeout = const Duration(seconds: 3),
+    bool Function()? shouldProceed,
+  }) async {
+    await startGattServer();
+    if (shouldProceed != null && !shouldProceed()) return;
+    await startAdvertising(sessionUuid: sessionUuid, displayName: displayName);
+  }
+
   @override
   Future<bool> stopGattServer() async {
     calls.add('stopGattServer');


### PR DESCRIPTION
## Summary

- **Oboe `ErrorDisconnected` (AAudio -899)**: audio device route changes (BT headset connect/disconnect) killed both Oboe streams with no recovery. The `AudioEngineErrorCallback` now attempts a transparent restart from a detached background thread in `onErrorAfterClose`. An `atomic<bool>` on the shared callback prevents both streams from double-triggering. Flutter only sees the error event if restart fails.

- **0 guests / discovery failure**: two bugs combined. `BluetoothGattServer.addService()` is async — the service isn't visible to connecting peers until `onServiceAdded` fires. Both cubit host-start paths were also calling `startAdvertising` *before* `startGattServer`, widening the race window. A fast-scanning guest could connect, run service discovery, find nothing, and silently disconnect (`GATT_SETUP_FAILED`) before the service was ready.

## Changes

| File | Change |
|------|--------|
| `audio_engine.cpp` | `AudioEngineErrorCallback`: defer error emit for `ErrorDisconnected`; add `onErrorAfterClose` restart logic with atomic guard |
| `GattServerManager.kt` | Add `onServerReady` param; override `onServiceAdded` to invoke it |
| `MainActivity.kt` | Wire `onServerReady` → emit `gattServerReady` audio event |
| `audio_service.dart` | Add `startGattServerAndAdvertise()`: awaits `gattServerReady` event before calling `startAdvertising` |
| `frequency_session_cubit.dart` | Replace both host-start call sites with `startGattServerAndAdvertise` |

## Test plan

- [ ] Connect BT headset while in a room — audio should resume automatically without an error screen
- [ ] Disconnect BT headset — same
- [ ] Join as host, confirm guest phone discovers and connects (check logcat for `"GATT service registered — server ready"` before `"Advertising started"`)
- [ ] Check `gattServerReady` event arrives in Dart before advertising starts (add temporary debug print if needed)
- [ ] Verify `writeControlBytes` logs show guest count > 0 after a guest joins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defer handling of audio disconnects and auto-restart the engine to reduce interruptions.
  * Corrected Bluetooth server callback wiring so readiness/error are reported reliably.

* **New Features**
  * Added a combined "start GATT server and advertise" operation to streamline host startup.

* **Improvements**
  * Restart deduplication, gated advertising with a configurable server-ready timeout, and more robust error reporting.

* **Tests**
  * Updated tests to reflect the event-driven GATT/server-ready startup flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->