### PR TITLE
fix(settings): wrap settings card in Material to fix ListTile assert + CI

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1179,11 +1179,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // Start host BLE surfaces so remaining guests can reconnect.
     final audio = _audio;
     if (audio != null) {
-      unawaited(audio.startGattServerAndAdvertise(
-        sessionUuid: sessionUuid,
-        displayName: current.myName,
-        shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
-      ));
+      unawaited(
+        audio.startGattServerAndAdvertise(
+          sessionUuid: sessionUuid,
+          displayName: current.myName,
+          shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
+        ),
+      );
       // Close the guest-side voice client before opening the host server.
       // Awaited so the native layer tears down the client transport before
       // startVoiceServer() runs; without this, the native code reuses the
@@ -1438,11 +1440,13 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       // happens in [leaveRoom] and [close].
       final audio = _audio;
       if (audio != null) {
-        unawaited(audio.startGattServerAndAdvertise(
-          sessionUuid: sessionUuid,
-          displayName: myName,
-          shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
-        ));
+        unawaited(
+          audio.startGattServerAndAdvertise(
+            sessionUuid: sessionUuid,
+            displayName: myName,
+            shouldProceed: () => !isClosed && _sessionUuid == sessionUuid,
+          ),
+        );
         // Open the L2CAP voice server. Store the future so _sendJoinAccepted
         // can await it if a guest arrives before the native call returns.
         final gen = ++_voiceGeneration;

--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -461,11 +461,14 @@ class _SettingsCard extends StatelessWidget {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
       decoration: BoxDecoration(
-        color: c.surface,
         border: Border.all(color: c.line),
         borderRadius: BorderRadius.circular(12),
       ),
-      child: child,
+      child: Material(
+        color: c.surface,
+        borderRadius: BorderRadius.circular(12),
+        child: child,
+      ),
     );
   }
 }

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -483,7 +483,10 @@ class AudioService {
       }
 
       if (shouldProceed != null && !shouldProceed()) return;
-      await startAdvertising(sessionUuid: sessionUuid, displayName: displayName);
+      await startAdvertising(
+        sessionUuid: sessionUuid,
+        displayName: displayName,
+      );
     } finally {
       await readySub.cancel();
     }

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -575,17 +575,17 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockStreamHandler(
-        eventChan,
-        MockStreamHandler.inline(
-          onListen: (_, events) {
-            eventController.stream.listen(
-              events.success,
-              onError: (Object e) =>
-                  events.error(code: 'ERR', message: e.toString()),
-            );
-          },
-        ),
-      );
+            eventChan,
+            MockStreamHandler.inline(
+              onListen: (_, events) {
+                eventController.stream.listen(
+                  events.success,
+                  onError: (Object e) =>
+                      events.error(code: 'ERR', message: e.toString()),
+                );
+              },
+            ),
+          );
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (call) async {

--- a/test/contracts/native_audio_bridge_contract_test.dart
+++ b/test/contracts/native_audio_bridge_contract_test.dart
@@ -10,7 +10,10 @@ void main() {
       ).readAsStringSync();
 
       expect(mainActivity, contains('"startVoice" ->'));
-      expect(mainActivity, contains('if (peerAudioManager != null) return true'));
+      expect(
+        mainActivity,
+        contains('if (peerAudioManager != null) return true'),
+      );
       expect(
         mainActivity,
         contains('startVoiceCapture(loopbackTestMode = false)'),
@@ -19,7 +22,10 @@ void main() {
       expect(mainActivity, contains('stopVoiceCapture()'));
       expect(mainActivity, contains('service.startAudioEngine()'));
       // The service lookup was refactored to use a local variable for efficiency
-      expect(mainActivity, contains('val service = WalkieTalkieService.getRunning()'));
+      expect(
+        mainActivity,
+        contains('val service = WalkieTalkieService.getRunning()'),
+      );
       expect(mainActivity, contains('service?.stopAudioEngine()'));
     });
 


### PR DESCRIPTION
## Summary
- 22 widget tests in `frequency_settings_screen_test.dart` + `security_faq_screen_test.dart` are failing on `main` (and on #396). Each throws `ListTile background color or ink splashes may be invisible.` because `_SettingsCard` wraps its `ListTile` child in a `Container` whose `BoxDecoration` paints `color: c.surface`. ListTile asserts that no ancestor `DecoratedBox` between it and the nearest `Material` paints a background.
- Fix: keep the border + radius on the outer Container, but move `color: c.surface` onto a `Material` widget that wraps the child. The ListTile now has a Material ancestor and the assert no longer fires.
- Also re-applies `dart format` to the 4 files PR #396 was fixing (`lib/bloc/frequency_session_cubit.dart`, `lib/services/audio_service.dart`, `test/bloc/frequency_session_cubit_test.dart`, `test/contracts/native_audio_bridge_contract_test.dart`) so `scripts/presubmit.sh` passes. This PR is a superset of #396 — #396 can be closed once this lands.

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` — clean
- [x] `flutter analyze` — No issues found
- [x] `flutter test` — 896 tests pass (22 previously failing now green)
- [x] `bash scripts/run_native_cpp_tests.sh` — pass
- [x] `cd android && ./gradlew :app:testDebugUnitTest --no-daemon` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)