### PR TITLE
fix(audio): raise BLE conn priority + align bitrate + cap send queue

### DIFF
--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -103,6 +103,14 @@ bool PeerAudioManager::onVoiceFramePushed(const std::string& macAddress,
         std::lock_guard<std::mutex> lock(peerRegistryMutex_);
         auto it = peers_.find(macAddress);
         if (it == peers_.end()) {
+            // VOICE-DIAG: frames arriving for a peer with no registered
+            // audio state — inbound leg is up but the decode path is dead.
+            // Throttled so a sustained mismatch doesn't flood logcat.
+            static int dropLog = 0;
+            if (dropLog++ % 50 == 0) {
+                LOGW("VOICE-DIAG drop: frame seq=%u for unregistered peer %s",
+                     seq, macAddress.c_str());
+            }
             return false;
         }
         state = it->second;  // shared_ptr keeps state alive past unlock.

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/GattClientManager.kt
@@ -148,6 +148,15 @@ class GattClientManager(
                     // the retry counter so the next failure starts fresh.
                     cancelPendingRetry()
                     connectRetryCount = 0
+                    // Drop the connection interval to the BLE minimum
+                    // (~11.25–15 ms). At the default ~30 ms interval the link
+                    // only carries ~33–35 voice packets/s, but we produce 50
+                    // fps (20 ms Opus frames) — the deficit accumulates in the
+                    // controller's tx buffer, so playout latency grows without
+                    // bound. HIGH priority gives ~66–88 pkt/s of headroom,
+                    // comfortably above 50 fps. The central owns the interval,
+                    // so this is set here on the guest's GATT client.
+                    gatt.requestConnectionPriority(BluetoothGatt.CONNECTION_PRIORITY_HIGH)
                     // Request MTU increase for better throughput
                     gatt.requestMtu(GattConstants.TARGET_ATT_MTU)
                 }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
@@ -53,12 +53,16 @@ class L2capVoiceTransport(
         private val BACKOFF_MS = longArrayOf(250, 500, 1000, 2000, 5000)
 
         /**
-         * Per-socket send queue capacity. ~64 frames at one-per-20-ms is
-         * ~1.3 s of audio. Above this, the link can't keep up; we drop
-         * the oldest frame so latency stays bounded instead of blocking
-         * the audio capture thread.
+         * Per-socket send queue capacity. At one frame per 20 ms, this is
+         * the worst-case send-side latency the queue can inject before the
+         * drop-oldest policy ([enqueueFrame]) kicks in. Voice is
+         * latency-sensitive, so we keep this shallow: 6 frames is ~120 ms,
+         * enough to ride out a brief link stall without the queue itself
+         * becoming a multi-second backlog under full-duplex contention.
+         * (Was 64 ≈ 1.3 s, which pinned playout ~1.3 s stale once the link
+         * couldn't keep up.)
          */
-        const val SEND_QUEUE_CAPACITY = 64
+        const val SEND_QUEUE_CAPACITY = 6
 
         /** Length-prefix size: 2 bytes big-endian. */
         const val LENGTH_PREFIX_SIZE = 2
@@ -260,6 +264,7 @@ class L2capVoiceTransport(
             Log.w(TAG, "Writer for $addr couldn't open output stream: ${e.message}")
             return
         }
+        var sent = 0L
         try {
             while (true) {
                 val frame = io.sendQueue.take()
@@ -271,8 +276,13 @@ class L2capVoiceTransport(
                 }
                 try {
                     writeFramed(out, frame)
+                    // VOICE-DIAG: per-direction send rate + backlog. One leg
+                    // showing 0 sent pinpoints a one-direction-audio failure.
+                    if (++sent % 50L == 0L) {
+                        Log.i(TAG, "VOICE-DIAG tx $addr sent=$sent qDepth=${io.sendQueue.size}")
+                    }
                 } catch (e: IOException) {
-                    Log.i(TAG, "Writer for $addr ended: ${e.message}")
+                    Log.i(TAG, "Writer for $addr ended after $sent frames: ${e.message}")
                     break
                 }
             }
@@ -283,13 +293,14 @@ class L2capVoiceTransport(
 
     private fun receiveLoop(addr: String, io: SocketIo) {
         val socket = io.socket
+        var recv = 0L
         try {
             val input = DataInputStream(socket.inputStream)
             while (socket.isConnected) {
                 val frame = try {
                     readFramed(input)
                 } catch (e: IOException) {
-                    Log.i(TAG, "Receive loop ended for $addr: ${e.message}")
+                    Log.i(TAG, "Receive loop ended for $addr after $recv frames: ${e.message}")
                     break
                 } ?: break // EOF
                 if (frame.size < 8) {
@@ -297,6 +308,11 @@ class L2capVoiceTransport(
                     // reading; a malformed peer can't lock us out.
                     Log.w(TAG, "Frame from $addr shorter than VoiceFrame header — dropping")
                     continue
+                }
+                // VOICE-DIAG: per-direction receive rate. A registered+mixing
+                // peer with recv stuck at 0 means the inbound leg is dead.
+                if (++recv % 50L == 0L) {
+                    Log.i(TAG, "VOICE-DIAG rx $addr recv=$recv")
                 }
                 onVoiceFrame(addr, frame)
             }

--- a/lib/services/bitrate_adapter.dart
+++ b/lib/services/bitrate_adapter.dart
@@ -5,16 +5,18 @@ import '../protocol/messages.dart';
 /// the native side clamps a bitrate set to anything else into one of
 /// these, so keeping the Dart-side schedule in lockstep avoids surprises.
 enum BitrateLevel {
-  /// 8 kbps narrowband — used when the link is degraded and we need to
-  /// shed bytes to keep the jitter buffer fed.
-  low(8000),
+  /// 16 kbps — used when the link is degraded and we need to shed bytes
+  /// to keep the jitter buffer fed. Matches native `kBitrateLow`.
+  low(16000),
 
-  /// 16 kbps wideband — the default operating point the encoder boots in.
-  mid(16000),
+  /// 32 kbps — the default operating point the encoder boots in.
+  /// Matches native `kBitrateMid` / `kDefaultBitrate`.
+  mid(32000),
 
-  /// 24 kbps wideband — the best operating point the encoder will reach
-  /// when the link has been clean for a sustained window.
-  high(24000);
+  /// 48 kbps — the best operating point the encoder will reach when the
+  /// link has been clean for a sustained window. Matches native
+  /// `kBitrateHigh`.
+  high(48000);
 
   const BitrateLevel(this.bps);
 

--- a/test/services/bitrate_adapter_test.dart
+++ b/test/services/bitrate_adapter_test.dart
@@ -31,23 +31,24 @@ void main() {
     test('bps values match audio_config.h operating points', () {
       // These three are the only values native PeerAudioManager will
       // honour after clamping. The Dart adapter must agree with the
-      // native enum so a `BitrateHint(bps: 16000)` lands as Mid and not
-      // as a "snap to nearest" surprise.
-      expect(BitrateLevel.low.bps, 8000);
-      expect(BitrateLevel.mid.bps, 16000);
-      expect(BitrateLevel.high.bps, 24000);
+      // native enum (audio_config.h kBitrateLow/Mid/High) so a
+      // `BitrateHint(bps: 32000)` lands as Mid and not as a "snap to
+      // nearest" surprise.
+      expect(BitrateLevel.low.bps, 16000);
+      expect(BitrateLevel.mid.bps, 32000);
+      expect(BitrateLevel.high.bps, 48000);
     });
 
     test('nearest snaps to the closest operating point, ties favour lower', () {
-      expect(BitrateLevel.nearest(8000), BitrateLevel.low);
-      expect(BitrateLevel.nearest(16000), BitrateLevel.mid);
-      expect(BitrateLevel.nearest(24000), BitrateLevel.high);
-      // 12000 is equidistant from low (8000) and mid (16000) — the
+      expect(BitrateLevel.nearest(16000), BitrateLevel.low);
+      expect(BitrateLevel.nearest(32000), BitrateLevel.mid);
+      expect(BitrateLevel.nearest(48000), BitrateLevel.high);
+      // 24000 is equidistant from low (16000) and mid (32000) — the
       // tie-break docstring says "favour the lower level."
-      expect(BitrateLevel.nearest(12000), BitrateLevel.low);
-      // 11000 is closer to low; 14000 closer to mid.
-      expect(BitrateLevel.nearest(11000), BitrateLevel.low);
-      expect(BitrateLevel.nearest(14000), BitrateLevel.mid);
+      expect(BitrateLevel.nearest(24000), BitrateLevel.low);
+      // 22000 is closer to low; 28000 closer to mid.
+      expect(BitrateLevel.nearest(22000), BitrateLevel.low);
+      expect(BitrateLevel.nearest(28000), BitrateLevel.mid);
     });
   });
 


### PR DESCRIPTION
## Problem

Voice latency grew unbounded over a call. The mic encoder produces 50 fps (20ms Opus frames), but the BLE link ran at Android's default ~30ms connection interval, carrying only ~33-35 packets/s. The ~15 fps/s deficit piled up in the controller TX buffer (below the app send queue, which stayed at qDepth=0), so playout latency climbed without bound and eventually degraded to static.

## Fix

- **GattClientManager**: request `CONNECTION_PRIORITY_HIGH` on `STATE_CONNECTED` (the central owns the interval) before the MTU request. Drops the interval to 6-12 units (7.5-15ms).
- **bitrate_adapter**: Dart ladder was 8/16/24k — exactly half native `audio_config.h` `kBitrateLow/Mid/High` (16/32/48k) despite a comment claiming it mirrored them, so the encoder ran at native low. Align to 16/32/48k; update the test.
- **L2capVoiceTransport**: `SEND_QUEUE_CAPACITY` 64 (~1.3s) -> 6 (~120ms); 64 was ~10x too deep for latency-sensitive voice.
- Add throttled `VOICE-DIAG` tx/rx frame counters + native drop-on-unregistered-peer log; the voice plane previously had ~zero instrumentation, which masked the throughput deficit.

## Verification

- On-device, two phones: after `CONNECTION_PRIORITY_HIGH` the interval drops to 6-12 units and receive throughput tracks send at 50 fps with zero backlog.
- Local CI (Flutter 3.44.0, WSL) on the committed HEAD: `flutter analyze` → No issues found; `flutter test` → All 896 tests passed.

Touches native Kotlin/C++ + Dart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Increased audio bitrate operating points for improved voice quality across all levels.
  * Enhanced Bluetooth connection priority to optimize link performance and stability.
  * Refined frame buffering behavior for improved congestion handling.

* **Diagnostics**
  * Added periodic diagnostic logging for voice transport frame transfers.
  * Improved frame validation with diagnostic warnings for enhanced monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->