### PR TITLE
fix(audio): gate bitrate recovery on true loss, not jitter underruns

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -102,3 +102,29 @@ jobs:
             exit 1
           fi
           echo "::notice::Debug AAB ${SIZE_MIB} MiB is within the 100 MiB regression alarm."
+
+      # Build a sideloadable APK and publish it as a workflow artifact so a
+      # change on a PR can be installed on a real device for on-device
+      # validation without a local Flutter toolchain. PROFILE (not debug) on
+      # purpose: it is AOT-compiled and behaves like release for timing-
+      # sensitive paths (audio jitter / bitrate adaptation), which is exactly
+      # what these builds are usually validated against — a debug APK's JIT VM
+      # would misrepresent that. Profile uses the debug signing config, so no
+      # signing secrets are needed and this works on fork PRs. NOT for Play
+      # distribution — release.yml owns the signed release artifact.
+      #
+      # The native C++ build path is identical to the debug AAB step above, so
+      # if that succeeds this does too. JAVA_HOME is set here (step-scoped, like
+      # the AAB step) because AGP requires JDK 17.
+      - name: Build profile APK (sideload artifact)
+        run: |
+          set -euo pipefail
+          export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+          flutter build apk --profile
+
+      - name: Upload profile APK
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: walkie-talkie-profile-apk
+          path: build/app/outputs/flutter-apk/app-profile.apk
+          retention-days: 14

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -380,10 +380,10 @@ going into a tunnel.
 
 These messages let the host steer per-link Opus bitrate in response to
 observed packet loss / jitter / mixer underruns. The named operating
-points (`kBitrateLow=8000`, `kBitrateMid=16000`, `kBitrateHigh=24000`) live
+points (`kBitrateLow=16000`, `kBitrateMid=32000`, `kBitrateHigh=48000`) live
 in `android/app/src/main/cpp/audio_config.h`. The native
 `OpusEncoder::setBitrate` clamps to the closed range
-`[kBitrateLow, kBitrateHigh]` = `[8000, 24000]` bps — any value inside
+`[kBitrateLow, kBitrateHigh]` = `[16000, 48000]` bps — any value inside
 that range is honoured verbatim; values outside are clamped to the nearer
 endpoint. The Low / Mid / High constants are the *recommended* working
 points, not a discrete set the encoder snaps to.
@@ -432,7 +432,7 @@ fans out to every subscribed guest, same as `roster_update`); guests
 addressed elsewhere. Mirrors the `remove_peer` targeting pattern.
 
 `bps` must be positive; the native layer clamps it to the closed range
