### PR TITLE
fix(settings): wrap settings tiles in transparent Material

### DIFF
--- a/lib/screens/frequency_settings_screen.dart
+++ b/lib/screens/frequency_settings_screen.dart
@@ -465,7 +465,12 @@ class _SettingsCard extends StatelessWidget {
         border: Border.all(color: c.line),
         borderRadius: BorderRadius.circular(12),
       ),
-      child: child,
+      // The decorated Container paints a background color, but a ListTile
+      // paints its own background and ink splashes on the nearest Material
+      // ancestor. Without an intervening Material the colored Container hides
+      // those effects (Flutter asserts on this). Give the tile its own
+      // transparent Material to paint on.
+      child: Material(type: MaterialType.transparency, child: child),
     );
   }
 }


### PR DESCRIPTION
## Problem

`flutter test` fails on `main` with **22 failing widget tests**, all in:
- `test/screens/frequency_settings_screen_test.dart`
- `test/screens/security_faq_screen_test.dart`

Every test that pumps `FrequencySettingsScreen` throws:

```
ListTile background color or ink splashes may be invisible.
The ListTile is wrapped in a DecoratedBox that has a background color.
```

## Root cause

`_SettingsCard` wraps each settings row's `ListTile` in a `Container` with a
`BoxDecoration(color: …)`. A `ListTile` paints its background and ink splashes
on the nearest `Material` ancestor; when a colored `Container`/`DecoratedBox`
sits between the tile and that `Material`, Flutter asserts (the colored box
would hide the tile's own background/splashes). It fires on every pump, so the
whole screen's test suite fails.

## Fix

Give the tile its own transparent `Material` to paint on, inside the decorated
`Container`. Single-point fix in `_SettingsCard` — covers all row types
(toggle, link, destructive link, info row). No visual change.

## Verification (local CI, Flutter 3.44.0 in WSL, run on committed HEAD)

- `flutter test` → **All tests passed!** (890 tests; previously 868 passing + 22 failing)
- `flutter analyze` → **No issues found!**
- `dart format --set-exit-if-changed` on the changed file → clean

Dart-only change; native C++ / Kotlin / AAB CI steps are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual rendering of list items in the Frequency Settings screen to display background and interaction effects correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->