### PR TITLE
fix(#476): wire unregisterVoicePeer so host frees departed peers

### DIFF
--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -508,6 +508,23 @@ class MainActivity : FlutterActivity() {
                     voiceTransport = null
                     result.success(true)
                 }
+                "unregisterVoicePeer" -> {
+                    // Drop a departed peer's native PeerAudioManager state
+                    // (encoder/decoder/jitter buffer + mixer slot). Called by
+                    // the cubit on Leave / RemovePeer / heartbeat-loss so the
+                    // host doesn't leak one PeerState per guest that ever
+                    // connected (issue #476). The native unregisterPeer removes
+                    // the mixer device and resolves an unknown MAC as a no-op,
+                    // so this is safe even if voice never came up for the peer.
+                    val mac = call.argument<String>("macAddress")
+                    if (mac == null) {
+                        result.error("INVALID_ARGUMENT", "macAddress is required", null)
+                    } else {
+                        Log.i(TAG, "Unregistering voice peer $mac")
+                        peerAudioManager?.unregisterPeer(mac)
+                        result.success(true)
+                    }
+                }
                 "getLinkTelemetry" -> {
                     val mac = call.argument<String>("macAddress")
                     if (mac == null) {

--- a/lib/bloc/frequency_session_cubit.dart
+++ b/lib/bloc/frequency_session_cubit.dart
@@ -359,6 +359,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
               .where((p) => p.peerId != m.peerId)
               .toList();
           emit(current.copyWith(roster: updated));
+          // Resolve + drop the native voice peer before forgetPeer wipes the
+          // peerId→MAC mapping it depends on (issue #476).
+          _unregisterVoicePeer(m.peerId);
           _transport?.forgetPeer(m.peerId);
           _heartbeats.forgetPeer(m.peerId);
           _weakSignalDetector.forgetPeer(m.peerId);
@@ -373,6 +376,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
             .where((p) => p.peerId != m.target)
             .toList();
         emit(current.copyWith(roster: updated));
+        // Resolve + drop the native voice peer before forgetPeer wipes the
+        // peerId→MAC mapping it depends on (issue #476).
+        _unregisterVoicePeer(m.target);
         _transport?.forgetPeer(m.target);
         _heartbeats.forgetPeer(m.target);
         _weakSignalDetector.forgetPeer(m.target);
@@ -905,6 +911,25 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
     return _transport?.endpointForPeer(peerId);
   }
 
+  /// Drop [peerId]'s native voice state (per-peer encoder/decoder/jitter
+  /// buffer + mixer slot) from the platform `PeerAudioManager`.
+  ///
+  /// Resolves the peer's MAC via [macForPeerId] **before** the caller drops
+  /// the transport's peerId→MAC mapping — [BleControlTransport.forgetPeer]
+  /// wipes it — so this must run *ahead* of `_transport.forgetPeer(peerId)`
+  /// in the departure cleanup paths.
+  ///
+  /// No-op when the peer has no known MAC (e.g. a guest seeing another
+  /// guest's `Leave`, where no L2CAP endpoint was ever recorded) or was never
+  /// registered with the voice layer — the native side resolves an unknown
+  /// MAC as a no-op. Without this the host leaks one `PeerState` per guest
+  /// that ever connected (issue #476).
+  void _unregisterVoicePeer(String peerId) {
+    final mac = macForPeerId(peerId);
+    if (mac == null) return;
+    unawaited(_audio?.unregisterPeer(mac));
+  }
+
   /// Build and send a `BitrateHint` to [targetPeerId]. Best-effort:
   /// transport-level failures are logged and swallowed so a single bad
   /// adapter step doesn't poison the rest of the dispatch loop.
@@ -1033,6 +1058,9 @@ class FrequencySessionCubit extends Cubit<FrequencySessionState> {
       final updated = current.roster.where((p) => p.peerId != peerId).toList();
       if (updated.length == current.roster.length) return;
       emit(current.copyWith(roster: updated));
+      // Host dropped a guest for good — release its native voice state before
+      // forgetPeer wipes the peerId→MAC mapping it depends on (issue #476).
+      _unregisterVoicePeer(peerId);
       _transport?.forgetPeer(peerId);
       _weakSignalDetector.forgetPeer(peerId);
       final t = _transport;

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -764,6 +764,33 @@ class AudioService {
     }
   }
 
+  /// Drop a departed peer's native voice state.
+  ///
+  /// Tears down the per-peer Opus encoder, decoder, jitter buffer, and mixer
+  /// slot the native `PeerAudioManager` holds for [macAddress]. Counterpart to
+  /// the implicit registration that happens when an L2CAP voice channel opens
+  /// (the host registers each guest; a guest registers the host).
+  ///
+  /// Called by [FrequencySessionCubit] on the control-plane departure paths
+  /// (Leave / RemovePeer / host-side heartbeat loss) so the host doesn't
+  /// accumulate one `PeerState` per guest that ever connected (issue #476).
+  ///
+  /// Safe to call for a MAC that was never registered — the native side
+  /// resolves an unknown MAC as a no-op. Returns true if the platform call
+  /// succeeded, false if it threw.
+  Future<bool> unregisterPeer(String macAddress) async {
+    try {
+      final result = await _methodChannel.invokeMethod<bool>(
+        'unregisterVoicePeer',
+        <String, dynamic>{'macAddress': macAddress},
+      );
+      return result == true;
+    } catch (e) {
+      if (kDebugMode) debugPrint('Error unregistering peer $macAddress: $e');
+      return false;
+    }
+  }
+
   /// Stream of control-plane byte fragments from the native GATT layer.
   ///
   /// On the host side, each event carries bytes written to the REQUEST

--- a/test/bloc/frequency_session_cubit_test.dart
+++ b/test/bloc/frequency_session_cubit_test.dart
@@ -2993,6 +2993,165 @@ void main() {
       await t.inbox.close();
       t.transport.dispose();
     });
+
+    test('Leave dispatch unregisters the departed peer from the native voice '
+        'layer (issue #476)', () async {
+      final t = makeTestTransport();
+      final audio = _RecordingUnregisterAudio();
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(hours: 1),
+      );
+      final cubit = _makeCubit(
+        heartbeats: scheduler,
+        transport: t.transport,
+        audio: audio,
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [
+            ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ProtocolPeer(peerId: 'p-guest', displayName: 'Maya'),
+          ],
+        ),
+      );
+
+      // Deliver a Leave from p-guest over endpoint AA:BB. The transport
+      // records p-guest → AA:BB on this inbound message; the dispatch must
+      // resolve that MAC and unregister the native peer *before* forgetPeer
+      // wipes the mapping.
+      final leaveJson = const Leave(
+        peerId: 'p-guest',
+        seq: 1,
+        atMs: 0,
+      ).encode();
+      for (final frag in encodeFragments(leaveJson)) {
+        t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      expect(audio.unregistered, ['AA:BB']);
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
+
+    test(
+      'RemovePeer dispatch unregisters the target peer from the native voice '
+      'layer (issue #476)',
+      () async {
+        final t = makeTestTransport();
+        final audio = _RecordingUnregisterAudio();
+        final scheduler = HeartbeatScheduler(
+          pingInterval: const Duration(hours: 1),
+        );
+        final cubit = _makeCubit(
+          heartbeats: scheduler,
+          transport: t.transport,
+          audio: audio,
+        );
+        await cubit.bootstrap();
+        cubit.emit(const SessionDiscovery(myName: 'Devon'));
+        await cubit.joinRoom(freq: '104.3', isHost: true);
+        cubit.applyJoinAccepted(
+          JoinAccepted(
+            peerId: 'p-host',
+            seq: 1,
+            atMs: 0,
+            hostPeerId: 'p-host',
+            roster: const [
+              ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+              ProtocolPeer(peerId: 'p-guest', displayName: 'Maya'),
+            ],
+          ),
+        );
+
+        // RemovePeer targeting p-guest, delivered over p-guest's endpoint so
+        // the transport records p-guest → AA:BB before dispatch resolves and
+        // unregisters it.
+        final removeJson = const RemovePeer(
+          peerId: 'p-guest',
+          seq: 1,
+          atMs: 0,
+          target: 'p-guest',
+        ).encode();
+        for (final frag in encodeFragments(removeJson)) {
+          t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+        }
+        await Future<void>.delayed(Duration.zero);
+
+        expect(audio.unregistered, ['AA:BB']);
+
+        await cubit.close();
+        await t.inbox.close();
+        t.transport.dispose();
+      },
+    );
+
+    test('host: peer-lost unregisters the departed peer from the native voice '
+        'layer (issue #476)', () async {
+      final t = makeTestTransport();
+      final audio = _RecordingUnregisterAudio();
+      var fakeNow = DateTime(2026, 1, 1, 12, 0, 0);
+      final scheduler = HeartbeatScheduler(
+        pingInterval: const Duration(hours: 1),
+        missThreshold: const Duration(seconds: 15),
+        clock: () => fakeNow,
+      );
+      final cubit = _makeCubit(
+        heartbeats: scheduler,
+        transport: t.transport,
+        audio: audio,
+      );
+      await cubit.bootstrap();
+      cubit.emit(const SessionDiscovery(myName: 'Devon'));
+      await cubit.joinRoom(freq: '104.3', isHost: true);
+      cubit.applyJoinAccepted(
+        JoinAccepted(
+          peerId: 'p-host',
+          seq: 1,
+          atMs: 0,
+          hostPeerId: 'p-host',
+          roster: const [
+            ProtocolPeer(peerId: 'p-host', displayName: 'Devon'),
+            ProtocolPeer(peerId: 'p-stale', displayName: 'Stale'),
+          ],
+        ),
+      );
+
+      // Deliver one inbound message from p-stale so the transport records
+      // its endpoint (the peerId→MAC mapping the unregister resolves
+      // against) and the heartbeat plane notes it as last-seen at t=0.
+      final pingJson = const Heartbeat(
+        peerId: 'p-stale',
+        seq: 1,
+        atMs: 0,
+      ).encode();
+      for (final frag in encodeFragments(pingJson)) {
+        t.inbox.add((endpointId: 'AA:BB', bytes: frag));
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      // Advance past the silence threshold and tick → p-stale is declared
+      // lost, and its native voice state released before forgetPeer wipes
+      // the MAC.
+      fakeNow = fakeNow.add(const Duration(seconds: 20));
+      scheduler.debugTick();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(audio.unregistered, ['AA:BB']);
+
+      await cubit.close();
+      await t.inbox.close();
+      t.transport.dispose();
+    });
   });
 
   // ── SignalReport / weak-signal ────────────────────────────────────────
@@ -5477,6 +5636,41 @@ class _StubLocalTalkingAudio extends AudioService {
 
   @override
   Stream<bool> get localTalking => _localTalking;
+
+  @override
+  Future<bool> stopAdvertising() async => true;
+
+  @override
+  Future<bool> stopGattServer() async => true;
+
+  @override
+  Future<bool> stopVoiceTransport() async => true;
+}
+
+/// AudioService stub that records the MACs passed to [unregisterPeer] so the
+/// peer-departure tests can assert the cubit releases a departed peer's native
+/// voice state (issue #476). The host join/teardown methods the cubit reaches
+/// are stubbed to no-ops (same rationale as [_StubLocalTalkingAudio]) so the
+/// tests never touch the real MethodChannel.
+class _RecordingUnregisterAudio extends AudioService {
+  final List<String> unregistered = <String>[];
+
+  @override
+  Future<bool> unregisterPeer(String macAddress) async {
+    unregistered.add(macAddress);
+    return true;
+  }
+
+  @override
+  Future<void> startGattServerAndAdvertise({
+    required String sessionUuid,
+    required String displayName,
+    Duration serverReadyTimeout = const Duration(seconds: 3),
+    bool Function()? shouldProceed,
+  }) async {}
+
+  @override
+  Future<int?> startVoiceServer() async => null;
 
   @override
   Future<bool> stopAdvertising() async => true;

--- a/test/contracts/native_audio_bridge_contract_test.dart
+++ b/test/contracts/native_audio_bridge_contract_test.dart
@@ -62,5 +62,18 @@ void main() {
       expect(audioEngine, contains('playbackStream->write('));
       expect(audioEngine, contains('playoutScratch_'));
     });
+
+    test('unregisterVoicePeer releases a departed peer\'s native state', () {
+      final mainActivity = File(
+        'android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt',
+      ).readAsStringSync();
+
+      // Issue #476: the cubit calls this channel method on a peer's departure
+      // so the host doesn't leak one native PeerState per guest that ever
+      // connected. Native unregisterPeer + JNI already exist; this pins the
+      // MainActivity wiring that the Dart-side tests can't exercise directly.
+      expect(mainActivity, contains('"unregisterVoicePeer" ->'));
+      expect(mainActivity, contains('peerAudioManager?.unregisterPeer(mac)'));
+    });
   });
 }

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -31,6 +31,7 @@ void main() {
                 case 'setAudioOutput':
                 case 'connectVoiceClient':
                 case 'stopVoiceTransport':
+                case 'unregisterVoicePeer':
                   return true;
                 case 'startVoiceServer':
                   return 0x81;
@@ -519,6 +520,18 @@ void main() {
         expect(result, true);
         expect(log, [isMethodCall('stopVoiceTransport', arguments: null)]);
       });
