### PR TITLE
fix(#454): wire guest GATT connect on Tune in + queue early control writes

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -51,6 +51,18 @@ class GattClientManager(
     private var requestCharacteristic: BluetoothGattCharacteristic? = null
     private var responseCharacteristic: BluetoothGattCharacteristic? = null
     private var connectRetryCount = 0
+
+    // True once the control link is fully ready to write: services discovered,
+    // REQUEST/RESPONSE characteristics cached, and the RESPONSE CCCD write
+    // confirmed (notifications active). connectToHost() returns at connection
+    // *initiation*, well before this point, so the guest's first JoinRequest
+    // can race ahead of a writable characteristic. Reset on every fresh connect.
+    private var controlReady = false
+    // Outbound REQUEST writes that arrived before [controlReady]. Flushed in
+    // order once the link is ready instead of being dropped — otherwise the
+    // guest's JoinRequest is lost, the host never answers with JoinAccepted,
+    // and the guest is stranded until its watchdog drops it back to Discovery.
+    private val pendingRequestWrites = mutableListOf<ByteArray>()
     private var pendingMacAddress: String? = null
 
     // ATT MTU negotiated for the connected host, keyed by MAC. Populated by
@@ -286,6 +298,12 @@ class GattClientManager(
             if (descriptor.uuid == GattConstants.CCCD_UUID) {
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     Log.i(TAG, "CCCD write successful, notifications active")
+                    // Link is now fully ready: services discovered, characteristics
+                    // cached, notifications enabled. Flush any REQUEST writes that
+                    // raced ahead of discovery (the guest's first JoinRequest) so
+                    // the host receives them and can answer with JoinAccepted.
+                    controlReady = true
+                    flushPendingRequestWrites()
                     // CCCD confirmed — GATT is fully idle, safe to start RSSI polling.
                     startRssiPolling()
                 } else {
@@ -400,6 +418,12 @@ class GattClientManager(
             return false
         }
 
+        // Fresh attempt: the new link isn't writable until its CCCD write
+        // confirms. Reset readiness and drop any writes left over from a prior
+        // link so they can't flush onto this one.
+        controlReady = false
+        pendingRequestWrites.clear()
+
         try {
             val device = adapter.getRemoteDevice(macAddress)
             Log.i(TAG, "Connecting to host at $macAddress (attempt ${connectRetryCount + 1})")
@@ -433,6 +457,34 @@ class GattClientManager(
      * Returns true if the write was queued, false otherwise.
      */
     fun writeRequest(bytes: ByteArray): Boolean {
+        // The control link isn't writable until service discovery + the CCCD
+        // write complete (see [controlReady]). connectToHost() returns at
+        // connection initiation, so callers — notably the guest's first
+        // JoinRequest — can race ahead of a writable characteristic. Queue those
+        // writes and flush them in order once the link is ready (see
+        // [flushPendingRequestWrites]) rather than dropping them, which would
+        // leave the host with no JoinRequest to answer.
+        if (!controlReady) {
+            Log.i(TAG, "Control link not ready — queueing ${bytes.size}-byte REQUEST write")
+            pendingRequestWrites.add(bytes)
+            return true
+        }
+        return writeRequestNow(bytes)
+    }
+
+    /** Flush writes that arrived before the control link was ready, in order. */
+    private fun flushPendingRequestWrites() {
+        if (pendingRequestWrites.isEmpty()) return
+        val queued = pendingRequestWrites.toList()
+        pendingRequestWrites.clear()
+        Log.i(TAG, "Flushing ${queued.size} queued REQUEST write(s) now that the link is ready")
+        for (queuedBytes in queued) {
+            writeRequestNow(queuedBytes)
+        }
+    }
+
+    /** Performs the actual REQUEST characteristic write. Assumes the link is ready. */
+    private fun writeRequestNow(bytes: ByteArray): Boolean {
         val char = requestCharacteristic
         if (char == null) {
             Log.w(TAG, "Cannot write REQUEST: characteristic not available")

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1472,8 +1472,21 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         roomIsHost: false,
         macAddress: macAddress,
         sessionUuidLow8: sessionUuidLow8,
+        // Enter in the "reconnecting" phase (the UI's connecting pill) — we
+        // are NOT actually in the room until the host's JoinAccepted lands
+        // and flips us to online. The JoinAccepted watchdog also keys off
+        // this phase, so it must be set before we dial.
+        connectionPhase: ConnectionPhase.reconnecting,
       );
       emit(room);
+      // Dial the host's GATT control link and send the JoinRequest. This is
+      // the step that was deferred to #43 and never wired at the call site:
+      // without it the guest sits in the room heart-beating into a link that
+      // was never opened, and the host shows "0 guest(s)" forever. macAddress
+      // is null only for cosmetic / test-only entries with no real BLE device.
+      if (macAddress != null) {
+        unawaited(_connectAndSendJoin(macAddress));
+      }
     }
     // Begin the heartbeat plane for the lifetime of the room. Pings the
     // wire every interval and watches inbound activity for silent peers
@@ -1900,6 +1913,105 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     }
   }
 
+  /// Guest-only: builds + sends the [JoinRequest] that asks the host to admit
+  /// this peer. The host replies with a targeted [JoinAccepted] (handled by
+  /// [applyJoinAccepted]) carrying the roster + voicePsm. Mirrors
+  /// [_sendHeartbeat]'s resolve-peerId-then-guarded-send idiom; the seq
+  /// counter advances even on the no-transport path so it stays monotonic
+  /// once the link is up.
+  Future<void> _sendJoinRequest() async {
+    final t = _transport;
+    if (t == null) {
+      _seq++;
+      return;
+    }
+    final current = state;
+    if (current is! SessionRoom) return;
+    final String peerId;
+    try {
+      peerId = _localPeerId ?? await identityStore.getPeerId();
+      _localPeerId = peerId;
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('Failed to resolve peer id for join request: $error');
+      }
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+      _seq++;
+      return;
+    }
+    if (isClosed) return;
+    final msg = JoinRequest(
+      peerId: peerId,
+      seq: ++_seq,
+      atMs: DateTime.now().millisecondsSinceEpoch,
+      displayName: current.myName,
+    );
+    try {
+      await t.send(msg);
+    } catch (error, stackTrace) {
+      // Transport failures are already logged inside BleControlTransport;
+      // swallow here so the caller's room transition isn't poisoned.
+      if (kDebugMode) debugPrint('JoinRequest send failed: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+    }
+  }
+
+  /// Guest-only: dials the host's GATT control link for the *initial* join,
+  /// then sends the [JoinRequest]. The symmetric reconnect path lives in
+  /// [notifyDrop]; both share [_sendJoinRequest] + [_armJoinAcceptedWatchdog].
+  /// On connect failure (permission / OEM rejection / out of range) drop
+  /// straight back to Discovery; on success the host's [JoinAccepted] flips
+  /// the phase to online, or [_armJoinAcceptedWatchdog] bails if it never
+  /// comes. Guarded against the user leaving / switching rooms mid-dial.
+  Future<void> _connectAndSendJoin(String macAddress) async {
+    final audio = _audio;
+    if (audio == null) return;
+    bool connected;
+    try {
+      connected = await audio.connectToHost(macAddress);
+    } catch (error, stackTrace) {
+      if (kDebugMode) debugPrint('connectToHost failed: $error');
+      if (kDebugMode) debugPrintStack(stackTrace: stackTrace);
+      connected = false;
+    }
+    if (isClosed) return;
+    final current = state;
+    // Bail if the user left, we became the host, or moved to a different room
+    // while the native connect was in flight.
+    if (current is! SessionRoom ||
+        current.roomIsHost ||
+        current.macAddress != macAddress) {
+      return;
+    }
+    if (!connected) {
+      emit(current.copyWith(connectionPhase: ConnectionPhase.lost));
+      await leaveRoom();
+      return;
+    }
+    await _sendJoinRequest();
+    _armJoinAcceptedWatchdog();
+  }
+
+  /// (Re)arms the JoinAccepted watchdog. A live native link is not enough —
+  /// the host must answer the JoinRequest with a [JoinAccepted] to complete
+  /// the (re)join. If it never arrives (host died, sessionUuid changed, GATT
+  /// subscription failed silently) bail to lost + Discovery instead of
+  /// hanging forever. Shared by the initial-join and reconnect paths so both
+  /// fail the same way; [applyJoinAccepted] cancels it on success.
+  void _armJoinAcceptedWatchdog() {
+    _joinAcceptedWatchdog?.cancel();
+    _joinAcceptedWatchdog = Timer(_joinAcceptedTimeout, () async {
+      if (isClosed) return;
+      final watchdogState = state;
+      if (watchdogState is! SessionRoom ||
+          watchdogState.connectionPhase != ConnectionPhase.reconnecting) {
+        return;
+      }
+      emit(watchdogState.copyWith(connectionPhase: ConnectionPhase.lost));
+      await leaveRoom();
+    });
+  }
+
   /// Called by heartbeat detection when the guest hasn't heard from the host
   /// for the heartbeat timeout. Transitions the room to
   /// [ConnectionPhase.reconnecting] and starts the exponential-backoff retry
@@ -1950,21 +2062,12 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     // host never sends JoinAccepted (host died, session UUID changed, GATT
     // subscription failed silently, ...), bail to lost + Discovery rather
     // than waiting forever.
-    _joinAcceptedWatchdog?.cancel();
-    _joinAcceptedWatchdog = Timer(_joinAcceptedTimeout, () async {
-      if (isClosed) return;
-      final watchdogState = state;
-      // Guard: applyJoinAccepted already fired and cleared to online, or the
-      // user manually left. Don't overwrite a healthy or exited state.
-      if (watchdogState is! SessionRoom ||
-          watchdogState.connectionPhase != ConnectionPhase.reconnecting) {
-        return;
-      }
-      // Host never sent JoinAccepted after native reconnect succeeded —
-      // treat it like a full connection loss.
-      emit(watchdogState.copyWith(connectionPhase: ConnectionPhase.lost));
-      await leaveRoom();
-    });
+    // Native link re-established, but the host won't emit JoinAccepted on its
+    // own — re-send the JoinRequest (the host's _onJoinRequest treats a known
+    // peerId as a re-join) so it answers, then arm the watchdog. Without the
+    // re-send the host stays silent and the watchdog would always fire.
+    unawaited(_sendJoinRequest());
+    _armJoinAcceptedWatchdog();
   }
 
   /// Broadcasts a media command originated by the local peer.

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -497,6 +497,11 @@ void main() {
           roomIsHost: false,
           macAddress: 'AA:BB:CC:DD:EE:FF',
           sessionUuidLow8: '0011223344556677',
+          // Guests now enter in the dialing (reconnecting) phase until the
+          // host's JoinAccepted flips them to online. This cubit has no
+          // audio injected, so _connectAndSendJoin no-ops and the phase
+          // stays reconnecting — exactly the pre-handshake state.
+          connectionPhase: ConnectionPhase.reconnecting,
         ),
       ],
     );
@@ -3028,6 +3033,11 @@ void main() {
                   .map((r) => {'peerId': r.peerId, 'rssi': r.rssi})
                   .toList();
             }
+            // The guest join path now dials the host via connectToHost.
+            // Report success so the cubit stays in the room (reconnecting,
+            // then online via the test's explicit applyJoinAccepted) instead
+            // of bailing back to Discovery on a false/null connect result.
+            if (call.method == 'connectToHost') return true;
             return null;
           });
       addTearDown(() {
@@ -3531,6 +3541,10 @@ void main() {
         cubit.emit(const SessionDiscovery(myName: 'Maya'));
         // Join without calling applyJoinAccepted — hostPeerId is null.
         await cubit.joinRoom(freq: '104.3', isHost: false, macAddress: hostMac);
+        // Let the join-time connect + JoinRequest flush so the outbox and seq
+        // measured below reflect only the signal-report behavior, not the
+        // one-time join handshake the guest now performs on tune-in.
+        await Future<void>.delayed(const Duration(milliseconds: 10));
 
         final seqBefore = cubit.debugSeq;
         t.outbox.clear();

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -154,6 +154,16 @@ FrequencySessionCubit _seededCubit({bool isHost = false}) {
   cubit
     ..emit(const SessionDiscovery(myName: 'Caleb'))
     ..joinRoom(freq: '104.3', isHost: isHost);
+  // joinRoom now parks guests in the dialing (reconnecting) phase until the
+  // host's JoinAccepted arrives. These screen tests want a settled, on-air
+  // room as their baseline (and drive reconnecting/lost explicitly where they
+  // need it), so flip guests to online here. Hosts are already online.
+  if (!isHost) {
+    final seeded = cubit.state;
+    if (seeded is SessionRoom) {
+      cubit.emit(seeded.copyWith(connectionPhase: ConnectionPhase.online));
+    }
+  }
   return cubit;
 }
 


### PR DESCRIPTION
## What

Fixes the core guest-join flow: tapping **Tune in** never connected to the host, so two phones could never share a frequency. Discovery worked, but the guest entered a phantom room and the host showed `0 guest(s)` forever.

Closes #454.

## Root causes (two layers)

1. **Dart** — `FrequencySessionCubit.joinRoom`'s guest branch stored the host MAC but never called `connectToHost`, never sent a `JoinRequest`, and never armed the JoinAccepted watchdog. The connect was deferred to #43 and the call site was never wired. `notifyDrop` (reconnect) had the same gap — it reconnected but never re-sent a `JoinRequest`, so reconnect would always time out too.
2. **Native** — exposed once layer 1 was fixed. `GattClientManager.connectToHost` returns at connection *initiation*, ~1s before service discovery makes the REQUEST characteristic writable. `writeRequest` then *dropped* the first JoinRequest (`Cannot write REQUEST: characteristic not available`) instead of queuing it — despite its docstring claiming *"returns true if queued"* — so the host never received it.

## Fix

- **`lib/bloc/frequency_session_cubit.dart`** — guest `joinRoom` now dials `connectToHost`, sends a `JoinRequest`, and arms the watchdog via new `_connectAndSendJoin` / `_sendJoinRequest` / `_armJoinAcceptedWatchdog`; the guest enters `ConnectionPhase.reconnecting` until `JoinAccepted` flips it to `online`. `notifyDrop` re-sends a `JoinRequest` after reconnect using the same shared helpers.
- **`android/.../GattClientManager.kt`** — `writeRequest` now queues writes while the control link isn't ready and flushes them in order once the RESPONSE CCCD write confirms (`onDescriptorWrite`); state resets on every fresh connect so reconnect's re-sent JoinRequest survives the same race.

## Verification

On two physical phones over real BLE radios (Pixel 10 Pro XL host + moto g play 2024 guest):

- Host went from `Host broadcasting … to 0 guest(s)` (entire session) to `1 guest(s)`.
- Guest log: `Control link not ready — queueing 131-byte REQUEST write` → `Flushing 2 queued REQUEST write(s) now that the link is ready` → `Received 247 bytes from host` (the `JoinAccepted` + roster).
- Both rosters populated; confirmed visually — both peers visible in both rooms.
- 896 Dart tests + Kotlin unit tests pass; `flutter analyze` clean.

## Not included / follow-ups

- Locking the screen tears down the room (the foreground service should keep it alive) — a **separate** lifecycle bug, not addressed here.
- The initial dial reuses the `reconnecting` "Reconnecting…" pill; a dedicated `connecting` phase + copy would read better.
- Flutter Kotlin-Gradle-Plugin deprecation warnings surface during the build (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth connection handshake reliability by properly sequencing outbound message delivery during link setup.
  * Guest room join flow now correctly handles reconnection with handshake message resending to ensure successful joins.

* **Tests**
  * Updated test expectations to reflect new connection state handling and handshake behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ElodinLaarz/walkie-talkie/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->