### PR TITLE
chore: apply dart format to align with presubmit

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1179,11 +1179,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Start host BLE surfaces so remaining guests can reconnect.
     final audio = _audio;
     if (audio != null) {
-      unawaited(audio.startGattServerAndAdvertise(
-        sessionUuid: sessionUuid,
-        displayName: current.myName,
-        shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
-      ));
+      unawaited(
+        audio.startGattServerAndAdvertise(
+          sessionUuid: sessionUuid,
+          displayName: current.myName,
+          shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
+        ),
+      );
       // Close the guest-side voice client before opening the host server.
       // Awaited so the native layer tears down the client transport before
       // startVoiceServer() runs; without this, the native code reuses the
@@ -1438,11 +1440,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // happens in [leaveRoom] and [close].
       final audio = _audio;
       if (audio != null) {
-        unawaited(audio.startGattServerAndAdvertise(
-          sessionUuid: sessionUuid,
-          displayName: myName,
-          shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
-        ));
+        unawaited(
+          audio.startGattServerAndAdvertise(
+            sessionUuid: sessionUuid,
+            displayName: myName,
+            shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
+          ),
+        );
         // Open the L2CAP voice server. Store the future so _sendJoinAccepted
         // can await it if a guest arrives before the native call returns.
         final gen = ++_voiceGeneration;

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -483,7 +483,10 @@ class AudioService {
       }
 
       if (shouldProceed != null && !shouldProceed()) return;
-      await startAdvertising(sessionUuid: sessionUuid, displayName: displayName);
+      await startAdvertising(
+        sessionUuid: sessionUuid,
+        displayName: displayName,
+      );
     } finally {
       await readySub.cancel();
     }

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -575,17 +575,17 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockStreamHandler(
-        eventChan,
-        MockStreamHandler.inline(
-          onListen: (_, events) {
-            eventController.stream.listen(
-              events.success,
-              onError: (Object e) =>
-                  events.error(code: 'ERR', message: e.toString()),
-            );
-          },
-        ),
-      );
+            eventChan,
+            MockStreamHandler.inline(
+              onListen: (_, events) {
+                eventController.stream.listen(
+                  events.success,
+                  onError: (Object e) =>
+                      events.error(code: 'ERR', message: e.toString()),
+                );
+              },
+            ),
+          );
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (call) async {

--- a/test/contracts/native_audio_bridge_contract_test.dart
+++ b/test/contracts/native_audio_bridge_contract_test.dart
@@ -10,7 +10,10 @@ void main() {
       ).readAsStringSync();
 
       expect(mainActivity, contains('"startVoice" ->'));
-      expect(mainActivity, contains('if (peerAudioManager != null) return true'));
+      expect(
+        mainActivity,
+        contains('if (peerAudioManager != null) return true'),
+      );
       expect(
         mainActivity,
         contains('startVoiceCapture(loopbackTestMode = false)'),
@@ -19,7 +22,10 @@ void main() {
       expect(mainActivity, contains('stopVoiceCapture()'));
       expect(mainActivity, contains('service.startAudioEngine()'));
       // The service lookup was refactored to use a local variable for efficiency
-      expect(mainActivity, contains('val service = WalkieTalkieService.getRunning()'));
+      expect(
+        mainActivity,
+        contains('val service = WalkieTalkieService.getRunning()'),
+      );
       expect(mainActivity, contains('service?.stopAudioEngine()'));
     });
 


### PR DESCRIPTION
## Summary
- `scripts/presubmit.sh` runs `dart format --output=none --set-exit-if-changed .` and currently fails on `main` for 4 files that drifted out of canonical format.
- The GitHub Flutter CI workflow (`.github/workflows/flutter.yml`) does not run a format gate — only `flutter analyze`, `flutter test`, native C++ tests, and Kotlin unit tests — so the regression slipped through silently.
- This PR is the result of running `dart format .` on a clean `main`. No logic changes, just whitespace/wrapping.

Files touched:
- `lib/bloc/frequency_session_cubit.dart`
- `lib/services/audio_service.dart`
- `test/bloc/frequency_session_cubit_test.dart`
- `test/contracts/native_audio_bridge_contract_test.dart`

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` exits 0 on this branch
- [x] `flutter analyze` clean
- [x] `flutter test` — 896 tests pass
- [x] `bash scripts/run_native_cpp_tests.sh` passes
- [x] `cd android && ./gradlew :app:testDebugUnitTest --no-daemon` BUILD SUCCESSFUL

## Follow-up suggestion
Consider adding a `dart format --set-exit-if-changed` step to `.github/workflows/flutter.yml` so future drift is caught at CI time, not just locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted code for improved readability across multiple files.

* **Tests**
  * Updated test assertions and mock event channel handling for better maintainability.

---

**Note:** This release contains internal code improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->