### PR TITLE
fix(audio): route playout to the voice-call stream and off the MMAP path

### DIFF
--- a/android/app/src/main/cpp/audio_engine.cpp
+++ b/android/app/src/main/cpp/audio_engine.cpp
@@ -14,6 +14,7 @@
 
 #include "audio_config.h"
 #include "audio_mixer.h"
+#include "playback_stream_config.h"
 #include "resampler.h"
 #include "talking_event_queue.h"
 #include "vad_detector.h"
@@ -416,22 +417,24 @@ public:
             return false;
         }
 
+        // Playout config (Usage/ContentType/PerformanceMode/SharingMode) lives
+        // in playback_stream_config.h so a host test can pin it. In short:
+        // VoiceCommunication usage routes playout to STREAM_VOICE_CALL (the
+        // stream the volume keys control in MODE_IN_COMMUNICATION) and follows
+        // the comm-device route; None + Shared keep it off the MMAP fast path,
+        // which bypasses the speaker loudness DSP on devices that grant MMAP.
         oboe::AudioStreamBuilder playbackBuilder;
         playbackBuilder.setDirection(oboe::Direction::Output)
-            ->setPerformanceMode(oboe::PerformanceMode::LowLatency)
-            ->setSharingMode(oboe::SharingMode::Exclusive)
+            ->setUsage(audio_engine_config::kPlaybackUsage)
+            ->setContentType(audio_engine_config::kPlaybackContentType)
+            ->setPerformanceMode(audio_engine_config::kPlaybackPerformanceMode)
+            ->setSharingMode(audio_engine_config::kPlaybackSharingMode)
             ->setFormat(kFormat)
             ->setChannelCount(kChannelCount)
             ->setSampleRate(kSampleRate)
             ->setErrorCallback(errorCallback.get());
 
         result = playbackBuilder.openStream(playbackStream);