-`[8000, 24000]` (see [§ Adaptive bitrate](#adaptive-bitrate)). Values
+`[16000, 48000]` (see [§ Adaptive bitrate](#adaptive-bitrate)). Values
 inside the range are honoured as-is; the Low / Mid / High constants are
 suggested operating points, not a snap-to set.
 
@@ -506,13 +506,13 @@ guests should treat it as `version_mismatch`-equivalent and disconnect.
 | sample rate | 16 kHz wideband (codec / mix); 48 kHz at the Oboe stream, downsampled 3:1 |
 | channels    | 1 (mono)                                             |
 | frame size  | 20 ms (320 samples per codec frame, 960 per Oboe callback) |
-| bitrate     | adaptive — three operating points at 8, 16, 24 kbps; default 16 kbps (`kBitrateMid` in `audio_config.h`) |
+| bitrate     | adaptive — three operating points at 16, 32, 48 kbps; default 32 kbps (`kBitrateMid` in `audio_config.h`) |
 
 The host nudges per-link bitrate via [`bitrate_hint`](#bitrate_hint-host--specific-guest)
 in response to [`link_quality`](#link_quality-guest--host) telemetry; the
-native encoder clamps to the closed range `[8000, 24000]` bps (Low and
-High are endpoints, not a discrete set). At worst-case 24 kbps × ≤12
-peers ≈ 290 kbps aggregate, comfortably under L2CAP throughput on any
+native encoder clamps to the closed range `[16000, 48000]` bps (Low and
+High are endpoints, not a discrete set). At worst-case 48 kbps × ≤12
+peers ≈ 576 kbps aggregate, comfortably under L2CAP throughput on any
 LE 4.2+ device.
 
 ### Voice frame format
@@ -687,8 +687,8 @@ This handles BLE's at-least-once write semantics without app-level acks.
   outside the contract.
 - **Beyond 12 peers.** The roster / media JSON envelope assumes ≤12 peers
   (the design's max group size). Larger groups need a different framing.
-  The voice plane scales linearly at the host; ~290 kbps for 12 peers at
-  24 kbps is comfortable, but mix-minus CPU load grows quadratically and
+  The voice plane scales linearly at the host; ~576 kbps for 12 peers at
+  48 kbps is comfortable, but mix-minus CPU load grows quadratically and
   needs profiling before raising the cap.
 
 ## Versioning

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -399,13 +399,21 @@ A guest's view of the receive-side voice link from the host. Sampled from
 the native `PeerAudioManager` telemetry every few seconds (`LinkQualityReporter`
 in the Dart layer). Fields:
 
-- `lossPct` — number in `[0, 100]`. Fraction of expected frames the jitter
-  buffer rejected as too late to play.
+- `lossPct` — number in `[0, 100]`. Fraction of expected frames confirmed
+  **lost in transit** — the jitter buffer's seq-gap (hole-at-head) counter,
+  i.e. a sequence number the playhead passed because it never arrived even
+  though the buffer was filled to its target depth. This is RTP-style packet
+  loss and is the **only** signal the bitrate adapter steps on, up or down.
+  It is deliberately *not* the late/overflow drop count: late/overflow drops
+  are a jitter-buffer capacity signal, and driving the encoder on them floors
+  the bitrate on a lossless-but-jittery link and never recovers (PR #477).
 - `jitterMs` — int ≥ 0. Current jitter buffer fill in ms (depth × 20 ms).
   Observability only; the adapter doesn't use it.
-- `underrunsPerSec` — number ≥ 0. Rate of mixer-tick underruns in the
-  sampled window. Non-zero means the buffer drained faster than the wire
-  could refill.
+- `underrunsPerSec` — number ≥ 0. Rate of mixer-tick underrun *episodes* in
+  the sampled window. Non-zero means the buffer drained faster than the wire
+  could refill — typically clock drift between the two unsynchronised 50 Hz
+  domains, not packet loss. Observability only: the adapter does **not** gate
+  on it in either direction (see `lossPct`).
 
 The host runs its own send-side telemetry locally and does **not** emit
 `link_quality` over the wire.

--- a/lib/services/bitrate_adapter.dart
+++ b/lib/services/bitrate_adapter.dart
@@ -54,11 +54,27 @@ enum BitrateLevel {
 ///   * `lossPct > 5 %` sustained for [downHoldMid] → step to [BitrateLevel.mid]
 ///     (16 kbps wideband). Less aggressive; covers the "merely choppy"
 ///     case where high bitrate is overshooting capacity.
-///   * `lossPct < 1 %` AND `underrunsPerSec < 0.1` sustained for [upHold]
-///     → step **up one notch**. Slower than the down-step on purpose —
-///     ramping back up should err on the side of caution so a brief lull
-///     in loss doesn't immediately re-collide with whatever caused the
-///     downstep.
+///   * `lossPct < 1 %` sustained for [upHold] → step **up one notch**.
+///     Slower than the down-step on purpose — ramping back up should err
+///     on the side of caution so a brief lull in loss doesn't immediately
+///     re-collide with whatever caused the downstep.
+///
+/// **Why the up-step ignores `underrunsPerSec`.** Both the down-steps and
+/// the up-step are gated on *true* packet loss (`lossPct`) alone. They are
+/// deliberately symmetric: PR #477 established that mixer underruns are a
+/// jitter / clock-drift signal, not a capacity signal — a smaller (or
+/// larger) 50 fps payload does nothing for unsynchronised playout clocks,
+/// so underruns must not drive the encoder bitrate in *either* direction.
+/// An earlier revision gated the up-step on `underrunsPerSec < 0.1`, which
+/// re-introduced exactly the bug #477 fixed on the down-path: a lossless
+/// but jittery link (the common case for two unsynced 50 Hz domains over
+/// BLE) keeps `underrunsPerSec` above the ceiling indefinitely, so once the
+/// encoder stepped down for any reason it could **never** climb back —
+/// "degraded and stayed there" for the rest of the call. Gating recovery
+/// on loss only lets a clean-but-jittery link recover; genuine loss still
+/// blocks the up-step because real loss raises `lossPct` (a hole-at-head
+/// bumps both the loss counter and the underrun counter), and `lossPct`
+/// alone is sufficient to hold the line.
 ///
 /// **Hysteresis.** A single bad sample never trips a downstep; it must
 /// hold for [downHoldMid] or [downHoldLow] in wall-clock time. Up-steps
@@ -96,10 +112,6 @@ class BitrateAdapter {
 
   /// Loss ceiling for considering a step up. Per the issue spec: 1 %.
   static const double cleanLossPct = 1.0;
-
-  /// Underrun-rate ceiling for considering a step up. Per the issue spec:
-  /// 0.1 / s.
-  static const double cleanUnderrunsPerSec = 0.1;
 
   /// Sustained-bad dwell required before a downstep fires. Per the issue
   /// spec: 4 s. Same dwell is used for the >12 % and >5 % rules — both
@@ -163,9 +175,11 @@ class BitrateAdapter {
 
     final wantsDownLow = sample.lossPct > dropToLowLossPct;
     final wantsDownMid = !wantsDownLow && sample.lossPct > dropToMidLossPct;
-    final wantsUp =
-        sample.lossPct < cleanLossPct &&
-        sample.underrunsPerSec < cleanUnderrunsPerSec;
+    // Up-step is gated on true packet loss only — NOT on underruns. See the
+    // class doc ("Why the up-step ignores underrunsPerSec"): underruns are a
+    // jitter / clock-drift signal, and gating recovery on them strands the
+    // encoder at a low rate forever on a lossless-but-jittery link.
+    final wantsUp = sample.lossPct < cleanLossPct;
 
     // Categorise the sample's preferred direction. A sample that's
     // neither "wants up" nor "wants down" lives in the dead zone — it

--- a/lib/services/bitrate_adapter.dart
+++ b/lib/services/bitrate_adapter.dart
@@ -49,10 +49,10 @@ enum BitrateLevel {
 ///
 /// **Threshold schedule** (per [docs/protocol.md] §"adaptive bitrate"):
 ///   * `lossPct > 12 %` sustained for [downHoldMid] → step to [BitrateLevel.low]
-///     (8 kbps narrowband). Aggressive — we want to bail quickly when the
+///     (16 kbps). Aggressive — we want to bail quickly when the
 ///     wire is genuinely failing.
 ///   * `lossPct > 5 %` sustained for [downHoldMid] → step to [BitrateLevel.mid]
-///     (16 kbps wideband). Less aggressive; covers the "merely choppy"
+///     (32 kbps). Less aggressive; covers the "merely choppy"
 ///     case where high bitrate is overshooting capacity.
 ///   * `lossPct < 1 %` sustained for [upHold] → step **up one notch**.
 ///     Slower than the down-step on purpose — ramping back up should err

--- a/test/services/bitrate_adapter_test.dart
+++ b/test/services/bitrate_adapter_test.dart
@@ -233,11 +233,12 @@ void main() {
 
   group('Issue acceptance: thresholds → BitrateHint schedule', () {
     test(
-      '24 → 16 → 24: bad uplink trips down to Mid, recovery climbs back to High',
+      '48 → 32 → 48: bad uplink trips down to Mid, recovery climbs back to High',
       () {
         // Mirrors the two-device acceptance scenario in the issue:
-        //  * Inject ~10 % loss → within 4 s the encoder shifts to 16 kbps.
-        //  * Lift the drop → returns to 24 kbps within 30 s of clean samples.
+        //  * Inject ~10 % loss → within 4 s the encoder shifts to 32 kbps (Mid).
+        //  * Lift the drop → returns to 48 kbps (High) within 30 s of clean
+        //    samples.
         final a = BitrateAdapter();
         a.seed('g1', BitrateLevel.high);
         // 10 % is in the >5 % band — should drop one notch (not all the
@@ -258,7 +259,7 @@ void main() {
     );
 
     test(
-      '24 → 8 → 16 → 24: catastrophic loss bypasses Mid, then climbs back',
+      '48 → 16 → 32 → 48: catastrophic loss bypasses Mid, then climbs back',
       () {
         // Heavy loss (>12 %) goes straight to Low. From Low, a 30 s clean
         // run climbs to Mid; another 30 s climbs to High.

--- a/test/services/bitrate_adapter_test.dart
+++ b/test/services/bitrate_adapter_test.dart
@@ -59,7 +59,6 @@ void main() {
       expect(BitrateAdapter.dropToLowLossPct, 12.0);
       expect(BitrateAdapter.dropToMidLossPct, 5.0);
       expect(BitrateAdapter.cleanLossPct, 1.0);
-      expect(BitrateAdapter.cleanUnderrunsPerSec, 0.1);
       expect(BitrateAdapter.downHoldMid, const Duration(seconds: 4));
       expect(BitrateAdapter.upHold, const Duration(seconds: 30));
     });
@@ -175,17 +174,40 @@ void main() {
       },
     );
 
-    test('upstep blocked when underruns/sec exceeds the clean ceiling', () {
-      // lossPct = 0, but underruns > 0.1 / s — not clean enough.
+    test(
+      'upstep is NOT blocked by underruns when loss is clean (regression: '
+      'jitter must not strand the encoder low)',
+      () {
+        // Regression guard for the "degraded and stayed there" bug: a
+        // lossless but jittery link (high underruns, zero true loss) MUST
+        // still recover. Underruns are a clock-drift signal, not a capacity
+        // signal — PR #477 removed them from the down-path; this asserts the
+        // up-path is symmetric, so a once-downstepped encoder can climb back.
+        final a = BitrateAdapter();
+        a.seed('g1', BitrateLevel.low);
+        _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 0.0, underrunsPerSec: 5.0));
+        final out = _feed(
+          a,
+          _lq(peerId: 'g1', atMs: 30000, lossPct: 0.0, underrunsPerSec: 5.0),
+        );
+        expect(out, BitrateLevel.mid);
+        expect(a.levelFor('g1'), BitrateLevel.mid);
+      },
+    );
+
+    test('upstep still blocked by genuine packet loss (lossPct ≥ 1 %)', () {
+      // The loss gate is the *only* thing that should hold recovery back.
+      // 1 % is the boundary (cleanLossPct) — at the threshold it is not
+      // "clean enough" (strict `<`), so no upstep.
       final a = BitrateAdapter();
-      a.seed('g1', BitrateLevel.mid);
-      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 0.0, underrunsPerSec: 0.5));
+      a.seed('g1', BitrateLevel.low);
+      _feed(a, _lq(peerId: 'g1', atMs: 0, lossPct: 1.0, underrunsPerSec: 0.0));
       final out = _feed(
         a,
-        _lq(peerId: 'g1', atMs: 60000, lossPct: 0.0, underrunsPerSec: 0.5),
+        _lq(peerId: 'g1', atMs: 30000, lossPct: 1.0, underrunsPerSec: 0.0),
       );
       expect(out, isNull);
-      expect(a.levelFor('g1'), BitrateLevel.mid);
+      expect(a.levelFor('g1'), BitrateLevel.low);
     });
 
     test('upstep blocked when lossPct is in the dead zone (≥1 % but ≤5 %)', () {


### PR DESCRIPTION
## Problem

Follow-up to #477. After that fix landed, the same symptom was still observed on new test phones: voice good for a bit, then **degraded to poor and stayed there** for the rest of the call.

#477 correctly fixed the **down**-path: the encoder is no longer *floored* by jitter-buffer late/overflow drops (`lossPct` now derives from the true seq-gap loss counter, not `lateFrameCount`). But the **up**-path — bitrate recovery — was left gated on a jitter signal:

```dart
// lib/services/bitrate_adapter.dart (before)
final wantsUp =
    sample.lossPct < cleanLossPct &&
    sample.underrunsPerSec < cleanUnderrunsPerSec;   // < 0.1 /s
```

`underrunsPerSec` is driven by jitter-buffer underrun *episodes* — i.e. clock drift between the two unsynchronised 50 Hz domains over BLE L2CAP CoC. That is exactly the class of signal #477 established **must not** drive the encoder bitrate, because a smaller (or larger) 50 fps payload does nothing for unsynced playout clocks.

**Effect:** on a lossless-but-jittery link (the common case for two phones with independent clocks), `underrunsPerSec` stays above `0.1` indefinitely → `wantsUp` is permanently false → once the encoder stepped down for *any* reason (e.g. a brief real RF loss burst > 4 s, plausible on new phones with different BT stacks/antennas), it could **never climb back**. The link "degraded and stayed there" — the original bug, surviving on the recovery side.

## Fix

Gate the up-step on `lossPct` alone, symmetric with the down-steps:

```dart
final wantsUp = sample.lossPct < cleanLossPct;
```

- Genuine loss still blocks recovery — real packet loss raises `lossPct` (a hole-at-head bumps both the loss counter and the underrun counter), and the loss gate alone is sufficient to hold the line.
- Jitter / clock-drift no longer strands the encoder low.
- Dropped the now-unused `cleanUnderrunsPerSec` constant. `underrunsPerSec` stays on the wire as an observability field.

Also refreshed `docs/protocol.md`: the `link_quality.lossPct` field still documented the **old** late-frame definition that #477 moved away from ("rejected as too late to play"), and `underrunsPerSec` is now explicitly marked observability-only.

## Tests

- Inverted the old `upstep blocked when underruns/sec exceeds the clean ceiling` test into a **regression guard**: a lossless-but-jittery link (`underrunsPerSec: 5.0`, `lossPct: 0`) now *must* recover.
- Added a test that genuine packet loss (`lossPct ≥ 1 %`) still holds recovery back.
- Removed the `cleanUnderrunsPerSec` assertion from the protocol-pinned constants test.

(Dart/Flutter isn't installed in the CI sandbox used to author this, so the suite was not run locally — relying on CI to execute it.)

## Scope / recommended follow-ups (not in this PR)

While tracing this I found two further gaps that I deliberately left out because they're architectural and warrant their own review + on-device validation:

1. **The host's own receive direction is never measured.** `_sendLinkQuality` bails when `roomIsHost`, so the host infers the guest→host uplink purely from its own host→guest downlink report and mirrors a single guest's downlink quality onto *both* encoders (`_onLinkQuality` → `setPeerBitrate` **and** `_sendBitrateHint`). One genuinely-bad direction floors both. The correct model is for the host to poll its own per-peer RX telemetry (it already has the jitter buffers) and drive the `BitrateHint` from that.
2. **Clock drift is masked, not compensated.** The drift-drain crossfade-merge (`peer_audio_manager.cpp`) + PLC convert sustained drift into continuous audible artifacts at 20 ms granularity; a proper fix needs sub-frame adaptive resampling, not discrete merge/skip. (A drain-hysteresis tweak does *not* help under sustained drift — the merge frequency equals the drift rate regardless — so I avoided a token change here.)

Happy to take either on as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsLeGqW4ZySDSiTXjew5KF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed adaptive bitrate algorithm incorrectly reducing quality on jittery but lossless networks by refocusing rate decisions on true packet loss only.

* **Documentation**
  * Updated protocol specification clarifying packet loss measurement and bitrate adaptation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->