### PR TITLE
fix(#432): add 3s timeout to adapterState.first + isSupported in startScan

### DIFF
--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -25,23 +25,32 @@ class DiscoveryService {
   /// no BLE advertisements arrive (e.g. every host went silent simultaneously).
   Timer? _pruneTimer;
 
+  // Timeout for Bluetooth pre-flight checks. Long enough for a healthy stack,
+  // short enough to unblock discovery on flaky OEM stacks (#432).
+  static const Duration _kBtCheckTimeout = Duration(seconds: 3);
+
   /// Starts scanning for Frequency advertisements.
   Future<void> startScan() async {
     // 1. Check if Bluetooth is available and on.
     final supported = await FlutterBluePlus.isSupported.timeout(
-      const Duration(seconds: 3),
+      _kBtCheckTimeout,
       onTimeout: () => false,
     );
     if (!supported) {
       throw Exception('Bluetooth LE is not supported on this device');
     }
 
-    // Guard with a timeout: some OEM stacks (Motorola/MediaTek) delay or never
-    // emit on adapterState, causing .first to hang indefinitely (#432).
-    final adapterState = await FlutterBluePlus.adapterState.first.timeout(
-      const Duration(seconds: 3),
-      onTimeout: () => BluetoothAdapterState.unknown,
-    );
+    // Apply the timeout to the stream before .first so the subscription is
+    // cancelled on timeout (Future.timeout() cannot cancel a stream sub, #432).
+    final adapterState = await FlutterBluePlus.adapterState
+        .timeout(
+          _kBtCheckTimeout,
+          onTimeout: (sink) {
+            sink.add(BluetoothAdapterState.unknown);
+            sink.close();
+          },
+        )
+        .first;
     if (adapterState != BluetoothAdapterState.on) {
       throw Exception('Bluetooth adapter is not on');
     }

--- a/lib/services/bluetooth_discovery_service.dart
+++ b/lib/services/bluetooth_discovery_service.dart
@@ -28,11 +28,21 @@ class DiscoveryService {
   /// Starts scanning for Frequency advertisements.
   Future<void> startScan() async {
     // 1. Check if Bluetooth is available and on.
-    if (await FlutterBluePlus.isSupported == false) {
+    final supported = await FlutterBluePlus.isSupported.timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => false,
+    );
+    if (!supported) {
       throw Exception('Bluetooth LE is not supported on this device');
     }
 
-    if (await FlutterBluePlus.adapterState.first != BluetoothAdapterState.on) {
+    // Guard with a timeout: some OEM stacks (Motorola/MediaTek) delay or never
+    // emit on adapterState, causing .first to hang indefinitely (#432).
+    final adapterState = await FlutterBluePlus.adapterState.first.timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => BluetoothAdapterState.unknown,
+    );
+    if (adapterState != BluetoothAdapterState.on) {
       throw Exception('Bluetooth adapter is not on');
     }
 


### PR DESCRIPTION
Fixes #432.

`DiscoveryService.startScan` calls `.first` on `adapterState` (a stream) and `await`s `isSupported` (a Future) with no timeout. On Motorola/MediaTek stacks the stream can delay or never emit, hanging `startScan` indefinitely and leaving `DiscoveryCubit` stuck on `DiscoveryScanning` with no escape.

## Change

Both calls now have a 3 s timeout; a timeout is treated as adapter-off/unsupported and throws the existing exception so callers degrade normally.

```dart
final supported = await FlutterBluePlus.isSupported.timeout(
  const Duration(seconds: 3),
  onTimeout: () => false,
);

final adapterState = await FlutterBluePlus.adapterState.first.timeout(
  const Duration(seconds: 3),
  onTimeout: () => BluetoothAdapterState.unknown,
);
```

## Local CI

- Gate 1 (dart analyze + flutter test + metadata): pass
- Gate 2 (Kotlin unit tests): pass
- Gate 3 (debug AAB ≤ 100 MiB): 79.7 MiB — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Bluetooth discovery reliability by preventing potential app hangs during device capability checks. Added timeout safeguards for better stability on certain device models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->