### PR TITLE
fix(audio): true-loss bitrate metric + drift-tolerant jitter buffer

### DIFF
--- a/android/app/src/main/cpp/audio_config.h
+++ b/android/app/src/main/cpp/audio_config.h
@@ -62,10 +62,32 @@ constexpr int kMaxOpusPacketSize = 4000;
 // Adaptive jitter buffer bounds. Depth is measured in 20 ms frames.
 //   - kJitterMinDepth=2 → 40 ms playout latency floor (one tick of slack)
 //   - kJitterInitialDepth=3 → 60 ms, the BLE CE-jitter sweet spot
-//   - kJitterMaxDepth=10 → 200 ms ceiling. Above this the user notices.
+//   - kJitterMaxTargetDepth=6 → 120 ms. Ceiling the *adaptive target depth*
+//     may ratchet to. Capped well below the hard cap so a jittery link can't
+//     ratchet playout latency to kJitterMaxDepth (the old death spiral: the
+//     target grew to 10, the buffer rode the cap, and every fresh frame
+//     overflowed → a flood of late-drops). Backlog past this is drained by
+//     the decode-path time-scaling, not by growing latency.
+//   - kJitterHighWatermark=8 → 160 ms. When the *current* fill reaches this,
+//     the producer's 50 Hz clock is outrunning our 50 Hz consume clock (the
+//     two domains are unsynced). The decode pass time-compresses one extra
+//     frame per tick (crossfade-merge) to drain the backlog smoothly instead
+//     of letting it pile up to the hard cap and hard-drop.
+//   - kJitterMaxDepth=10 → 200 ms hard cap / push backstop. With the drain
+//     active the buffer should rarely reach this; it stays as a memory and
+//     worst-case-latency bound.
 constexpr size_t kJitterMinDepth = 2;
 constexpr size_t kJitterInitialDepth = 3;
+constexpr size_t kJitterMaxTargetDepth = 6;
+constexpr size_t kJitterHighWatermark = 8;
 constexpr size_t kJitterMaxDepth = 10;
+
+static_assert(kJitterMinDepth <= kJitterInitialDepth &&
+                  kJitterInitialDepth <= kJitterMaxTargetDepth &&
+                  kJitterMaxTargetDepth < kJitterHighWatermark &&
+                  kJitterHighWatermark < kJitterMaxDepth,
+              "jitter thresholds must be ordered: "
+              "min <= init <= maxTarget < highWatermark < maxDepth");
 
 // How often the jitter buffer reviews its target depth, in adapt() calls.
 // adapt() is invoked from the mixer tick (every kFrameDurationMs ms), so

