### PR TITLE
fix: wrap _SettingsCard ListTiles in Material to restore ink + fix Privacy policy tap

### DIFF
--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -458,14 +458,16 @@ class _SettingsCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-      decoration: BoxDecoration(
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      child: Material(
         color: c.surface,
-        border: Border.all(color: c.line),
-        borderRadius: BorderRadius.circular(12),
+        shape: RoundedRectangleBorder(
+          side: BorderSide(color: c.line),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -307,6 +307,8 @@ void main() {
           find.byType(ListView),
           const Offset(0, -200),
         );
+        await tester.ensureVisible(find.text('Privacy policy'));
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Privacy policy'));
         await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary

`_SettingsCard` wrapped its `ListTile`s in `Container(decoration: BoxDecoration(color: ...))`, which Flutter asserts against:

> ListTile background color or ink splashes may be invisible. The ListTile is wrapped in a DecoratedBox that has a background color. Because ListTile paints its background and ink splashes on the nearest Material ancestor, this DecoratedBox will hide those effects.

This made **22 widget tests** in `test/screens/frequency_settings_screen_test.dart` fail locally on `main` (HEAD `e39ccd8`).

## Changes

- `lib/screens/frequency_settings_screen.dart` — Replace the inner `Container` with `Padding` + `Material`. Same surface color and rounded border, but via `RoundedRectangleBorder` so `Material` itself paints them. `ListTile` now has a proper `Material` ancestor.
- `test/screens/frequency_settings_screen_test.dart` — Add `ensureVisible` before tapping `Privacy policy`. `dragUntilVisible` was leaving the row's center at y=624, outside the 600 px test viewport, so the tap missed and navigation never fired.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — **890/890 pass** (was 868/890 on `main`)
- [x] `dart format --set-exit-if-changed lib test` — clean

## Notes

Supersedes #442 (same fix; that PR went `CONFLICTING` against `main`). #442 can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)