+
+      test('unregisterPeer passes mac to native layer', () async {
+        log.clear();
+        final result = await audioService.unregisterPeer('AA:BB:CC:DD:EE:FF');
+        expect(result, true);
+        expect(log, [
+          isMethodCall(
+            'unregisterVoicePeer',
+            arguments: <String, dynamic>{'macAddress': 'AA:BB:CC:DD:EE:FF'},
+          ),
+        ]);
+      });
     });
 
     group('error path coverage (catch blocks return defaults)', () {
@@ -633,6 +646,11 @@ void main() {
       test('stopVoiceTransport returns false', () async {
         installFailing();
         expect(await audioService.stopVoiceTransport(), false);
+      });
+
+      test('unregisterPeer returns false', () async {
+        installFailing();
+        expect(await audioService.unregisterPeer('AA:BB'), false);
       });
 
       test('connectToHost returns false', () async {


### PR DESCRIPTION
## Problem (#476)

`unregisterPeer` exists in native (`peer_audio_manager.cpp`) + JNI + Kotlin (`PeerAudioManager.kt`) — **zero callers**. Host leaks one `PeerState` (Opus encoder + decoder + jitter buffer + mixer slot) per guest that ever connected. Freed only on full `stopVoice`. Long session, guests in/out → unbounded growth.

Guest side never leaked: one host peer, cleared on `leaveRoom`. The reconnect-seq-drop half of #476 already landed in #477 (native `registerPeer` reset-on-reregister) — this PR is the remaining leak-fix.

## Fix — 3 layers

1. **MainActivity.kt** — `unregisterVoicePeer` channel handler → `peerAudioManager?.unregisterPeer(mac)`. Native `unregisterPeer` already removes the mixer device (same `g_audioMixer`) + frees state, so the handler stays thin.
2. **audio_service.dart** — `unregisterPeer(mac)` Dart wrapper.
3. **frequency_session_cubit.dart** — `_unregisterVoicePeer(peerId)` on **Leave / RemovePeer / host heartbeat-loss**.

## Landmine handled

`_transport.forgetPeer(peerId)` wipes `_endpointByPeer` (the peerId→MAC map). Helper resolves MAC via `macForPeerId` **before** `forgetPeer`. No-op on null MAC → safe on guest (sees another guest's Leave, no endpoint recorded) + for an unknown/never-registered peer (native no-ops). No L2CAP-disconnect event exists; heartbeat-loss is the de-facto voice-disconnect detector.

## Tests (+6, additive)

- audio_service: channel wrapper happy + error path
- cubit: unregister fires on all 3 departure paths (asserts MAC + resolve-before-forget ordering)
- contract: pins MainActivity Kotlin wiring (Dart can't run Kotlin)

`flutter analyze` clean. `flutter test` → 902 pass.

## Not validated here

Kotlin compile + on-device 2-device behavioral confirm → CI / device track.

Verify: `grep -rn "unregisterPeer" android/app/src/main/kotlin` now shows callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)