### PR TITLE
test(settings): ensure Privacy policy link is on-screen before tap

### DIFF
--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -307,6 +307,8 @@ void main() {
           find.byType(ListView),
           const Offset(0, -200),
         );
+        await tester.ensureVisible(find.text('Privacy policy'));
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Privacy policy'));
         await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- `dragUntilVisible` stops once the target intersects the viewport, which can leave the `Text` center off-screen. `tester.tap()` then no-ops with a `derived an Offset … that would not hit test` warning, so navigation never fires and the assertion `find.byType(FrequencyPrivacyPolicyScreen)` fails.
- Match the pattern already used by the reset-all-data tests below (lines 372–380): call `ensureVisible` + `pumpAndSettle` between the drag and the tap so the link is fully on-screen before `tap()`.

This was the single remaining flake in `test/screens/frequency_settings_screen_test.dart` after #397; the other 19 tests in that file already pass.

## Test plan
- [x] `flutter test test/screens/frequency_settings_screen_test.dart` → `+20 All tests passed!`
- [x] `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Privacy policy navigation test with improved element visibility handling and interaction timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->