-        if (result != oboe::Result::OK) {
-            LOGE("Exclusive playback open failed (%s) — retrying Shared",
-                 oboe::convertToText(result));
-            playbackBuilder.setSharingMode(oboe::SharingMode::Shared);
-            result = playbackBuilder.openStream(playbackStream);
-        }
         if (result != oboe::Result::OK) {
             LOGE("Failed to create playback stream: %s",
                  oboe::convertToText(result));

--- a/android/app/src/main/cpp/playback_stream_config.h
+++ b/android/app/src/main/cpp/playback_stream_config.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// Output (playback) Oboe stream configuration, factored out of audio_engine.cpp
+// so it can be asserted by a host unit test. audio_engine.cpp itself is not
+// host-testable (opening an Oboe stream needs a device), but these enum choices
+// are pure data, and only <oboe/Definitions.h> — which is header-only — is
+// needed to pin them. See playback_stream_config_test.cpp.
+//
+// These values fix two on-device playout bugs that made incoming voice
+// near-inaudible:
+//
+//  1. Wrong volume stream. The app runs in MODE_IN_COMMUNICATION (so
+//     AudioManager.setCommunicationDevice can steer the route). Oboe's default
+//     output Usage is Media, which rides STREAM_MUSIC — but in communication
+//     mode the hardware volume keys control STREAM_VOICE_CALL. The playing
+//     stream was therefore un-raisable and sat quiet. Usage::VoiceCommunication
+//     (with ContentType::Speech) puts playout on STREAM_VOICE_CALL, so the
+//     volume keys control it and it follows the communication-device route.
+//
+//  2. MMAP bypasses the speaker DSP. A LowLatency + Exclusive output takes the
+//     MMAP fast path on devices that grant it (e.g. Pixel), which bypasses the
+//     platform speaker loudness/protection processing — the loudspeaker was
+//     near-silent on the Pixel while a non-MMAP device (moto) was loud.
+//     PerformanceMode::None + SharingMode::Shared keep playout on the normal
+//     mixer path so the speaker DSP applies. Output is write()-driven from the
+//     input callback, so dropping LowLatency does not change callback burst
+//     sizing.
+
+#include <oboe/Definitions.h>
+
+namespace audio_engine_config {
+
+inline constexpr oboe::Usage kPlaybackUsage = oboe::Usage::VoiceCommunication;
+inline constexpr oboe::ContentType kPlaybackContentType =
+    oboe::ContentType::Speech;
+inline constexpr oboe::PerformanceMode kPlaybackPerformanceMode =
+    oboe::PerformanceMode::None;
+inline constexpr oboe::SharingMode kPlaybackSharingMode =
+    oboe::SharingMode::Shared;
+
+}  // namespace audio_engine_config

--- a/scripts/run_native_cpp_tests.sh
+++ b/scripts/run_native_cpp_tests.sh
@@ -14,8 +14,10 @@ for required in \
     test/cpp/ring_buffer_test.cpp \
     test/cpp/opus_codec_test.cpp \
     test/cpp/vad_detector_test.cpp \
+    test/cpp/playback_stream_config_test.cpp \
     test/cpp/peer_audio_manager_test.cpp \
     android/app/src/main/cpp/audio_mixer.cpp \
+    android/app/src/main/cpp/playback_stream_config.h \
     android/app/src/main/cpp/talking_event_queue.h \
     android/app/src/main/cpp/ring_buffer.h \
     android/app/src/main/cpp/opus_codec.h \
@@ -85,6 +87,17 @@ ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
     test/cpp/vad_detector_test.cpp \
     -o build/cpp_test/vad_detector_test
 build/cpp_test/vad_detector_test
+
+# playback_stream_config_test pins the output Oboe stream config that fixes the
+# quiet-playout bug. Header-only: needs Oboe's (header-only) Definitions.h, no
+# Oboe library and no NDK.
+${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+    -I test/cpp \
+    -I android/app/src/main/cpp \
+    -I android/app/src/main/cpp/oboe/include \
+    test/cpp/playback_stream_config_test.cpp \
+    -o build/cpp_test/playback_stream_config_test
+build/cpp_test/playback_stream_config_test
 
 # opus_codec_test exercises OpusEncoder/OpusDecoder from opus_codec.cpp.
 # Requires libopus and pkg-config.

--- a/test/cpp/playback_stream_config_test.cpp
+++ b/test/cpp/playback_stream_config_test.cpp
@@ -1,0 +1,73 @@
+// Host-buildable regression guard for the output (playback) Oboe stream
+// configuration in playback_stream_config.h.
+//
+// audio_engine.cpp can't be host-tested (opening an Oboe stream needs a real
+// device), so the playout config it applies is factored into the header and
+// pinned here. <oboe/Definitions.h> is header-only, so the enum values compile
+// under a host g++ with no Oboe library or NDK.
+//
+// These exact values fix the "incoming voice too quiet / volume keys do
+// nothing" bug:
+//   - Usage::VoiceCommunication + ContentType::Speech put playout on
+//     STREAM_VOICE_CALL — the stream the hardware volume keys control while the
+//     app is in MODE_IN_COMMUNICATION — instead of the un-raisable STREAM_MUSIC
+//     that the default Media usage rode.
+//   - PerformanceMode::None + SharingMode::Shared keep playout off the MMAP
+//     fast path, which bypasses the speaker loudness/protection DSP on devices
+//     that grant MMAP (the loudspeaker was near-silent on a Pixel while a
+//     non-MMAP device was loud).
+// If playout is "optimized" back to LowLatency/Exclusive or loses the
+// VoiceCommunication usage, this test fails loudly.
+//
+// Compile (see scripts/run_native_cpp_tests.sh):
+//   g++ -std=c++17 -Wall -Wextra -I android/app/src/main/cpp
+//       -I android/app/src/main/cpp/oboe/include
+//       test/cpp/playback_stream_config_test.cpp
+//       -o build/cpp_test/playback_stream_config_test
+
+#include "playback_stream_config.h"
+
+#include <cassert>
+#include <iostream>
+
+#include <oboe/Definitions.h>
+
+namespace {
+
+void testPlayoutUsesVoiceCallStream() {
+    // STREAM_VOICE_CALL is the stream the volume keys control in
+    // MODE_IN_COMMUNICATION; Media usage rode STREAM_MUSIC, which the keys
+    // cannot touch in that mode, so playout was stuck quiet.
+    assert(audio_engine_config::kPlaybackUsage ==
+           oboe::Usage::VoiceCommunication);
+    assert(audio_engine_config::kPlaybackContentType ==
+           oboe::ContentType::Speech);
+}
+
+void testPlayoutAvoidsMmapFastPath() {
+    // LowLatency + Exclusive selects the MMAP path on devices that grant it,
+    // which bypasses the platform speaker loudness/protection DSP and makes the
+    // loudspeaker near-inaudible.
+    assert(audio_engine_config::kPlaybackPerformanceMode ==
+           oboe::PerformanceMode::None);
+    assert(audio_engine_config::kPlaybackSharingMode ==
+           oboe::SharingMode::Shared);
+    assert(audio_engine_config::kPlaybackPerformanceMode !=
+           oboe::PerformanceMode::LowLatency);
+    assert(audio_engine_config::kPlaybackSharingMode !=
+           oboe::SharingMode::Exclusive);
+}
+
+}  // namespace
+
+int main() {
+    try {
+        testPlayoutUsesVoiceCallStream();
+        testPlayoutAvoidsMmapFastPath();
+        std::cout << "All playback_stream_config tests passed!" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Problem

Incoming voice connected and was coherent, but came out **near-inaudible on the loudspeaker**. On a Pixel 10 Pro XL the only way to hear anything was to hold the earpiece to your ear or fall back to a Bluetooth headset; a moto g play on the same call was loud. Turning the volume up did nothing.

## Root cause

Two stacked problems in the Oboe **output** stream config (`audio_engine.cpp`):

1. **Wrong volume stream.** The app runs in `MODE_IN_COMMUNICATION` (so `AudioManager.setCommunicationDevice` can steer the route). Oboe's default output `Usage` is `Media`, which rides `STREAM_MUSIC` — but in communication mode the hardware volume keys control `STREAM_VOICE_CALL`. So the stream that was actually playing could not be turned up (raising it even reverted), and it sat mid-scale and quiet. Media usage also ignores `setCommunicationDevice` routing entirely.

2. **MMAP bypasses the speaker DSP.** A `LowLatency + Exclusive` output takes the **MMAP fast path** on devices that grant it (Pixel), which bypasses the platform speaker loudness/protection processing. That's why the Pixel loudspeaker was near-silent while the moto (no MMAP → normal mixer path) was loud.

## Fix

Configure playout for the voice path:

- `Usage::VoiceCommunication` + `ContentType::Speech` → playout rides `STREAM_VOICE_CALL` (volume-key controllable in comm mode) and follows the communication-device route.
- `PerformanceMode::None` + `SharingMode::Shared` → stays on the normal mixer path so the speaker DSP applies. Output is `write()`-driven from the input callback, so dropping `LowLatency` does not change callback burst sizing.

The four enums are factored into `playback_stream_config.h`.

## Test

`audio_engine.cpp` can't be host-tested (opening an Oboe stream needs a device), so the config is pinned by a new host test, `test/cpp/playback_stream_config_test.cpp`, wired into `scripts/run_native_cpp_tests.sh`. It asserts playout uses `VoiceCommunication`/`Speech` and is **not** `LowLatency`/`Exclusive` — a loud failure if anyone "optimizes" playout back onto the MMAP/Media path. Only Oboe's header-only `Definitions.h` is needed, no Oboe lib or NDK.

All native C++ host tests pass.

## Validation

On-device on a Pixel 10 Pro XL + moto g play: loudspeaker is now loud and the volume keys adjust it on both; audio stays coherent both directions (no regression to the drift fix in #477).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Consolidated audio playback settings for consistent voice communication handling, optimizing volume key behavior and preserving speaker audio processing.
  * Removed automatic fallback logic for audio mode switching.

* **Tests**
  * Added automated regression tests verifying audio configuration integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->