### PR TITLE
fix: ListTile-under-DecoratedBox assertion in FrequencySettingsScreen

### DIFF
--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -458,14 +458,22 @@ class _SettingsCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-      decoration: BoxDecoration(
+    // Use Material (not a Container with a background color) so that any
+    // ListTile inside paints its background / ink splashes against this
+    // Material ancestor. A DecoratedBox with a fill color above a ListTile
+    // both hides the splash and trips a framework assertion in test mode
+    // ("ListTile background color or ink splashes may be invisible").
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      child: Material(
+        type: MaterialType.card,
         color: c.surface,
-        border: Border.all(color: c.line),
-        borderRadius: BorderRadius.circular(12),
+        shape: RoundedRectangleBorder(
+          side: BorderSide(color: c.line),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -307,6 +307,12 @@ void main() {
           find.byType(ListView),
           const Offset(0, -200),
         );
+        // dragUntilVisible can stop as soon as the target is mounted, even
+        // when it is still just below the viewport edge. ensureVisible
+        // scrolls the exact rect into the viewport so the subsequent tap
+        // hit-tests on-screen.
+        await tester.ensureVisible(find.text('Privacy policy'));
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Privacy policy'));
         await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- Local `flutter test` was failing 22 widget tests in `test/screens/frequency_settings_screen_test.dart` because `_SettingsCard` wrapped each `ListTile` in a `Container` with `BoxDecoration(color: …)`. Flutter asserts on this layout — the ListTile's ink/background paints on the nearest `Material` and would be invisible under the colored DecoratedBox.
- Swap the colored `Container` for `Padding` + `Material(type: card, shape: RoundedRectangleBorder(side, borderRadius))`. The card surface is now itself a Material, so the assertion no longer fires and visuals are unchanged (same surface color, same 1 px border, same 12 px radius, same 16/2 outer margin).
- Drive-by: stabilize `tapping Privacy policy link navigates to FrequencyPrivacyPolicyScreen`. `dragUntilVisible` can stop the moment the target is mounted while its rect is still just below the viewport edge, so the follow-up `tap()` hit-tests off-screen. Add an `ensureVisible` + `pumpAndSettle` between the drag and the tap.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 890/890 pass (was 868/890 with 22 failing in this file before the fix)
- [x] `bash scripts/run_native_cpp_tests.sh` — all PeerAudioManager tests pass
- [x] `./gradlew :app:testDebugUnitTest --no-daemon` — BUILD SUCCESSFUL
- [x] `bash scripts/validate_store_metadata.sh` — within Play Store limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal UI component rendering for consistency.

* **Tests**
  * Enhanced test reliability for settings navigation flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->