### PR TITLE
fix: restore ListTile ink + tappable Privacy policy in frequency settings

### DIFF
--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -458,14 +458,16 @@ class _SettingsCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-      decoration: BoxDecoration(
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      child: Material(
         color: c.surface,
-        border: Border.all(color: c.line),
-        borderRadius: BorderRadius.circular(12),
+        shape: RoundedRectangleBorder(
+          side: BorderSide(color: c.line),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -307,6 +307,8 @@ void main() {
           find.byType(ListView),
           const Offset(0, -200),
         );
+        await tester.ensureVisible(find.text('Privacy policy'));
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Privacy policy'));
         await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- `_SettingsCard` wrapped `ListTile`s in a `Container(decoration: BoxDecoration(color: ...))`, which Flutter now asserts against (ListTile background/ink splashes invisible under an opaque DecoratedBox). 21 widget tests in `frequency_settings_screen_test.dart` failed on this assertion.
- Replaced the inner `Container` with `Padding` + `Material` carrying the same surface color and rounded border via `RoundedRectangleBorder` — visuals unchanged, ListTile gets a proper Material ancestor.
- Fixed the "tapping Privacy policy link" test: `dragUntilVisible` stopped with the row's center at y=624 (outside the 600px test viewport), so the tap missed and navigation never fired. Added `ensureVisible` before the tap.

Closes the 22 local test failures surfaced by `flutter test`. Full local suite: 890 passed, 0 failed.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 890/890 pass
- [x] `dart format --set-exit-if-changed lib test` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved underlying UI component implementation structure.

* **Tests**
  * Enhanced test reliability for interactive features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->