### PR TITLE
discovery: fix room discovery and connection failures on Pixel devices (#459)

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -64,7 +64,19 @@ class GattClientManager(
     // and the guest is stranded until its watchdog drops it back to Discovery.
     private val pendingRequestWrites = mutableListOf<ByteArray>()
     private var pendingMacAddress: String? = null
+    @Volatile
     private var connectCallback: ((Boolean) -> Unit)? = null
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /** Fire the pending connect callback exactly once, on the main thread. */
+    private fun finishConnect(success: Boolean) {
+        mainHandler.post {
+            val cb = connectCallback
+            connectCallback = null
+            cb?.invoke(success)
+        }
+    }
 
     // ATT MTU negotiated for the connected host, keyed by MAC. Populated by
     // [onMtuChanged] once the GATT layer answers our [requestMtu] from
@@ -114,11 +126,7 @@ class GattClientManager(
                 gatt.close()
                 requestCharacteristic = null
                 responseCharacteristic = null
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 return
             }
 
@@ -174,11 +182,7 @@ class GattClientManager(
                         cancelPendingRetry()
                         connectRetryCount = 0
                         pendingMacAddress = null
-                        val cb = connectCallback
-                        connectCallback = null
-                        cb?.let {
-                            Handler(Looper.getMainLooper()).post { it(false) }
-                        }
+                        finishConnect(false)
                     }
                 }
             }
@@ -200,21 +204,13 @@ class GattClientManager(
                 if (!started) {
                     Log.e(TAG, "discoverServices() returned false — GATT stack busy or disconnected")
                     onError?.invoke("GATT_SETUP_FAILED")
-                    val cb = connectCallback
-                    connectCallback = null
-                    cb?.let {
-                        Handler(Looper.getMainLooper()).post { it(false) }
-                    }
+                    finishConnect(false)
                     gatt.disconnect()
                 }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Missing Bluetooth permission for discoverServices()", e)
                 onError?.invoke("BLUETOOTH_PERMISSION_DENIED")
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
             }
         }
@@ -227,11 +223,7 @@ class GattClientManager(
                 } else {
                     onError?.invoke("GATT_SETUP_FAILED")
                 }
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
                 return
             }
