### PR TITLE
fix(#451): fix settings screen test failures on Flutter stable 3.44

### DIFF
--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -460,12 +460,15 @@ class _SettingsCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-      decoration: BoxDecoration(
+      child: Material(
         color: c.surface,
-        border: Border.all(color: c.line),
-        borderRadius: BorderRadius.circular(12),
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          side: BorderSide(color: c.line),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/test/screens/frequency_settings_screen_test.dart
+++ b/test/screens/frequency_settings_screen_test.dart
@@ -307,6 +307,8 @@ void main() {
           find.byType(ListView),
           const Offset(0, -200),
         );
+        await tester.ensureVisible(find.text('Privacy policy'));
+        await tester.pumpAndSettle();
         await tester.tap(find.text('Privacy policy'));
         await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary
- Local CI (`scripts/presubmit.sh`) was failing 22 widget tests in `test/screens/frequency_settings_screen_test.dart` on current Flutter stable (3.44.0). CI uses `channel: stable` unpinned, so it hits the same failures.
- `_SettingsCard` wrapped a `ListTile` in a decorated `Container`; Flutter 3.44's new "ListTile background color or ink splashes may be invisible" assertion tripped 21 tests. Replaced the `BoxDecoration` `Container` with a `Material` (color + `RoundedRectangleBorder` + `Clip.antiAlias`).
- Privacy-policy navigation test: `dragUntilVisible` left the row at the viewport bottom edge so the tap missed; added `ensureVisible` before tapping.

Closes #451

## Test plan
- [x] `flutter analyze` clean
- [x] `dart format` clean
- [x] `flutter test` — full suite green
- [x] native C++ tests pass
- [x] `./gradlew :app:testDebugUnitTest` — BUILD SUCCESSFUL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor & Style**
  * Improved settings card component rendering and border behavior for better visual consistency

* **Tests**
  * Enhanced test robustness for privacy policy navigation verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->