### PR TITLE
fix(audio): survive BT headset connect + host startup race (PR #464)

### DIFF
--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <mutex>
@@ -271,6 +272,17 @@ static void stopTalkingEventWorker() {
 static std::mutex g_engineMutex;
 static AudioEngine* g_audioEngine = nullptr;
 
+// Monotonic epoch bumped every time nativeStart creates a new AudioEngine.
+// The auto-restart thread captures the epoch at schedule time and bails if it
+// has changed by the time it wakes, so a stop()+start() during the backoff
+// ladder (which yields a *different* engine instance) is not clobbered by a
+// restart meant for the engine that originally disconnected. A plain
+// raw-pointer comparison can't do this safely: a freed engine address may be
+// reused by the replacement (ABA), making a new engine look like the old one.
+// Atomic so onErrorAfterClose can read it without taking g_engineMutex (which
+// could deadlock if the callback fires synchronously under a stop()).
+static std::atomic<uint64_t> g_engineGeneration{0};
+
 // Restart guard for ErrorDisconnected auto-recovery. Static (not a member of
 // AudioEngineErrorCallback) so the detached restart thread does not capture a
 // pointer to the callback instance — the engine can destroy the callback while
@@ -285,8 +297,9 @@ static std::atomic<bool> g_restartScheduled{false};
 // All other errors are reported immediately in onErrorBeforeClose.
 //
 // Both recording and playback streams share a single instance (see AudioEngine
-// ctor). g_restartScheduled is the deduplicate guard; the lambda captures
-// nothing so the thread has no lifetime dependency on the callback object.
+// ctor). g_restartScheduled is the deduplicate guard; the restart lambda
+// captures only the engine epoch (a value), so the thread has no lifetime
+// dependency on the callback object.
 class AudioEngineErrorCallback : public oboe::AudioStreamErrorCallback {
 public:
     void onErrorBeforeClose(oboe::AudioStream* stream, oboe::Result error) override {
@@ -656,10 +669,17 @@ void AudioEngineErrorCallback::onErrorAfterClose(oboe::AudioStream* /*stream*/,
     }
 
     LOGI("Audio device disconnected — scheduling auto-restart");
+    // Snapshot the engine epoch now so the restart applies only to the instance
+    // that actually disconnected. If a stop()+start() cycle swaps in a new
+    // engine during the backoff ladder below, the epoch changes and the thread
+    // bails instead of clobbering the fresh session.
+    const uint64_t scheduledGen =
+        g_engineGeneration.load(std::memory_order_acquire);
     // No `this` capture: the callback object may be destroyed while this
     // thread blocks on g_engineMutex (e.g. nativeStop runs concurrently).
-    // All state the thread needs is in the static globals above.
-    std::thread([]() {
+    // All state the thread needs is in the static globals above (plus the
+    // captured epoch).
+    std::thread([scheduledGen]() {
         // A route change (BT headset connect/disconnect) leaves the new audio
         // endpoint briefly unavailable; reopening immediately races that settle
         // and fails. Back off and retry a few times before giving up. The lock
@@ -675,8 +695,13 @@ void AudioEngineErrorCallback::onErrorAfterClose(oboe::AudioStream* /*stream*/,
             std::this_thread::sleep_for(
                 std::chrono::milliseconds(kBackoffMs[attempt]));
             std::lock_guard<std::mutex> lock(g_engineMutex);
-            if (g_audioEngine == nullptr) {
-                // Engine was intentionally stopped (nativeStop); not an error.
+            if (g_audioEngine == nullptr ||
+                g_engineGeneration.load(std::memory_order_acquire) !=
+                    scheduledGen) {
+                // Engine was intentionally stopped (nativeStop), or stopped and
+                // replaced by a newer instance (nativeStop + nativeStart) while
+                // we were backing off. Either way the disconnect we were
+                // recovering from is moot; don't touch the current engine.
                 engineGone = true;
                 break;
             }
@@ -742,6 +767,9 @@ Java_com_elodin_walkie_1talkie_AudioEngineManager_nativeStart(JNIEnv* env,
     std::lock_guard<std::mutex> lock(g_engineMutex);
     if (g_audioEngine == nullptr) {
         g_audioEngine = new AudioEngine();
+        // New instance — advance the epoch so any in-flight auto-restart
+        // scheduled against the previous engine bails instead of restarting us.
+        g_engineGeneration.fetch_add(1, std::memory_order_relaxed);
     }
     return g_audioEngine->start();
 }

--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -384,7 +384,19 @@ public:
             ->setDataCallback(this)
             ->setErrorCallback(errorCallback.get());
 
+        // Bluetooth SCO/A2DP routes have no exclusive low-latency (MMAP) path,
+        // so an Exclusive open fails the instant a headset becomes the active
+        // device — which is exactly what kills the engine on headset hot-plug.
+        // Fall back to Shared: built-in speaker/earpiece still negotiate
+        // Exclusive, while BT gets a working Shared stream instead of a dead
+        // engine.
         oboe::Result result = recordingBuilder.openStream(recordingStream);
+        if (result != oboe::Result::OK) {
+            LOGE("Exclusive recording open failed (%s) — retrying Shared",
+                 oboe::convertToText(result));
+            recordingBuilder.setSharingMode(oboe::SharingMode::Shared);
+            result = recordingBuilder.openStream(recordingStream);
+        }
         if (result != oboe::Result::OK) {
             LOGE("Failed to create recording stream: %s",
                  oboe::convertToText(result));
@@ -401,6 +413,12 @@ public:
             ->setErrorCallback(errorCallback.get());
 
         result = playbackBuilder.openStream(playbackStream);
+        if (result != oboe::Result::OK) {
+            LOGE("Exclusive playback open failed (%s) — retrying Shared",
+                 oboe::convertToText(result));
+            playbackBuilder.setSharingMode(oboe::SharingMode::Shared);
+            result = playbackBuilder.openStream(playbackStream);
+        }
         if (result != oboe::Result::OK) {
             LOGE("Failed to create playback stream: %s",
                  oboe::convertToText(result));
@@ -642,23 +660,44 @@ void AudioEngineErrorCallback::onErrorAfterClose(oboe::AudioStream* /*stream*/,
     // thread blocks on g_engineMutex (e.g. nativeStop runs concurrently).
     // All state the thread needs is in the static globals above.
     std::thread([]() {
-        std::lock_guard<std::mutex> lock(g_engineMutex);
-        if (g_audioEngine != nullptr) {
-            // stop() is idempotent on already-closed streams; it resets
-            // the worker thread and shared_ptrs before start() reopens them.
-            g_audioEngine->stop();
-            const bool ok = g_audioEngine->start();
-            g_restartScheduled.store(false, std::memory_order_release);
-            if (!ok) {
-                LOGE("Auto-restart after disconnect failed — reporting to Flutter");
-                emitAudioErrorEvent(oboe::Result::ErrorDisconnected);
-            } else {
-                LOGI("Auto-restart after disconnect succeeded");
+        // A route change (BT headset connect/disconnect) leaves the new audio
+        // endpoint briefly unavailable; reopening immediately races that settle
+        // and fails. Back off and retry a few times before giving up. The lock
+        // is re-acquired per attempt (not held across the sleeps) so a
+        // concurrent nativeStop can tear the engine down without blocking for
+        // the full backoff ladder.
+        static constexpr int kMaxAttempts = 5;
+        static constexpr int kBackoffMs[kMaxAttempts] = {150, 300, 600, 1000, 1500};
+        bool ok = false;
+        bool engineGone = false;
+        for (int attempt = 0; attempt < kMaxAttempts && !ok && !engineGone;
+             ++attempt) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kBackoffMs[attempt]));
+            std::lock_guard<std::mutex> lock(g_engineMutex);
+            if (g_audioEngine == nullptr) {
+                // Engine was intentionally stopped (nativeStop); not an error.
+                engineGone = true;
+                break;
             }
-        } else {
-            // Engine was intentionally stopped (nativeStop); not an error.
-            g_restartScheduled.store(false, std::memory_order_release);
+            // stop() is idempotent on already-closed streams; it resets the
+            // worker thread and shared_ptrs before start() reopens them.
+            g_audioEngine->stop();
+            ok = g_audioEngine->start();
+            if (ok) {
+                LOGI("Auto-restart after disconnect succeeded (attempt %d)",
+                     attempt + 1);
+            } else {
+                LOGE("Auto-restart attempt %d/%d failed", attempt + 1,
+                     kMaxAttempts);
+            }
+        }
+        g_restartScheduled.store(false, std::memory_order_release);
+        if (engineGone) {
             LOGI("Auto-restart skipped — engine already stopped");
+        } else if (!ok) {
+            LOGE("Auto-restart after disconnect failed — reporting to Flutter");
+            emitAudioErrorEvent(oboe::Result::ErrorDisconnected);
         }
     }).detach();
 }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioRoutingManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/AudioRoutingManager.kt
@@ -159,6 +159,23 @@ class AudioRoutingManager(private val ctx: Context) {
         }
 
         audioManager.registerAudioDeviceCallback(deviceCallback, handler)
+
+        // A headset connected *before* tune-in never fires onAudioDevicesAdded,
+        // so the AudioDeviceCallback alone misses it and voice silently stays on
+        // the A2DP media path (or speaker). Do an initial route now: if a BT
+        // comm device is already present, switch to it.
+        val btAlreadyPresent = audioManager.availableCommunicationDevices.any {
+            it.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO ||
+            it.type == AudioDeviceInfo.TYPE_BLE_HEADSET ||
+            it.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+        }
+        if (btAlreadyPresent) {
+            Log.i(TAG, "Bluetooth comm device already present — routing to it")
+            if (setOutput("bluetooth")) {
+                onChangeListener?.invoke("bluetooth")
+            }
+        }
+
         Log.i(TAG, "Auto-detect started for audio device changes")
     }
 

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
@@ -408,6 +408,18 @@ class L2capVoiceTransport(
      */
     internal fun activeClientCount(): Int =
         synchronized(clientSockets) { clientSockets.size }
+
+    /**
+     * Snapshot of the addresses of currently-connected host-side clients.
+     *
+     * Used to recover from the host startup race: a guest can open its L2CAP
+     * channel (and the host's [onClientConnected] -> registerVoicePeer can
+     * give up against a not-yet-created mixer) while the foreground service is
+     * still coming up. Once the mixer exists, the caller re-registers everyone
+     * in this list so their frames get a device slot instead of being dropped.
+     */
+    fun getConnectedClients(): List<String> =
+        synchronized(clientSockets) { clientSockets.keys.toList() }
 }
 
 // ── Framing helpers (package-private for unit tests) ───────────────────────

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -21,6 +21,13 @@ class MainActivity : FlutterActivity() {
         private const val CONTROL_BYTES_EVENT_CHANNEL = "com.elodin.walkie_talkie/control_bytes"
         private const val LOOPBACK_TEST_DEVICE_ID = -1
 
+        // startVoiceCapture retry budget while the foreground service comes up.
+        // startForegroundService is async, so WalkieTalkieService.getRunning()
+        // can be null for a few ms after Flutter calls startVoice. 10 x 100ms =
+        // up to 1s; the service is observed ready in ~30ms.
+        private const val START_VOICE_MAX_RETRIES = 10
+        private const val START_VOICE_RETRY_MS = 100L
+
         init {
             System.loadLibrary("walkie_talkie_audio")
         }
@@ -198,14 +205,14 @@ class MainActivity : FlutterActivity() {
                     }
                 }
                 "startVoice" -> {
-                    result.success(startVoiceCapture(loopbackTestMode = false))
+                    startVoiceCapture(loopbackTestMode = false) { ok -> result.success(ok) }
                 }
                 "stopVoice" -> {
                     stopVoiceCapture()
                     result.success(true)
                 }
                 "startLoopbackTest" -> {
-                    result.success(startVoiceCapture(loopbackTestMode = true))
+                    startVoiceCapture(loopbackTestMode = true) { ok -> result.success(ok) }
                 }
                 "stopLoopbackTest" -> {
                     stopVoiceCapture()
@@ -591,14 +598,47 @@ class MainActivity : FlutterActivity() {
         mediaSessionBridge?.attach()
     }
 
-    private fun startVoiceCapture(loopbackTestMode: Boolean): Boolean {
-        if (peerAudioManager != null) return true
-        Log.i(TAG, if (loopbackTestMode) "Starting loopback voice test" else "Starting voice capture")
+    /**
+     * Start mic capture + the Oboe engine + per-peer mixer.
+     *
+     * The foreground [WalkieTalkieService] hosts the engine and is launched via
+     * `startForegroundService` (async): its `onCreate` — which publishes the
+     * `getRunning()` handle — can land a few ms AFTER Flutter's `startVoice`
+     * call arrives. Bailing on a null service here permanently dead-ends the
+     * host (no engine, no mixer; the guest's L2CAP frames get no device slot and
+     * are dropped) — the root cause of "joined the room but hear nothing". So
+     * when the service isn't up yet we retry on the main thread instead of
+     * failing, mirroring [registerVoicePeer].
+     *
+     * Async: replies via [onResult] once the engine is up or the retry budget is
+     * exhausted, so the Flutter `startVoice` result reflects the real outcome.
+     */
+    private fun startVoiceCapture(loopbackTestMode: Boolean, onResult: ((Boolean) -> Unit)? = null) {
+        startVoiceCapture(loopbackTestMode, attempt = 0, onResult = onResult)
+    }
+
+    private fun startVoiceCapture(
+        loopbackTestMode: Boolean,
+        attempt: Int,
+        onResult: ((Boolean) -> Unit)?
+    ) {
+        if (peerAudioManager != null) {
+            onResult?.invoke(true)
+            return
+        }
         val service = WalkieTalkieService.getRunning()
         if (service == null) {
-            Log.e(TAG, "Cannot start voice: WalkieTalkieService is not running")
-            return false
+            if (attempt >= START_VOICE_MAX_RETRIES) {
+                Log.e(TAG, "Cannot start voice: WalkieTalkieService not running after $attempt retries")
+                onResult?.invoke(false)
+                return
+            }
+            Handler(Looper.getMainLooper()).postDelayed({
+                startVoiceCapture(loopbackTestMode, attempt + 1, onResult)
+            }, START_VOICE_RETRY_MS)
+            return
         }
+        Log.i(TAG, if (loopbackTestMode) "Starting loopback voice test" else "Starting voice capture")
         service.setLoopbackTestMode(loopbackTestMode)
         audioRoutingManager?.startAutoDetect { outputType ->
             sendEventToFlutter(mapOf(
@@ -619,7 +659,8 @@ class MainActivity : FlutterActivity() {
             audioRoutingManager?.stopAutoDetect()
             audioMixerManager?.clear()
             audioMixerManager = null
-            return false
+            onResult?.invoke(false)
+            return
         }
         // Init the per-peer manager and wire its outbound callback to L2CAP.
         val pm = PeerAudioManager()
@@ -648,7 +689,16 @@ class MainActivity : FlutterActivity() {
         })
         pm.startMixerThread()
         peerAudioManager = pm
-        return true
+        // A guest can dial the L2CAP voice channel while we were still waiting
+        // for the service to come up (host race): its onClientConnected ->
+        // registerVoicePeer fired against a null peerAudioManager and gave up.
+        // Re-register every currently-connected voice client now that the mixer
+        // exists, so their frames get a device slot instead of being dropped.
+        voiceTransport?.getConnectedClients()?.forEach { mac ->
+            Log.i(TAG, "Re-registering voice peer connected during startup: $mac")
+            pm.registerPeer(mac)
+        }
+        onResult?.invoke(true)
     }
 
     private fun stopVoiceCapture() {

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -620,8 +620,17 @@ class MainActivity : FlutterActivity() {
     private fun startVoiceCapture(
         loopbackTestMode: Boolean,
         attempt: Int,
-        onResult: ((Boolean) -> Unit)?
+        onResult: ((Boolean) -> Unit)?,
+        sessionId: Int = voiceSessionId
     ) {
+        if (sessionId != voiceSessionId) {
+            // stopVoiceCapture ran (bumping voiceSessionId) while this retry was
+            // queued on the main looper. The start belongs to an ended session;
+            // proceeding would spin up a zombie engine/mixer after teardown.
+            Log.i(TAG, "startVoiceCapture: stale retry for ended session; aborting")
+            onResult?.invoke(false)
+            return
+        }
         if (peerAudioManager != null) {
             onResult?.invoke(true)
             return
@@ -634,7 +643,7 @@ class MainActivity : FlutterActivity() {
                 return
             }
             Handler(Looper.getMainLooper()).postDelayed({
-                startVoiceCapture(loopbackTestMode, attempt + 1, onResult)
+                startVoiceCapture(loopbackTestMode, attempt + 1, onResult, sessionId)
             }, START_VOICE_RETRY_MS)
             return
         }
@@ -696,7 +705,10 @@ class MainActivity : FlutterActivity() {
         // exists, so their frames get a device slot instead of being dropped.
         voiceTransport?.getConnectedClients()?.forEach { mac ->
             Log.i(TAG, "Re-registering voice peer connected during startup: $mac")
-            pm.registerPeer(mac)
+            // Go through registerVoicePeer (not pm.registerPeer directly) so the
+            // Kotlin-side audioMixerManager gets the device slot too; a bare
+            // registerPeer leaves the mixer out of sync with the native peer set.
+            registerVoicePeer(mac)
         }
         onResult?.invoke(true)
     }

--- a/test/contracts/native_audio_bridge_contract_test.dart
+++ b/test/contracts/native_audio_bridge_contract_test.dart
@@ -10,9 +10,14 @@ void main() {
       ).readAsStringSync();
 
       expect(mainActivity, contains('"startVoice" ->'));
+      // startVoiceCapture stays idempotent on an existing peerAudioManager —
+      // the early-return short-circuits a duplicate start. (Form changed from a
+      // `return true` expression to a callback-style guard when startVoice was
+      // made async to retry past the foreground-service startup race; the
+      // idempotency contract is unchanged.)
       expect(
         mainActivity,
-        contains('if (peerAudioManager != null) return true'),
+        contains('if (peerAudioManager != null) {'),
       );
       expect(
         mainActivity,


### PR DESCRIPTION
## What
BT headset connect = dead audio engine = silence. Three stacked native bugs. All three fixed. Verified on-device (Pixel 10 Pro XL + Shokz OpenRun Pro 2, moto g play guest).

## Bugs

**1. Oboe hardcoded `SharingMode::Exclusive` — BT can't grant it.** BT SCO/A2DP has no exclusive low-latency (MMAP) path. Headset becomes active device → `openStream` fails → engine dead. Built-in speaker grants Exclusive, so bug hid until a headset connected. Fix: fall back to `Shared` on Exclusive open failure, both record + playback streams. (`audio_engine.cpp`)

**2. Auto-restart one-shot, no backoff — raced the route settle.** `onErrorAfterClose` reopened immediately, once. On headset connect the new endpoint isn't ready yet → instant reopen misses → engine stays dead. Fix: backoff ladder (150/300/600/1000/1500 ms), 5 attempts, lock re-acquired per attempt so `nativeStop` isn't blocked. (`audio_engine.cpp`)

**3. Comm route never forced pre-tune-in.** `AudioRoutingManager` only routed on explicit Flutter call or the device-add callback — neither fires for a headset already connected at room entry, so voice stayed on A2DP-media (or speaker). Fix: in `startAutoDetect`, if a BT comm device is already present, route to it immediately. (`AudioRoutingManager.kt`)

## Verified on-device
Log proof — exact scenario that was silent now recovers:
```
Bluetooth comm device already present — routing to it       (Bug 3)
Routed audio to Bluetooth: OpenRun Pro 2 by Shokz          (Bug 3)
Audio engine started successfully                          (Bug 1: Shared fallback)
Oboe stream error: ErrorDisconnected                       (A2DP->SCO switch)
Audio engine started successfully
Auto-restart after disconnect succeeded (attempt 1)        (Bug 2: was "failed" before)
```
`dumpsys audio` confirms active comm device settles on `bt_sco_hs` (the SCO comm path voice needs). Audio came through the headset.

## Known NOT fixed here (separate blocker)
Audio quality still poor — **delayed + low-quality + intermittent**. Root cause is NOT this fix: the host/guest link churns (role swaps, re-tune, RPA rotation; GATT status 19/62/255). Each churn resets the jitter buffer (delay) and the bitrate adapter to its `8000 bps` floor (8 kbps Opus = unusable). Tracking separately — needs link-stability + bitrate-floor work, not audio-routing.

Draft until the quality/stability blocker is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