--- a/android/app/src/main/cpp/jitter_buffer.cpp
+++ b/android/app/src/main/cpp/jitter_buffer.cpp
@@ -84,6 +84,13 @@ std::optional<JitterBuffer::Frame> JitterBuffer::pop() {
     // loss. Bulk-advancing would skip directly to the next queued frame
     // and time-compress audio, which is exactly the bug this branch fixes.
     if (playheadInit_ && seqLess(playhead_, frames_.front().seq)) {
+        // The expected seq was never received even though the buffer is full
+        // enough to play — this is confirmed packet loss, not a capacity or
+        // jitter artifact. Count every missing seq (a 3-frame hole fires this
+        // branch three times, once per advanced playhead), unlike the
+        // episode-gated underrun counter: the bitrate adapter wants the true
+        // per-frame loss rate.
+        ++lostCount_;
         if (primed_ && !inUnderrun_) {
             ++underrunCount_;
             ++underrunsThisInterval_;
@@ -127,8 +134,13 @@ void JitterBuffer::tick() {
     if (underrunsThisInterval_ > 0) {
         // Any underrun in the window: grow target depth, reset stability
         // counter. We grow conservatively (+1) rather than jumping to max —
-        // the link may have just been transiently bad.
-        if (targetDepth_ < audio_config::kJitterMaxDepth) {
+        // the link may have just been transiently bad. The ceiling is
+        // kJitterMaxTargetDepth (NOT kJitterMaxDepth): the adaptive target
+        // must not ratchet playout latency up to the hard cap, where the
+        // buffer would ride the overflow boundary and hard-drop every fresh
+        // frame. Sustained over-fill past the target is the time-scaling
+        // drain's job, not the target's.
+        if (targetDepth_ < audio_config::kJitterMaxTargetDepth) {
             ++targetDepth_;
         }
         stableIntervalsCount_ = 0;

--- a/android/app/src/main/cpp/jitter_buffer.h
+++ b/android/app/src/main/cpp/jitter_buffer.h
@@ -98,6 +98,14 @@ public:
     // these to the LinkQuality control-plane message).
     size_t underrunCount() const { return underrunCount_; }
     size_t lateFrameCount() const { return lateCount_; }
+    // True network loss: frames the playhead passed because they were never
+    // received, despite the buffer being filled to its target depth (the
+    // "hole-at-head" path in pop()). This is the RTP-style "frames lost in
+    // transit" signal — distinct from lateFrameCount, which counts frames
+    // that *did* arrive but were unusable (too late, or dropped on a full
+    // buffer). The bitrate adapter consumes THIS, so capacity/jitter churn
+    // can't masquerade as packet loss and floor the encoder.
+    size_t lostFrameCount() const { return lostCount_; }
     size_t targetDepth() const { return targetDepth_; }
     size_t currentDepth() const { return frames_.size(); }
     bool playheadInitialized() const { return playheadInit_; }
@@ -136,6 +144,9 @@ private:
     // Lifetime stats.
     size_t underrunCount_{0};
     size_t lateCount_{0};
+    // Confirmed network losses (hole-at-head in pop()). Lifetime counter,
+    // retained across reset() like underrunCount_/lateCount_.
+    size_t lostCount_{0};
 
     // Adaptation rolling state.
     size_t ticksThisInterval_{0};

--- a/android/app/src/main/cpp/jitter_buffer.h
+++ b/android/app/src/main/cpp/jitter_buffer.h
@@ -27,9 +27,11 @@
 // **Adaptive target depth.** `tick()` is called every mixer tick by the
 // consumer; once per `kJitterAdaptIntervalTicks` it acts on the recent
 // underrun count: if any underruns occurred in the window, target depth
-// grows by one frame (capped at `kJitterMaxDepth`). If no underruns happened
-// for `kJitterShrinkAfterStableTicks`, target depth shrinks by one (floored
-// at `kJitterMinDepth`). Result: the buffer rides the smallest depth that
+// grows by one frame (capped at `kJitterMaxTargetDepth` — deliberately well
+// below the `kJitterMaxDepth` push cap, so a jittery link can't ratchet
+// playout latency to the overflow boundary). If no underruns happened for
+// `kJitterShrinkAfterStableTicks`, target depth shrinks by one (floored at
+// `kJitterMinDepth`). Result: the buffer rides the smallest depth that
 // doesn't glitch on the current link.
 //
 // **Cold-start handling.** Underruns are counted only after the buffer has
@@ -117,7 +119,7 @@ public:
 
     // Hard reset: clear queued frames and rolling state. Use on peer
     // unregister / re-register or on a session-level reset. Does NOT clear
-    // lifetime stats (underrunCount, lateFrameCount).
+    // lifetime stats (underrunCount, lateFrameCount, lostFrameCount).
     void reset();
 
 private:

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <android/log.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <thread>
@@ -11,6 +12,30 @@
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 #define LOGW(...) __android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+namespace {
+
+// Crossfade-merge two consecutive decoded PCM frames into one, time-
+// compressing 2 frames of input into 1 frame of output. Used by the jitter
+// buffer's drift drain: when the producer's clock outruns ours and the buffer
+// runs hot, collapsing two 20 ms frames into one releases 20 ms of accumulated
+// backlog. A linear A->B crossfade (weight ramps 0->1 across the frame) avoids
+// the hard click a frame-skip would make. Writes the result into `a` in place
+// and returns the merged sample count; operates on the shorter of the two
+// lengths (20 ms Opus frames are equal-length in practice).
+int crossfadeMergeFrames(int16_t* a, int aLen, const int16_t* b, int bLen) {
+    const int n = std::min(aLen, bLen);
+    for (int i = 0; i < n; ++i) {
+        const float w =
+            (n > 1) ? static_cast<float>(i) / static_cast<float>(n - 1) : 1.0f;
+        const float mixed = static_cast<float>(a[i]) * (1.0f - w) +
+                            static_cast<float>(b[i]) * w;
+        a[i] = static_cast<int16_t>(std::lround(mixed));
+    }
+    return n;
+}
+
+}  // namespace
 
 PeerAudioManager::PeerAudioManager() { LOGI("PeerAudioManager created"); }
 
@@ -36,8 +61,19 @@ int PeerAudioManager::registerPeer(const std::string& macAddress) {
 
     auto it = peers_.find(macAddress);
     if (it != peers_.end()) {
-        LOGI("Peer %s already registered with device ID %d", macAddress.c_str(),
-             it->second->deviceId);
+        // Re-register of a still-known peer (fast GATT reconnect, or a role
+        // swap that didn't tear the audio state down). Reset the jitter buffer
+        // so the rejoin starts at the cold-start depth with a fresh playhead,
+        // instead of inheriting a stale playhead and a target depth that
+        // ratcheted up on the previous link — both make the first seconds of a
+        // rejoin play out of a mis-sized buffer. Safe to take the per-peer
+        // mutex while holding peerRegistryMutex_: no path locks in reverse.
+        {
+            std::lock_guard<std::mutex> stateLock(it->second->mutex);
+            it->second->jitterBuffer->reset();
+        }
+        LOGI("Peer %s already registered with device ID %d (jitter reset)",
+             macAddress.c_str(), it->second->deviceId);
         return it->second->deviceId;
     }
 
@@ -194,6 +230,8 @@ PeerAudioManager::LinkTelemetry PeerAudioManager::getTelemetry(
             static_cast<uint32_t>(state->jitterBuffer->underrunCount());
         t.lateFrameCount =
             static_cast<uint32_t>(state->jitterBuffer->lateFrameCount());
+        t.lostFrameCount =
+            static_cast<uint32_t>(state->jitterBuffer->lostFrameCount());
         t.jitterTargetDepth =
             static_cast<uint32_t>(state->jitterBuffer->targetDepth());
         t.jitterCurrentDepth =
@@ -258,6 +296,8 @@ void PeerAudioManager::mixerTickLoop() {
     // Pre-allocate scratch — the mixer thread runs every 20 ms, so the cost
     // of a tick matters more than memory.
     std::vector<int16_t> decodedBuffer(audio_config::kCodecMaxFrameSize);
+    // Second decode scratch — used only by the drift-drain crossfade-merge.
+    std::vector<int16_t> decodedBuffer2(audio_config::kCodecMaxFrameSize);
     std::vector<int16_t> mixedBuffer(kFrameSize);
     std::vector<uint8_t> opusBuffer(audio_config::kMaxOpusPacketSize);
 
@@ -355,6 +395,34 @@ void PeerAudioManager::mixerTickLoop() {
                         decodedBuffer.data(),
                         audio_config::kCodecMaxFrameSize);
                     state->consecutiveUnderruns = 0;
+
+                    // Drift drain (time-scaling "accelerate"). If the buffer is
+                    // still at/above the high watermark after this pop, the
+                    // producer's 50 Hz clock is outrunning ours. Pull one extra
+                    // frame and crossfade-merge it into the frame we just
+                    // decoded — two 20 ms input frames collapse into one 20 ms
+                    // output frame, draining the backlog by one without a hard
+                    // skip. Capped at one extra frame per tick so the time
+                    // compression stays subtle and spreads across ticks. (The
+                    // opposite drift — our clock outrunning the producer — is
+                    // handled by the underrun/PLC path below, which stretches.)
+                    if (decoded > 0 &&
+                        state->jitterBuffer->currentDepth() >=
+                            audio_config::kJitterHighWatermark) {
+                        auto extra = state->jitterBuffer->pop();
+                        if (extra.has_value()) {
+                            int decoded2 = state->decoder->decode(
+                                extra->opusData.data(),
+                                static_cast<int>(extra->opusData.size()),
+                                decodedBuffer2.data(),
+                                audio_config::kCodecMaxFrameSize);
+                            if (decoded2 > 0) {
+                                decoded = crossfadeMergeFrames(
+                                    decodedBuffer.data(), decoded,
+                                    decodedBuffer2.data(), decoded2);
+                            }
+                        }
+                    }
                 } else {
                     // Underrun. PLC for one frame; if we've already PLC'd twice in
                     // a row, prefer popAny() so the buffer doesn't grow stale.
@@ -756,11 +824,12 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeSetPeerBitrate(
     return applied;
 }
 
-// Returns a 5-element int array with telemetry, or null if peer not found.
+// Returns a 6-element int array with telemetry, or null if peer not found.
 // Layout: [underrunCount, lateFrameCount, jitterTargetDepth,
-//          jitterCurrentDepth, currentBitrate]. Kotlin unpacks this into a
-// data class — keeping the marshaling cheap (no JNI object allocations) is
-// the point.
+//          jitterCurrentDepth, currentBitrate, lostFrameCount]. lostFrameCount
+// is appended last so the existing index layout is undisturbed. Kotlin unpacks
+// this into a data class — keeping the marshaling cheap (no JNI object
+// allocations) is the point.
 JNIEXPORT jintArray JNICALL
 Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeGetTelemetry(
     JNIEnv* env, jobject thiz, jstring macAddress) {
@@ -772,16 +841,17 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeGetTelemetry(
 
     if (!t.valid) return nullptr;
 
-    jintArray arr = env->NewIntArray(5);
+    jintArray arr = env->NewIntArray(6);
     if (!arr) return nullptr;
-    jint values[5] = {
+    jint values[6] = {
         static_cast<jint>(t.underrunCount),
         static_cast<jint>(t.lateFrameCount),
         static_cast<jint>(t.jitterTargetDepth),
         static_cast<jint>(t.jitterCurrentDepth),
         static_cast<jint>(t.currentBitrate),
+        static_cast<jint>(t.lostFrameCount),
     };
-    env->SetIntArrayRegion(arr, 0, 5, values);
+    env->SetIntArrayRegion(arr, 0, 6, values);
     return arr;
 }
 

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <thread>
 #include <utility>
 
@@ -25,12 +26,25 @@ namespace {
 // lengths (20 ms Opus frames are equal-length in practice).
 int crossfadeMergeFrames(int16_t* a, int aLen, const int16_t* b, int bLen) {
     const int n = std::min(aLen, bLen);
+    if (n <= 0) return 0;
+    if (n == 1) {
+        // Degenerate frame: nothing to ramp across, so the merged output is
+        // just the later frame (w would be 1).
+        a[0] = b[0];
+        return 1;
+    }
+    // Precompute the ramp step so the per-sample inner loop is a multiply, not
+    // a divide — this runs in the 50 Hz mixer hot path.
+    const float step = 1.0f / static_cast<float>(n - 1);
     for (int i = 0; i < n; ++i) {
-        const float w =
-            (n > 1) ? static_cast<float>(i) / static_cast<float>(n - 1) : 1.0f;
+        const float w = static_cast<float>(i) * step;
         const float mixed = static_cast<float>(a[i]) * (1.0f - w) +
                             static_cast<float>(b[i]) * w;
-        a[i] = static_cast<int16_t>(std::lround(mixed));
+        // A convex blend of two int16 samples is in range mathematically, but
+        // clamp defensively: narrowing an out-of-range float-rounded value to
+        // int16_t is implementation-defined and could wrap into a loud glitch.
+        a[i] = static_cast<int16_t>(
+            std::clamp<long>(std::lround(mixed), INT16_MIN, INT16_MAX));
     }
     return n;
 }

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -436,6 +436,15 @@ void PeerAudioManager::mixerTickLoop() {
                                     decodedBuffer2.data(), decoded2);
                             }
                         }
+                        // A nullopt here can only be a hole-at-head: depth is
+                        // >= the high watermark, so pop() never reports an
+                        // underrun in this branch. pop() has already advanced
+                        // the playhead past one lost seq, and that advance IS
+                        // the drain we want — collapsing the missing 20 ms is
+                        // exactly the time compression drift-drain exists to do.
+                        // Deliberately no PLC for it: synthesizing concealment
+                        // would re-stretch the very gap we are draining. The
+                        // real frame decoded above is still played out this tick.
                     }
                 } else {
                     // Underrun. PLC for one frame; if we've already PLC'd twice in

--- a/android/app/src/main/cpp/peer_audio_manager.h
+++ b/android/app/src/main/cpp/peer_audio_manager.h
@@ -43,6 +43,10 @@ public:
     struct LinkTelemetry {
         uint32_t underrunCount{0};
         uint32_t lateFrameCount{0};
+        // True network loss (seq-gap). This — not lateFrameCount — is what
+        // the bitrate adapter consumes, so jitter-buffer overflow/late drops
+        // can't be misread as link loss and floor the encoder.
+        uint32_t lostFrameCount{0};
         uint32_t jitterTargetDepth{0};
         uint32_t jitterCurrentDepth{0};
         int currentBitrate{audio_config::kDefaultBitrate};

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -523,6 +523,7 @@ class MainActivity : FlutterActivity() {
                                 t.targetDepthFrames,
                                 t.currentDepthFrames,
                                 t.currentBitrateBps,
+                                t.lostFrameCount,
                             ))
                         }
                     }

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
@@ -95,6 +95,9 @@ class PeerAudioManager {
         val targetDepthFrames: Int,
         val currentDepthFrames: Int,
         val currentBitrateBps: Int,
+        // True network loss (seq-gap). Drives bitrate adaptation; lateFrameCount
+        // is kept for observability only.
+        val lostFrameCount: Int,
     )
 
     /**
@@ -126,7 +129,7 @@ class PeerAudioManager {
     /** Returns null if the peer isn't registered. */
     fun getTelemetry(macAddress: String): LinkTelemetry? {
         val raw = nativeGetTelemetry(macAddress) ?: return null
-        if (raw.size != 5) {
+        if (raw.size != 6) {
             Log.w(TAG, "getTelemetry returned unexpected array size ${raw.size}")
             return null
         }
@@ -136,6 +139,7 @@ class PeerAudioManager {
             targetDepthFrames = raw[2],
             currentDepthFrames = raw[3],
             currentBitrateBps = raw[4],
+            lostFrameCount = raw[5],
         )
     }
 

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -11,8 +11,16 @@ class LinkTelemetrySnapshot {
   /// Lifetime mixer-tick underruns for this peer's stream.
   final int underrunCount;
 
-  /// Lifetime jitter-buffer drops (frames that arrived too late to play).
+  /// Lifetime jitter-buffer drops (frames that arrived too late to play, or
+  /// were dropped on a full buffer). Observability only — does NOT drive
+  /// bitrate adaptation, because it conflates jitter/capacity with loss.
+  /// See [lostFrameCount].
   final int lateFrameCount;
+
+  /// Lifetime true network loss: frames confirmed never-arrived (a seq the
+  /// playhead passed because it wasn't received despite an adequately-filled
+  /// buffer). This is the RTP-style loss signal the bitrate adapter reacts to.
+  final int lostFrameCount;
 
   /// Adaptive jitter buffer target depth in 20 ms frames.
   final int targetDepthFrames;
@@ -26,6 +34,7 @@ class LinkTelemetrySnapshot {
   const LinkTelemetrySnapshot({
     required this.underrunCount,
     required this.lateFrameCount,
+    required this.lostFrameCount,
     required this.targetDepthFrames,
     required this.currentDepthFrames,
     required this.currentBitrateBps,
@@ -37,6 +46,7 @@ class LinkTelemetrySnapshot {
       other is LinkTelemetrySnapshot &&
           underrunCount == other.underrunCount &&
           lateFrameCount == other.lateFrameCount &&
+          lostFrameCount == other.lostFrameCount &&
           targetDepthFrames == other.targetDepthFrames &&
           currentDepthFrames == other.currentDepthFrames &&
           currentBitrateBps == other.currentBitrateBps;
@@ -45,6 +55,7 @@ class LinkTelemetrySnapshot {
   int get hashCode => Object.hash(
     underrunCount,
     lateFrameCount,
+    lostFrameCount,
     targetDepthFrames,
     currentDepthFrames,
     currentBitrateBps,
@@ -605,10 +616,11 @@ class AudioService {
         'getLinkTelemetry',
         <String, dynamic>{'macAddress': macAddress},
       );
-      if (raw is! List || raw.length != 5) return null;
-      // Native returns a 5-element int array: [underruns, late, target,
-      // current, bitrate]. Element-wise check guards against a truncated
-      // or padded response from a stale platform handler.
+      if (raw is! List || raw.length != 6) return null;
+      // Native returns a 6-element int array: [underruns, late, target,
+      // current, bitrate, lost]. lostFrameCount is appended last so the
+      // historical index layout is undisturbed. Element-wise check guards
+      // against a truncated or padded response from a stale platform handler.
       final values = raw.map((e) => e is int ? e : null).toList();
       if (values.any((v) => v == null)) return null;
       return LinkTelemetrySnapshot(
@@ -617,6 +629,7 @@ class AudioService {
         targetDepthFrames: values[2]!,
         currentDepthFrames: values[3]!,
         currentBitrateBps: values[4]!,
+        lostFrameCount: values[5]!,
       );
     } catch (e) {
       if (kDebugMode) {

--- a/lib/services/link_quality_reporter.dart
+++ b/lib/services/link_quality_reporter.dart
@@ -7,12 +7,20 @@ import 'audio_service.dart';
 /// wire format wants per-second rates and a percentage, so we delta and
 /// scale here.
 ///
-/// **Loss model.** `lossPct` is `lateFrameDelta / expectedFrames * 100`,
-/// where `expectedFrames = elapsed_ms / 20` (one Opus frame per
-/// `audio_config::kFrameDurationMs`). This conservatively assumes the
-/// talker was speaking continuously across the window. When voice isn't
-/// flowing, `lateFrameDelta` is 0, `lossPct` is 0, and the adapter sees
-/// a clean sample — which is fine: no audio means link quality is moot.
+/// **Loss model.** `lossPct` is `lostFrameDelta / expectedFrames * 100`,
+/// where `lostFrameDelta` is the change in the native jitter buffer's *true*
+/// loss counter (frames the playhead passed because they never arrived —
+/// RTP-style seq-gap loss) and `expectedFrames = elapsed_ms / 20` (one Opus
+/// frame per `audio_config::kFrameDurationMs`). This conservatively assumes
+/// the talker was speaking continuously across the window. When voice isn't
+/// flowing, `lostFrameDelta` is 0, `lossPct` is 0, and the adapter sees a
+/// clean sample — which is fine: no audio means link quality is moot.
+///
+/// We deliberately do **not** use `lateFrameCount` here. Late/overflow drops
+/// are a jitter-buffer *capacity* signal, not packet loss — driving the
+/// encoder bitrate down on them is both wrong (a smaller 50 fps payload does
+/// nothing for clock drift or fixed-interval jitter) and self-perpetuating
+/// (the buffer keeps overflowing, so the bitrate floors and never recovers).
 /// The percentage is clamped to [0, 100] so a counter rollover or bad
 /// snapshot can't push absurd values into the adapter.
 ///
@@ -59,7 +67,10 @@ import 'audio_service.dart';
   // Clamp to zero to swallow a counter reset (e.g. native side cleared and
   // reseeded between snapshots) without poisoning the adapter with a
   // negative rate.
-  final lateDelta = (current.lateFrameCount - previous.lateFrameCount).clamp(
+  // True network loss (seq-gap), NOT lateFrameCount — see the loss-model note
+  // above for why jitter-buffer late/overflow drops must never feed the
+  // bitrate adapter.
+  final lostDelta = (current.lostFrameCount - previous.lostFrameCount).clamp(
     0,
     1 << 31,
   );
@@ -70,7 +81,7 @@ import 'audio_service.dart';
 
   final lossPctRaw = expectedFrames <= 0
       ? 0.0
-      : (lateDelta / expectedFrames) * 100.0;
+      : (lostDelta / expectedFrames) * 100.0;
   // `num.clamp` returns `num`, not `double`; the record's `lossPct` field is
   // typed `double`, so spell the conversion explicitly to keep the analyzer
   // (and a strict-mode reader) happy.

--- a/test/cpp/jitter_buffer_test.cpp
+++ b/test/cpp/jitter_buffer_test.cpp
@@ -146,6 +146,11 @@ void testMultiFrameHoleProducesContiguousPLC() {
     // Episode invariant: h1 and h2 belong to the same starvation episode,
     // counted exactly once.
     assert(jb.underrunCount() == 1);
+    // True loss, however, is per-frame: BOTH missing seqs (11, 12) count, so
+    // the bitrate adapter sees the real loss rate rather than an episode count.
+    assert(jb.lostFrameCount() == 2);
+    // And neither missing frame is a late/overflow drop.
+    assert(jb.lateFrameCount() == 0);
 
     std::cout << "Test Multi-Frame Hole Produces Contiguous PLC: PASSED"
               << std::endl;
@@ -405,6 +410,72 @@ void testResetClearsQueueAndState() {
     std::cout << "Test Reset Clears Queue And State: PASSED" << std::endl;
 }
 
+// Defect A: the hole-at-head path increments lostFrameCount (true seq-gap
+// loss) exactly once per confirmed-missing seq, and does NOT touch
+// lateFrameCount. This is the counter the bitrate adapter consumes, so
+// jitter-buffer late/overflow churn can't masquerade as packet loss.
+void testLostFrameCountOnHole() {
+    JitterBuffer jb;
+    const uint8_t data[1] = {0x5a};
+    // Present 20, 22, 23, 24; seq 21 lost. Depth (4) >= target (3) so the
+    // depth-underrun branch doesn't fire — isolates the hole path.
+    assert(jb.push(20, data, 1));
+    assert(jb.push(22, data, 1));
+    assert(jb.push(23, data, 1));
+    assert(jb.push(24, data, 1));
+    assert(jb.lostFrameCount() == 0);
+
+    auto p20 = jb.pop();  // playhead 20 -> release, ph advances to 21
+    assert(p20.has_value() && p20->seq == 20);
+    assert(jb.lostFrameCount() == 0);
+
+    auto hole = jb.pop();  // ph=21 missing, front=22 -> confirmed loss
+    assert(!hole.has_value());
+    assert(jb.lostFrameCount() == 1);
+    assert(jb.lateFrameCount() == 0);
+
+    auto p22 = jb.pop();  // ph=22 now matches front
+    assert(p22.has_value() && p22->seq == 22);
+    assert(jb.lostFrameCount() == 1);
+
+    std::cout << "Test Lost Frame Count On Hole: PASSED" << std::endl;
+}
+
+// Defect B: the adaptive target depth caps at kJitterMaxTargetDepth, NOT
+// kJitterMaxDepth. A jittery link must not be able to ratchet playout latency
+// up to the hard cap, where the buffer rides the overflow boundary and
+// hard-drops every fresh frame (the degradation/artifacting death spiral).
+void testTargetDepthCapsAtMaxTarget() {
+    JitterBuffer jb;
+    // Prime so underruns are counted.
+    seedAtDepth(jb, 1, audio_config::kJitterInitialDepth);
+    assert(jb.pop().has_value());
+
+    // Drive far more counted-underrun intervals than the distance from the
+    // initial depth to the hard cap — if the ceiling were kJitterMaxDepth the
+    // target would reach it.
+    for (size_t round = 0; round < audio_config::kJitterMaxDepth + 5; ++round) {
+        while (jb.popAny().has_value()) {
+        }
+        // Seed more than the cap, contiguous with the playhead, so a pop
+        // always succeeds regardless of the (growing) target and clears
+        // inUnderrun_ for a fresh episode.
+        seedAtDepth(jb, jb.playhead(), audio_config::kJitterMaxTargetDepth + 2);
+        assert(jb.pop().has_value());
+        while (jb.popAny().has_value()) {
+        }
+        assert(!jb.pop().has_value());  // starve on empty -> +1 underrun episode
+        for (size_t i = 0; i < audio_config::kJitterAdaptIntervalTicks; ++i) {
+            jb.tick();
+        }
+    }
+
+    assert(jb.targetDepth() == audio_config::kJitterMaxTargetDepth);
+    assert(jb.targetDepth() < audio_config::kJitterMaxDepth);
+
+    std::cout << "Test Target Depth Caps At Max Target: PASSED" << std::endl;
+}
+
 }  // namespace
 
 int main() {
@@ -423,6 +494,8 @@ int main() {
         testWraparoundOrdering();
         testPopAnyWhenBelowTarget();
         testResetClearsQueueAndState();
+        testLostFrameCountOnHole();
+        testTargetDepthCapsAtMaxTarget();
         std::cout << "All JitterBuffer tests passed!" << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "Test failed: " << e.what() << std::endl;

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -818,7 +818,8 @@ void main() {
       });
 
       test('getLinkTelemetry returns parsed snapshot', () async {
-        handler = (_) async => [10, 5, 8, 4, 16000];
+        // Layout: [underrun, late, target, current, bitrate, lost].
+        handler = (_) async => [10, 5, 8, 4, 16000, 3];
         final snap = await audioService.getLinkTelemetry('AA:BB');
         expect(snap, isNotNull);
         expect(snap!.underrunCount, 10);
@@ -826,6 +827,7 @@ void main() {
         expect(snap.targetDepthFrames, 8);
         expect(snap.currentDepthFrames, 4);
         expect(snap.currentBitrateBps, 16000);
+        expect(snap.lostFrameCount, 3);
       });
 
       test('getLinkTelemetry returns null on wrong shape (length)', () async {
@@ -834,7 +836,9 @@ void main() {
       });
 
       test('getLinkTelemetry returns null on wrong type element', () async {
-        handler = (_) async => [1, 2, 3, 4, '16000']; // last is string
+        // 6 elements so the length check passes and the element-type check
+        // is what rejects it.
+        handler = (_) async => [1, 2, 3, 4, 5, '16000']; // last is string
         expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
       });
 
@@ -866,6 +870,7 @@ void main() {
       const a = LinkTelemetrySnapshot(
         underrunCount: 1,
         lateFrameCount: 2,
+        lostFrameCount: 7,
         targetDepthFrames: 3,
         currentDepthFrames: 4,
         currentBitrateBps: 16000,
@@ -873,6 +878,7 @@ void main() {
       const b = LinkTelemetrySnapshot(
         underrunCount: 1,
         lateFrameCount: 2,
+        lostFrameCount: 7,
         targetDepthFrames: 3,
         currentDepthFrames: 4,
         currentBitrateBps: 16000,
@@ -880,6 +886,7 @@ void main() {
       const c = LinkTelemetrySnapshot(
         underrunCount: 99,
         lateFrameCount: 2,
+        lostFrameCount: 7,
         targetDepthFrames: 3,
         currentDepthFrames: 4,
         currentBitrateBps: 16000,

--- a/test/services/link_quality_reporter_test.dart
+++ b/test/services/link_quality_reporter_test.dart
@@ -5,12 +5,14 @@ import 'package:walkie_talkie/services/link_quality_reporter.dart';
 LinkTelemetrySnapshot _snap({
   int underrun = 0,
   int late = 0,
+  int lost = 0,
   int target = 3,
   int current = 3,
   int bps = 16000,
 }) => LinkTelemetrySnapshot(
   underrunCount: underrun,
   lateFrameCount: late,
+  lostFrameCount: lost,
   targetDepthFrames: target,
   currentDepthFrames: current,
   currentBitrateBps: bps,
@@ -103,11 +105,11 @@ void main() {
       },
     );
 
-    test('lossPct: lateDelta / expected * 100', () {
+    test('lossPct: lostDelta / expected * 100', () {
       // 2 s window → 100 expected frames (one Opus frame per 20 ms).
-      // 7 late frames in the delta → 7 % loss.
-      final prev = _snap(late: 10);
-      final curr = _snap(late: 17);
+      // 7 truly-lost frames in the delta → 7 % loss.
+      final prev = _snap(lost: 10);
+      final curr = _snap(lost: 17);
       final out = computeLinkQuality(
         previous: prev,
         current: curr,
@@ -116,12 +118,27 @@ void main() {
       expect(out.lossPct, closeTo(7.0, 1e-9));
     });
 
-    test('lossPct clamps to 100 when lateDelta exceeds expected', () {
-      // 1 s window expects 50 frames; 200 late frames is impossible in
+    test('lossPct ignores lateFrameCount entirely (Defect A decoupling)', () {
+      // Jitter-buffer late/overflow churn must NOT register as loss: a huge
+      // lateFrameCount delta with zero true loss is a clean link as far as
+      // the bitrate adapter is concerned. This is the exact failure that
+      // floored the encoder to 16 kbps on a loss-free (rx==tx) 2-device call.
+      final prev = _snap(late: 0, lost: 0);
+      final curr = _snap(late: 500, lost: 0);
+      final out = computeLinkQuality(
+        previous: prev,
+        current: curr,
+        elapsed: const Duration(seconds: 2),
+      );
+      expect(out.lossPct, 0.0);
+    });
+
+    test('lossPct clamps to 100 when lostDelta exceeds expected', () {
+      // 1 s window expects 50 frames; 200 lost frames is impossible in
       // practice (counter rollover, OS hibernation) but the function
       // mustn't return a 400 % loss value into the adapter.
-      final prev = _snap(late: 0);
-      final curr = _snap(late: 200);
+      final prev = _snap(lost: 0);
+      final curr = _snap(lost: 200);
       final out = computeLinkQuality(
         previous: prev,
         current: curr,
@@ -145,8 +162,8 @@ void main() {
     test('counter reset (delta < 0) clamps to zero rather than throwing', () {
       // Native side cleared and reseeded between snapshots — current is
       // *less* than previous. Treat as zero delta, not a negative rate.
-      final prev = _snap(underrun: 100, late: 100);
-      final curr = _snap(underrun: 0, late: 0);
+      final prev = _snap(underrun: 100, late: 100, lost: 100);
+      final curr = _snap(underrun: 0, late: 0, lost: 0);
       final out = computeLinkQuality(
         previous: prev,
         current: curr,
@@ -162,8 +179,8 @@ void main() {
       // up to Infinity even though the guard above only rejects
       // `<= Duration.zero`. The math must use microseconds (or some
       // other higher-resolution conversion) so the rate stays finite.
-      final prev = _snap(underrun: 0, late: 0);
-      final curr = _snap(underrun: 1, late: 1);
+      final prev = _snap(underrun: 0, late: 0, lost: 0);
+      final curr = _snap(underrun: 1, late: 1, lost: 1);
       final out = computeLinkQuality(
         previous: prev,
         current: curr,


### PR DESCRIPTION
## Problem

On a 2-device call, voice was good for ~13s then degraded to poor and **stayed** there, in both directions. Confirmed in logcat:

```
OpusCodec: Opus encoder created: 24000 Hz mono, 32 kbps ...   ← good start
OpusCodec: Encoder bitrate 32000 -> 16000 bps                 ← ~13s in, floors
L2capVoiceTransport: VOICE-DIAG rx recv=N ... sent=N qDepth=0  ← rx==tx, ZERO loss
```

The link lost nothing, yet the encoder floored to 16 kbps and never recovered.

## Defect A — bitrate adapted on the wrong signal

`lossPct` was computed from `lateFrameCount` — jitter-buffer **late/overflow drops**, not packet loss. Persistent jitter / clock-skew between the two unsynced 50 Hz domains overflowed the buffer → `lateFrameCount` climbed → false `lossPct > 12%` → encoder floored. Lowering the bitrate does nothing for jitter, so the buffer kept overflowing and the rate never climbed back.

**Fix:** a true seq-gap loss counter — `JitterBuffer::lostFrameCount`, incremented only on the confirmed *hole-at-head* in `pop()` (a seq the playhead passed because it never arrived despite an adequately-filled buffer). Threaded through telemetry (native 6-int array → Kotlin → Dart). `computeLinkQuality` now derives `lossPct` from it; `lateFrameCount` is observability only.

## Defect B — jitter buffer rode the overflow cap

The adaptive target depth ratcheted to `kJitterMaxDepth` (10) under jitter, then the buffer sat at the cap and hard-dropped every fresh frame (continuous artifacting), independent of bitrate.

**Fix:**
- Cap the adaptive target at `kJitterMaxTargetDepth = 6` (was ratcheting to the hard cap of 10).
- Decode-path **time-compression drain**: when the fill reaches `kJitterHighWatermark = 8`, pop one extra frame and crossfade-merge it with the one just decoded — two 20 ms input frames collapse into one 20 ms output frame, draining clock-drift backlog smoothly instead of hard-dropping at the cap. This is the "accelerate"; the existing PLC path is the "decelerate".
- Reset the jitter buffer on peer **re-register** so a rejoin/role-swap starts at the cold-start depth, not a stale, ratcheted one.

## Tests

- **16 host C++ jitter-buffer tests** (`-Wall -Wextra`, clean) — including new `testLostFrameCountOnHole` and `testTargetDepthCapsAtMaxTarget`, plus a `lateFrameCount`-stays-zero assertion on the multi-frame-hole test.
- **Full Dart suite: 897 passing** — including a new `link_quality_reporter` test proving `lateFrameCount` no longer affects `lossPct`.
- Profile APK builds clean.

## Validation status

Root cause was confirmed on-device. This fix is unit/integration-validated and builds clean. The on-device **2-device behavioral confirm** (encoder holds 32k+ over a long call; no artifacting) is **pending** — the test phone locked mid-session. Recommend a 2-device confirm before/right after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a telemetry metric for confirmed packet loss separate from buffer drops
  * Introduced a gentle crossfade-based drift-drain to smoothly reduce audio backlog

* **Improvements**
  * Link-quality now uses true packet-loss for loss calculations
  * Adaptive jitter buffering respects a lower target-cap to avoid ratcheting latency
  * Added compile-time validation to ensure jitter thresholds remain consistent

* **Tests**
  * Added/updated tests covering loss counting and target-depth capping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->