### PR TITLE
fix(#441): pin sentry_flutter < 9.20.0 to unbreak Android Kotlin build

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -857,18 +857,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: f04095a25ff02b202a914174c73ec309570aa93d61098cb4a0a9e715b4aaa465
+      sha256: "1f78300740739ff4b4920802687879231554350eab73eb229778f463aabda440"
       url: "https://pub.dev"
     source: hosted
-    version: "9.20.0"
+    version: "9.19.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "4f0a914d8c37e5015d7b86dd42b92dd265948fd31875b43e62ddfc2e7bea0e41"
+      sha256: "168bbb120f7684dee6c0e100817f56ee1925bc2eb7fa55a71253337640c7e241"
       url: "https://pub.dev"
     source: hosted
-    version: "9.20.0"
+    version: "9.19.0"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,7 +64,11 @@ dependencies:
   url_launcher: ^6.3.1
 
   # Crash Reporting (opt-in, privacy-first)
-  sentry_flutter: ^9.20.0
+  # Pinned to 9.19.x: 9.20.0 added Android SessionReplay code paths that
+  # reference io.sentry.android.replay.* without declaring the matching
+  # sentry-android-replay artifact in the plugin's build.gradle, breaking
+  # :app:compileDebugKotlin. Track upstream / un-pin in issue #441.
+  sentry_flutter: ">=9.19.0 <9.20.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

- Pin `sentry_flutter` to `>=9.19.0 <9.20.0` in `pubspec.yaml` (lockfile follows).
- Closes [#441](https://github.com/ElodinLaarz/walkie-talkie/issues/441).

## Root cause

`sentry_flutter` 9.20.0 added Android SessionReplay code paths in `SentryFlutterReplayRecorder.kt`/`SentryFlutterPlugin.kt` that import from `io.sentry.android.replay.*`. The plugin's own `android/build.gradle` only declares:

```
api 'io.sentry:sentry-android:8.41.0'
```

which does **not** transitively pull `io.sentry:sentry-android-replay`. Result:

```
e: .../sentry_flutter-9.20.0/.../SentryFlutterPlugin.kt:207:15
  Unresolved reference 'SentryFlutterReplayRecorder'.
```

This breaks `:sentry_flutter:compileDebugKotlin`, which fails `:app:testDebugUnitTest` (the Kotlin-unit-tests step in CI and `scripts/presubmit.sh`).

App-side dependency overrides don't help — plugin modules compile against their own classpath, so the missing `sentry-android-replay` artifact has to be addressed upstream (or by forking the plugin). Pinning is the cheapest unblock; un-pinning is tracked in #441.

## Test plan

- [x] `flutter pub get` — resolves `sentry_flutter 9.19.0`.
- [x] `flutter analyze` — clean.
- [x] `flutter test` — 890 passing.
- [x] `bash scripts/run_native_cpp_tests.sh` — passing.
- [x] `(cd android && ./gradlew :app:testDebugUnitTest --no-daemon)` — `BUILD SUCCESSFUL` (was failing on `main`).
- [x] `bash scripts/presubmit.sh` end-to-end — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)