@@ -240,11 +232,7 @@ class GattClientManager(
             if (service == null) {
                 Log.e(TAG, "Walkie-talkie service not found on host")
                 onError?.invoke("GATT_SETUP_FAILED")
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
                 return
             }
@@ -254,11 +242,7 @@ class GattClientManager(
             if (requestCharacteristic == null) {
                 Log.e(TAG, "REQUEST characteristic not found")
                 onError?.invoke("GATT_SETUP_FAILED")
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
                 return
             }
@@ -268,11 +252,7 @@ class GattClientManager(
             if (responseCharacteristic == null) {
                 Log.e(TAG, "RESPONSE characteristic not found")
                 onError?.invoke("GATT_SETUP_FAILED")
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
                 return
             }
@@ -282,11 +262,7 @@ class GattClientManager(
             if (!notifyEnabled) {
                 Log.e(TAG, "Failed to enable characteristic notification")
                 onError?.invoke("GATT_SETUP_FAILED")
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
                 return
             }
@@ -296,11 +272,7 @@ class GattClientManager(
             if (cccd == null) {
                 Log.e(TAG, "CCCD descriptor not found on RESPONSE characteristic")
                 onError?.invoke("GATT_SETUP_FAILED")
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
                 return
             }
@@ -315,11 +287,7 @@ class GattClientManager(
             if (writeSuccess != BluetoothStatusCodes.SUCCESS) {
                 Log.e(TAG, "Failed to write CCCD descriptor: $writeSuccess")
                 onError?.invoke("GATT_SETUP_FAILED")
-                val cb = connectCallback
-                connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
                 gatt.disconnect()
             } else {
                 Log.i(TAG, "GATT client setup complete, notifications enabled")
@@ -362,30 +330,18 @@ class GattClientManager(
                     flushPendingRequestWrites()
                     // CCCD confirmed — GATT is fully idle, safe to start RSSI polling.
                     startRssiPolling()
-                    val cb = connectCallback
-                    connectCallback = null
-                    cb?.let {
-                        Handler(Looper.getMainLooper()).post { it(true) }
-                    }
+                    finishConnect(true)
                 } else {
                     // Check for authorization failures on descriptor writes
                     if (status in GattConstants.AUTHORIZATION_ERRORS) {
                         Log.e(TAG, "CCCD write authorization failure: status=$status")
                         onError?.invoke("GATT_AUTHORIZATION_DENIED")
-                        val cb = connectCallback
-                        connectCallback = null
-                        cb?.let {
-                            Handler(Looper.getMainLooper()).post { it(false) }
-                        }
+                        finishConnect(false)
                         disconnect()
                     } else {
                         Log.e(TAG, "CCCD write failed with status $status")
                         onError?.invoke("GATT_SETUP_FAILED")
-                        val cb = connectCallback
-                        connectCallback = null
-                        cb?.let {
-                            Handler(Looper.getMainLooper()).post { it(false) }
-                        }
+                        finishConnect(false)
                         disconnect()
                     }
                 }
@@ -478,8 +434,10 @@ class GattClientManager(
      */
     fun connectToHost(macAddress: String, callback: ((Boolean) -> Unit)? = null): Boolean {
         if (callback != null) {
-            this.connectCallback?.let { oldCb ->
-                Handler(Looper.getMainLooper()).post { oldCb(false) }
+            val oldCb = this.connectCallback
+            this.connectCallback = null
+            oldCb?.let {
+                mainHandler.post { it(false) }
             }
             this.connectCallback = callback
         }
@@ -487,22 +445,14 @@ class GattClientManager(
         val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
         if (bluetoothManager == null) {
             Log.e(TAG, "BluetoothManager not available")
-            val cb = this.connectCallback
-            this.connectCallback = null
-            cb?.let {
-                Handler(Looper.getMainLooper()).post { it(false) }
-            }
+            finishConnect(false)
             return false
         }
 
         val adapter = bluetoothManager.adapter
         if (adapter == null) {
             Log.e(TAG, "BluetoothAdapter not available")
-            val cb = this.connectCallback
-            this.connectCallback = null
-            cb?.let {
-                Handler(Looper.getMainLooper()).post { it(false) }
-            }
+            finishConnect(false)
             return false
         }
 
@@ -519,11 +469,7 @@ class GattClientManager(
             gatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
             val success = gatt != null
             if (!success) {
-                val cb = this.connectCallback
-                this.connectCallback = null
-                cb?.let {
-                    Handler(Looper.getMainLooper()).post { it(false) }
-                }
+                finishConnect(false)
             }
             return success
         } catch (e: Exception) {
@@ -542,11 +488,7 @@ class GattClientManager(
             cancelPendingRetry()
             connectRetryCount = 0
             pendingMacAddress = null
-            val cb = this.connectCallback
-            this.connectCallback = null
-            cb?.let {
-                Handler(Looper.getMainLooper()).post { it(false) }
-            }
+            finishConnect(false)
             return false
         }
     }
@@ -637,11 +579,7 @@ class GattClientManager(
             pendingMacAddress = null
             gatt?.disconnect()
             Log.i(TAG, "GATT client disconnect initiated")
-            val cb = connectCallback
-            connectCallback = null
-            cb?.let {
-                Handler(Looper.getMainLooper()).post { it(false) }
-            }
+            finishConnect(false)
         } catch (e: Exception) {
             Log.e(TAG, "Error disconnecting GATT client", e)
         }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -64,6 +64,7 @@ class GattClientManager(
     // and the guest is stranded until its watchdog drops it back to Discovery.
     private val pendingRequestWrites = mutableListOf<ByteArray>()
     private var pendingMacAddress: String? = null
+    private var connectCallback: ((Boolean) -> Unit)? = null
 
     // ATT MTU negotiated for the connected host, keyed by MAC. Populated by
     // [onMtuChanged] once the GATT layer answers our [requestMtu] from
@@ -113,6 +114,11 @@ class GattClientManager(
                 gatt.close()
                 requestCharacteristic = null
                 responseCharacteristic = null
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 return
             }
 
@@ -168,6 +174,11 @@ class GattClientManager(
                         cancelPendingRetry()
                         connectRetryCount = 0
                         pendingMacAddress = null
+                        val cb = connectCallback
+                        connectCallback = null
+                        cb?.let {
+                            Handler(Looper.getMainLooper()).post { it(false) }
+                        }
                     }
                 }
             }
@@ -189,11 +200,21 @@ class GattClientManager(
                 if (!started) {
                     Log.e(TAG, "discoverServices() returned false — GATT stack busy or disconnected")
                     onError?.invoke("GATT_SETUP_FAILED")
+                    val cb = connectCallback
+                    connectCallback = null
+                    cb?.let {
+                        Handler(Looper.getMainLooper()).post { it(false) }
+                    }
                     gatt.disconnect()
                 }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Missing Bluetooth permission for discoverServices()", e)
                 onError?.invoke("BLUETOOTH_PERMISSION_DENIED")
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
             }
         }
@@ -206,6 +227,11 @@ class GattClientManager(
                 } else {
                     onError?.invoke("GATT_SETUP_FAILED")
                 }
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
                 return
             }
@@ -214,6 +240,11 @@ class GattClientManager(
             if (service == null) {
                 Log.e(TAG, "Walkie-talkie service not found on host")
                 onError?.invoke("GATT_SETUP_FAILED")
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
                 return
             }
@@ -223,6 +254,11 @@ class GattClientManager(
             if (requestCharacteristic == null) {
                 Log.e(TAG, "REQUEST characteristic not found")
                 onError?.invoke("GATT_SETUP_FAILED")
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
                 return
             }
@@ -232,6 +268,11 @@ class GattClientManager(
             if (responseCharacteristic == null) {
                 Log.e(TAG, "RESPONSE characteristic not found")
                 onError?.invoke("GATT_SETUP_FAILED")
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
                 return
             }
@@ -241,6 +282,11 @@ class GattClientManager(
             if (!notifyEnabled) {
                 Log.e(TAG, "Failed to enable characteristic notification")
                 onError?.invoke("GATT_SETUP_FAILED")
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
                 return
             }
@@ -250,6 +296,11 @@ class GattClientManager(
             if (cccd == null) {
                 Log.e(TAG, "CCCD descriptor not found on RESPONSE characteristic")
                 onError?.invoke("GATT_SETUP_FAILED")
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
                 return
             }
@@ -264,6 +315,11 @@ class GattClientManager(
             if (writeSuccess != BluetoothStatusCodes.SUCCESS) {
                 Log.e(TAG, "Failed to write CCCD descriptor: $writeSuccess")
                 onError?.invoke("GATT_SETUP_FAILED")
+                val cb = connectCallback
+                connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
                 gatt.disconnect()
             } else {
                 Log.i(TAG, "GATT client setup complete, notifications enabled")
@@ -306,15 +362,30 @@ class GattClientManager(
                     flushPendingRequestWrites()
                     // CCCD confirmed — GATT is fully idle, safe to start RSSI polling.
                     startRssiPolling()
+                    val cb = connectCallback
+                    connectCallback = null
+                    cb?.let {
+                        Handler(Looper.getMainLooper()).post { it(true) }
+                    }
                 } else {
                     // Check for authorization failures on descriptor writes
                     if (status in GattConstants.AUTHORIZATION_ERRORS) {
                         Log.e(TAG, "CCCD write authorization failure: status=$status")
                         onError?.invoke("GATT_AUTHORIZATION_DENIED")
+                        val cb = connectCallback
+                        connectCallback = null
+                        cb?.let {
+                            Handler(Looper.getMainLooper()).post { it(false) }
+                        }
                         disconnect()
                     } else {
                         Log.e(TAG, "CCCD write failed with status $status")
                         onError?.invoke("GATT_SETUP_FAILED")
+                        val cb = connectCallback
+                        connectCallback = null
+                        cb?.let {
+                            Handler(Looper.getMainLooper()).post { it(false) }
+                        }
                         disconnect()
                     }
                 }
@@ -405,16 +476,33 @@ class GattClientManager(
      * Returns true if the connection attempt was initiated, false otherwise.
      * Actual connection state changes are reported via the callback.
      */
-    fun connectToHost(macAddress: String): Boolean {
+    fun connectToHost(macAddress: String, callback: ((Boolean) -> Unit)? = null): Boolean {
+        if (callback != null) {
+            this.connectCallback?.let { oldCb ->
+                Handler(Looper.getMainLooper()).post { oldCb(false) }
+            }
+            this.connectCallback = callback
+        }
+
         val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
         if (bluetoothManager == null) {
             Log.e(TAG, "BluetoothManager not available")
+            val cb = this.connectCallback
+            this.connectCallback = null
+            cb?.let {
+                Handler(Looper.getMainLooper()).post { it(false) }
+            }
             return false
         }
 
         val adapter = bluetoothManager.adapter
         if (adapter == null) {
             Log.e(TAG, "BluetoothAdapter not available")
+            val cb = this.connectCallback
+            this.connectCallback = null
+            cb?.let {
+                Handler(Looper.getMainLooper()).post { it(false) }
+            }
             return false
         }
 
@@ -429,7 +517,15 @@ class GattClientManager(
             Log.i(TAG, "Connecting to host at $macAddress (attempt ${connectRetryCount + 1})")
             pendingMacAddress = macAddress
             gatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
-            return gatt != null
+            val success = gatt != null
+            if (!success) {
+                val cb = this.connectCallback
+                this.connectCallback = null
+                cb?.let {
+                    Handler(Looper.getMainLooper()).post { it(false) }
+                }
+            }
+            return success
         } catch (e: Exception) {
             // Reset retry / pending state on every failure path so a half-set
             // pendingMacAddress can't trigger a retry the user never asked for.
@@ -446,6 +542,11 @@ class GattClientManager(
             cancelPendingRetry()
             connectRetryCount = 0
             pendingMacAddress = null
+            val cb = this.connectCallback
+            this.connectCallback = null
+            cb?.let {
+                Handler(Looper.getMainLooper()).post { it(false) }
+            }
             return false
         }
     }
@@ -536,6 +637,11 @@ class GattClientManager(
             pendingMacAddress = null
             gatt?.disconnect()
             Log.i(TAG, "GATT client disconnect initiated")
+            val cb = connectCallback
+            connectCallback = null
+            cb?.let {
+                Handler(Looper.getMainLooper()).post { it(false) }
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Error disconnecting GATT client", e)
         }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -185,6 +185,13 @@ class HostAdvertiser(private val context: Context) {
         // rename the user's phone in their Bluetooth settings. Skipping
         // the rename if it already matches avoids touching the adapter
         // when the user's existing BT name is already their display name.
+        val maxNameLength = 11
+        val targetName = if (displayName.length > maxNameLength) {
+            displayName.substring(0, maxNameLength)
+        } else {
+            displayName
+        }
+
         val previousName = try {
             adapter.name
         } catch (e: SecurityException) {
@@ -194,43 +201,38 @@ class HostAdvertiser(private val context: Context) {
             Log.w(TAG, "Could not read adapter name; restore will be skipped", e)
             null
         }
-        if (previousName != displayName) {
+        if (previousName != targetName) {
             try {
-                adapter.setName(displayName)
+                adapter.setName(targetName)
                 savedAdapterName = previousName
             } catch (e: SecurityException) {
                 Log.w(TAG, "Could not set adapter name (BLUETOOTH_CONNECT missing)", e)
             }
         }
 
-        // Budget split across the two 31-byte legacy PDUs:
+        // Budget split across the two 31-byte legacy PDUs to ensure passive scanning
+        // Google Pixel devices (which miss SCAN_RSP in background/power-saving states)
+        // receive the critical session identifier payload:
         //
-        //   Primary ADV_IND (3 flags + 18 UUID = 21 bytes used, 10 remaining):
-        //     - Service UUID: allows passive BLE scanners and third-party apps to
-        //       identify this as a Frequency host without decoding the payload.
-        //     - Device name via setIncludeDeviceName(true): up to 8 chars fit in
-        //       the remaining 10 bytes; Android auto-uses Shortened Local Name
-        //       (AD 0x08) for longer names so they still advertise instead of
-        //       triggering ADVERTISE_FAILED_DATA_TOO_LARGE. Previously the name
-        //       lived in the scan response alongside the 20-byte manufacturer
-        //       payload; combined they overflowed 31 bytes on any device whose
-        //       BT name exceeded 9 chars (e.g. "moto g power (2022)"), silently
-        //       preventing advertising from starting on Motorola hosts.
+        //   Primary ADV_IND (3 flags + 18 manufacturer data = 21 bytes used, 10 remaining):
+        //     - Manufacturer payload only: Since it fits easily, we put it here so
+        //       passive scanners never miss the session UUID and other critical data.
         //
-        //   Scan response SCAN_RSP (20 bytes used):
-        //     - Manufacturer payload only. The Android stack merges both PDUs
-        //       into ScanRecord, so DiscoveredSession.fromManufacturerData
-        //       reassembles them transparently.
+        //   Scan response SCAN_RSP (18 UUID + 2 name header + 11 name chars = 31 bytes max):
+        //     - Service UUID: Allows active BLE scanners and third-party apps to
+        //       identify this as a Frequency host.
+        //     - Device name via setIncludeDeviceName(true): Truncated to max 11 characters
+        //       to guarantee the scan response never overflows 31 bytes.
         val payloadHex = payload.joinToString("") { "%02x".format(it.toInt() and 0xFF) }
         Log.d(TAG, "adv payload: mfg_id=0x%04x bytes=%s".format(MANUFACTURER_ID, payloadHex))
 
         val advData = AdvertiseData.Builder()
-            .addServiceUuid(ParcelUuid(SERVICE_UUID))
-            .setIncludeDeviceName(true)
+            .addManufacturerData(MANUFACTURER_ID, payload)
             .build()
 
         val scanResponse = AdvertiseData.Builder()
-            .addManufacturerData(MANUFACTURER_ID, payload)
+            .addServiceUuid(ParcelUuid(SERVICE_UUID))
+            .setIncludeDeviceName(true)
             .build()
 
         val settings = AdvertiseSettings.Builder()

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/HostAdvertiser.kt
@@ -185,12 +185,8 @@ class HostAdvertiser(private val context: Context) {
         // rename the user's phone in their Bluetooth settings. Skipping
         // the rename if it already matches avoids touching the adapter
         // when the user's existing BT name is already their display name.
-        val maxNameLength = 11
-        val targetName = if (displayName.length > maxNameLength) {
-            displayName.substring(0, maxNameLength)
-        } else {
-            displayName
-        }
+        val maxNameBytes = 11
+        val targetName = truncateToUtf8Bytes(displayName, maxNameBytes)
 
         val previousName = try {
             adapter.name
@@ -328,6 +324,17 @@ class HostAdvertiser(private val context: Context) {
         } catch (e: SecurityException) {
             Log.w(TAG, "Could not restore adapter name; will retry on next stop", e)
         }
+    }
+
+    /** Truncate [s] to at most [maxBytes] UTF-8 bytes without splitting multi-byte chars. */
+    private fun truncateToUtf8Bytes(s: String, maxBytes: Int): String {
+        val bytes = s.toByteArray(Charsets.UTF_8)
+        if (bytes.size <= maxBytes) return s
+        var end = maxBytes
+        while (end > 0 && (bytes[end].toInt() and 0xC0) == 0x80) {
+            end--
+        }
+        return String(bytes, 0, end, Charsets.UTF_8)
     }
 
     /**

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -319,8 +319,12 @@ class MainActivity : FlutterActivity() {
                                 }
                             )
                         }
-                        val success = gattClientManager?.connectToHost(macAddress) ?: false
-                        result.success(success)
+                        val initiated = gattClientManager?.connectToHost(macAddress) { success ->
+                            result.success(success)
+                        } ?: false
+                        if (!initiated) {
+                            result.success(false)
+                        }
                     }
                 }
                 "disconnectFromHost" -> {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -319,11 +319,16 @@ class MainActivity : FlutterActivity() {
                                 }
                             )
                         }
-                        val initiated = gattClientManager?.connectToHost(macAddress) { success ->
-                            result.success(success)
-                        } ?: false
-                        if (!initiated) {
+                        val manager = gattClientManager
+                        if (manager == null) {
                             result.success(false)
+                        } else {
+                            // connectToHost invokes the callback exactly once
+                            // (success or any failure path), so deliver the
+                            // Flutter result only through it to avoid a double reply.
+                            manager.connectToHost(macAddress) { success ->
+                                result.success(success)
+                            }
                         }
                     }
                 }

--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -55,8 +55,26 @@ class DiscoveryService {
       for (ScanResult r in results) {
         final session = parseResult(r);
         if (session != null) {
+          final existing = _discovered[session.sessionUuidLow8];
+          final resolvedHostName =
+              (session.hostName.isEmpty && existing != null)
+              ? existing.session.hostName
+              : session.hostName;
+
+          final resolvedSession = resolvedHostName == session.hostName
+              ? session
+              : DiscoveredSession(
+                  protocolVersion: session.protocolVersion,
+                  isHost: session.isHost,
+                  sessionUuidLow8: session.sessionUuidLow8,
+                  flags: session.flags,
+                  hostName: resolvedHostName,
+                  rssi: session.rssi,
+                  macAddress: session.macAddress,
+                );
+
           _discovered[session.sessionUuidLow8] = (
-            session: session,
+            session: resolvedSession,
             lastSeen: DateTime.now(),
           );
         }


### PR DESCRIPTION
Resolves #459.

This PR addresses room discovery and connection failures across different hardware ecosystems (such as Google Pixels) by addressing scan asymmetries, packet budget overflows, and GATT connection race conditions:

### 1. Swapped BLE Advertisement Payloads for Scan Asymmetry
- Google Pixel devices default to passive scanning in power-saving/background states and miss `SCAN_RSP` (Scan Response) packets entirely.
- Swapped the primary advertisement (`advData`) and scan response (`scanResponse`) payloads in `HostAdvertiser.kt`.
- **Primary PDU (`ADV_IND`)**: Now contains the 16-byte manufacturer data payload (including the low 8 bytes of `sessionUuid`), ensuring passive scanners can always discover and join rooms.
- **Scan Response PDU (`SCAN_RSP`)**: Now contains the custom 128-bit Service UUID and the device name.

### 2. Device Name Truncation for Byte Budget Safety
- Since the Service UUID takes up 18 bytes and the device name header takes up 2 bytes, only 11 bytes remain within the 31-byte legacy PDU limit.
- Truncated the display name set on the Bluetooth adapter to a maximum of 11 characters to guarantee `scanResponse` never overflows 31 bytes, preventing advertising start failures.

### 3. Asymmetric Scan UI Protection
- Modified the Dart `DiscoveryService` to check if a incoming scan result contains an empty host display name (which happens if `SCAN_RSP` hasn't arrived/been received). If a display name was previously cached for this room's UUID, the cached name is preserved to prevent UI clobbering.

### 4. Asynchronous Connection Setup & Collision Avoidance
- Modified `connectToHost` in `GattClientManager` to accept an asynchronous callback that resolves only after the connection is fully setup (services discovered, MTU negotiated, and CCCD descriptor written/notifications active on `RESPONSE`).
- Passed this completion block back to the MethodChannel's `Result` in `MainActivity.kt`.
- This ensures that Dart waits until the GATT stack is fully stable before sending a `JoinRequest` write, completely avoiding connection race conditions and GATT write collisions with the CCCD descriptor write (eliminating Status 133/129 errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time connection status callbacks for Bluetooth device pairing attempts, providing immediate feedback on connection success or failure.

* **Bug Fixes**
  * Fixed issue where device names were lost during subsequent Bluetooth discovery scans, ensuring consistent identification of previously found devices.
  * Optimized Bluetooth advertisement format for improved device discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->