### PR TITLE
style: dart format two files to satisfy presubmit format gate

### DIFF
--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -1900,22 +1900,25 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
         mac != null &&
         audio != null) {
       unawaited(
-        audio.stopVoiceTransport().then((_) {
-          // stopVoiceTransport is async; the user may have left or switched
-          // rooms while it was in flight. Re-check before dialing so we don't
-          // reconnect voice to a stale host after teardown.
-          final s = state;
-          if (isClosed ||
-              s is! SessionRoom ||
-              s.roomIsHost ||
-              s.macAddress != mac) {
-            return false;
-          }
-          return audio.connectVoiceClient(mac, voicePsm);
-        }).catchError((Object e) {
-          if (kDebugMode) debugPrint('connectVoiceClient failed: $e');
-          return false;
-        }),
+        audio
+            .stopVoiceTransport()
+            .then((_) {
+              // stopVoiceTransport is async; the user may have left or switched
+              // rooms while it was in flight. Re-check before dialing so we don't
+              // reconnect voice to a stale host after teardown.
+              final s = state;
+              if (isClosed ||
+                  s is! SessionRoom ||
+                  s.roomIsHost ||
+                  s.macAddress != mac) {
+                return false;
+              }
+              return audio.connectVoiceClient(mac, voicePsm);
+            })
+            .catchError((Object e) {
+              if (kDebugMode) debugPrint('connectVoiceClient failed: $e');
+              return false;
+            }),
       );
     }
   }

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -463,8 +463,9 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
 
   /// Syncs a peer's volume and muted settings to the native layer.
   void _syncPeerAudioSettings(String peerId) {
-    final macAddress =
-        context.read<FrequencySessionCubit>().macForPeerId(peerId);
+    final macAddress = context.read<FrequencySessionCubit>().macForPeerId(
+      peerId,
+    );
     if (macAddress == null || macAddress.isEmpty) return;
 
     final targetVol = _volumeFor(peerId);


### PR DESCRIPTION
These two files were committed with formatting that fails `dart format --output=none --set-exit-if-changed .` (run by `scripts/presubmit.sh`):

- `lib/bloc/frequency_session_cubit.dart`
- `lib/screens/frequency_room_screen.dart`

GitHub CI (`.github/workflows/flutter.yml`) does **not** run the format check — only `scripts/presubmit.sh` does — so the unformatted code landed on `main` and breaks anyone running local presubmit. This reformats them; no logic change.

Validated locally: `dart format` clean, `flutter analyze` clean, `flutter test` (896 passing), native C++ tests, and `./gradlew :app:testDebugUnitTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced voice connectivity reliability for guest users. Improved the voice reconnection process when guests rejoin frequency sessions with advanced error handling, enhanced session validation, and connection verification checks. These improvements prevent connection failures and ensure more stable, reliable, and uninterrupted voice communication experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->