### PR TITLE
fix(audio): catch up on recovery instead of replaying a multi-second backlog

### DIFF
--- a/android/app/src/main/cpp/audio_config.h
+++ b/android/app/src/main/cpp/audio_config.h
@@ -99,6 +99,25 @@ constexpr size_t kJitterAdaptIntervalTicks = 50;
 // buffer right back into the ground.
 constexpr size_t kJitterShrinkAfterStableTicks = 500;
 
+// Playout anti-bloat (latency catch-up). The per-device mixer ring is the
+// rendezvous between the producer (decode / mic feed, ~50 Hz on a steady_clock)
+// and the consumer (the Oboe playout callback, on the audio *hardware* clock).
+// Those two clocks are not synchronised, so left unbounded the ring drifts
+// toward full (its physical capacity is ~680 ms at the codec rate) and *stays*
+// there — pinning everything you hear that far behind real time, and on a link
+// stall it then faithfully replays the stale backlog instead of catching up.
+//
+// The playout consumer caps the ring: before mixing, it drops the oldest
+// samples so no more than this many remain, always favouring the freshest
+// audio. A small drift trims a few samples per callback; a big burst (e.g. a
+// kernel L2CAP TX backlog draining all at once on recovery) is dropped in one
+// shot — so this single mechanism is both the continuous cap and the hard
+// catch-up. 3 frames = 60 ms: enough slack to ride out callback jitter without
+// underrunning, far below the ring's physical capacity.
+constexpr size_t kPlayoutMaxRingFillFrames = 3;
+constexpr size_t kPlayoutMaxRingFillSamples =
+    kPlayoutMaxRingFillFrames * static_cast<size_t>(kCodecFrameSize);  // 1440
+
 // Mixer tick.
 constexpr int kMixerTickIntervalMs = kFrameDurationMs;
 

--- a/android/app/src/main/cpp/audio_mixer.cpp
+++ b/android/app/src/main/cpp/audio_mixer.cpp
@@ -157,6 +157,16 @@ void AudioMixer::getMixedAudioForDevice(int deviceId, int16_t* outputBuffer, int
         const auto& [id, device] = deviceSnapshot[d];
         if (!device) continue;
 
+        // Latency catch-up: fast-forward past any backlog so we mix the
+        // freshest audio instead of replaying a ring that drifted full (see
+        // audio_config::kPlayoutMaxRingFillSamples). Consumer-side and so
+        // SPSC-safe. The cap is widened to the current read size so we never
+        // drop samples this very call is about to consume.
+        const size_t fillCap = std::max(
+            audio_config::kPlayoutMaxRingFillSamples,
+            static_cast<size_t>(numFrames));
+        device->ringBuffer.dropOldestToFill(fillCap);
+
         // Skip mixing if the device is muted, but read to discard samples so they don't accumulate
         if (device->muted.load(std::memory_order_relaxed)) {
             device->ringBuffer.read(tempMix, std::min(static_cast<size_t>(numFrames), static_cast<size_t>(kMaxFrames)));

--- a/android/app/src/main/cpp/audio_mixer.cpp
+++ b/android/app/src/main/cpp/audio_mixer.cpp
@@ -157,24 +157,29 @@ void AudioMixer::getMixedAudioForDevice(int deviceId, int16_t* outputBuffer, int
         const auto& [id, device] = deviceSnapshot[d];
         if (!device) continue;
 
+        // The ring read is clamped to the scratch size (kMaxFrames), so use
+        // that same clamped count for the latency cap. Widening it to the raw
+        // numFrames would loosen the cap under burst callbacks where
+        // numFrames > kMaxFrames (the read can only drain kMaxFrames, leaving
+        // the excess as backlog). max() with the read count keeps the cap from
+        // ever dropping samples this very call is about to consume.
+        const size_t readCount = std::min(static_cast<size_t>(numFrames),
+                                          static_cast<size_t>(kMaxFrames));
         // Latency catch-up: fast-forward past any backlog so we mix the
         // freshest audio instead of replaying a ring that drifted full (see
-        // audio_config::kPlayoutMaxRingFillSamples). Consumer-side and so
-        // SPSC-safe. The cap is widened to the current read size so we never
-        // drop samples this very call is about to consume.
-        const size_t fillCap = std::max(
-            audio_config::kPlayoutMaxRingFillSamples,
-            static_cast<size_t>(numFrames));
+        // audio_config::kPlayoutMaxRingFillSamples). Consumer-side, SPSC-safe.
+        const size_t fillCap =
+            std::max(audio_config::kPlayoutMaxRingFillSamples, readCount);
         device->ringBuffer.dropOldestToFill(fillCap);
 
         // Skip mixing if the device is muted, but read to discard samples so they don't accumulate
         if (device->muted.load(std::memory_order_relaxed)) {
-            device->ringBuffer.read(tempMix, std::min(static_cast<size_t>(numFrames), static_cast<size_t>(kMaxFrames)));
+            device->ringBuffer.read(tempMix, readCount);
             continue;
         }
 
         // Use read() to consume the data from the ring buffer
-        size_t samplesRead = device->ringBuffer.read(tempMix, std::min(static_cast<size_t>(numFrames), static_cast<size_t>(kMaxFrames)));
+        size_t samplesRead = device->ringBuffer.read(tempMix, readCount);
         if (samplesRead > 0) {
             float vol = device->volume.load(std::memory_order_relaxed);
 

--- a/android/app/src/main/cpp/audio_mixer.h
+++ b/android/app/src/main/cpp/audio_mixer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <cstring>
 #include <algorithm>
+#include "audio_config.h"
 #include "ring_buffer.h"
 
 // Per-device audio buffer with lock-free ring buffer for real-time safety.

--- a/android/app/src/main/cpp/jitter_buffer.cpp
+++ b/android/app/src/main/cpp/jitter_buffer.cpp
@@ -53,11 +53,17 @@ bool JitterBuffer::push(uint32_t seq, const uint8_t* data, size_t size) {
         }
         const uint32_t droppedSeq = frames_.front().seq;
         frames_.pop_front();
-        // The evicted frame will never play; advance the playhead just past it
-        // so pop()'s hole-at-head check doesn't later miscount the deliberate
-        // skip as confirmed network loss.
-        if (playheadInit_ && !seqLess(droppedSeq, playhead_)) {
-            playhead_ = droppedSeq + 1;
+        // Only advance the playhead when the evicted frame is exactly the one
+        // we were about to play — then the deliberate skip isn't miscounted as
+        // a hole-at-head (network loss). When there is already a hole at the
+        // head (droppedSeq > playhead_), the intervening seqs are genuine
+        // losses that pop() must still count and PLC-pace; advancing the
+        // playhead over them would hide real loss from the bitrate adapter.
+        // (front is never behind the playhead — arrivals before it are rejected
+        // as late — so droppedSeq >= playhead_ always; equality is the
+        // contiguous case.)
+        if (playheadInit_ && droppedSeq == playhead_) {
+            ++playhead_;
         }
         // pop_front() invalidated `it`; recompute the insertion point.
         it = frames_.begin();

--- a/android/app/src/main/cpp/jitter_buffer.cpp
+++ b/android/app/src/main/cpp/jitter_buffer.cpp
@@ -34,16 +34,36 @@ bool JitterBuffer::push(uint32_t seq, const uint8_t* data, size_t size) {
         return false;
     }
 
-    // Bounded memory + bounded playout latency. If we're already at the cap,
-    // the consumer is stalled (e.g. mixer tick stuck) or the producer is
-    // flooding (out-of-spec peer). Drop the new frame and count it: the
-    // link-quality reporter sees the overflow and may decide to step bitrate
-    // down. We could equivalently drop the oldest queued frame, but dropping
-    // the newest preserves decoder context (PLC works better when contiguous
-    // audio is preserved) and keeps the playhead's chronology intact.
+    // Bounded memory + bounded playout latency. At the cap, the consumer is
+    // behind (clock drift, a stalled tick) or the producer is bursting (e.g. a
+    // kernel L2CAP TX backlog draining all at once on link recovery). Favour
+    // the freshest audio: evict the OLDEST queued frame to admit this newer
+    // arrival, rather than rejecting the arrival and pinning playout at the
+    // stale head. lateCount_ still records the overflow for telemetry.
+    //
+    // Exception: if the arrival is itself older than the oldest queued frame
+    // (seqLess(seq, front)), IT is the stale one — drop it and keep what we
+    // have. (We already rejected frames behind the playhead above; this guards
+    // the narrower "newer than playhead but older than everything buffered"
+    // case.)
     if (frames_.size() >= audio_config::kJitterMaxDepth) {
         ++lateCount_;
-        return false;
+        if (seqLess(seq, frames_.front().seq)) {
+            return false;
+        }
+        const uint32_t droppedSeq = frames_.front().seq;
+        frames_.pop_front();
+        // The evicted frame will never play; advance the playhead just past it
+        // so pop()'s hole-at-head check doesn't later miscount the deliberate
+        // skip as confirmed network loss.
+        if (playheadInit_ && !seqLess(droppedSeq, playhead_)) {
+            playhead_ = droppedSeq + 1;
+        }
+        // pop_front() invalidated `it`; recompute the insertion point.
+        it = frames_.begin();
+        while (it != frames_.end() && seqLess(it->seq, seq)) {
+            ++it;
+        }
     }
 
     Frame f;

--- a/android/app/src/main/cpp/jitter_buffer.h
+++ b/android/app/src/main/cpp/jitter_buffer.h
@@ -41,9 +41,14 @@
 // one underrun (not one per tick), so an idle peer or a long talkspurt gap
 // doesn't ratchet target depth upward in the absence of real network jitter.
 //
-// **Bounded memory.** `push()` enforces `kJitterMaxDepth`: if the buffer is
-// already at the cap, the new frame is dropped (with a `lateFrameCount` bump
-// for telemetry). This caps both memory and worst-case playout latency.
+// **Bounded memory + freshness bias.** `push()` enforces `kJitterMaxDepth`:
+// at the cap it evicts the OLDEST queued frame to admit a newer arrival
+// (advancing the playhead past the dropped seq so the skip isn't miscounted
+// as loss), with a `lateFrameCount` bump for telemetry. An arrival older than
+// everything queued is itself dropped instead. This caps memory and worst-case
+// playout latency *and* biases the buffer toward the freshest audio, so a
+// burst (e.g. a TX backlog draining at once on recovery) catches up rather
+// than replaying stale frames at the head.
 //
 // **Threading.** This class is **not** thread-safe on its own. The caller
 // must serialize all `push`/`pop`/`popAny`/`tick`/`reset` calls — typically
@@ -70,9 +75,12 @@ public:
     //   - exact duplicate of an already-queued seq (first arrival wins; not
     //     counted as late, since this is a transport retransmit, not actual
     //     packet ordering trouble),
-    //   - buffer already at `kJitterMaxDepth` (counts toward `lateFrameCount`
-    //     so the link-quality reporter sees the overflow as a sustained
-    //     mismatch between produce and consume rates).
+    //   - buffer already at `kJitterMaxDepth` AND this seq is older than the
+    //     oldest queued frame (counts toward `lateFrameCount`). A *newer*
+    //     arrival at the cap is instead accepted by evicting the oldest queued
+    //     frame — see the freshness-bias note in the class comment — so the
+    //     `lateFrameCount` bump there flags the overflow without dropping the
+    //     fresh audio.
     bool push(uint32_t seq, const uint8_t* data, size_t size);
 
     // Pop the next in-order frame for playback. Returns nullopt and

--- a/android/app/src/main/cpp/ring_buffer.h
+++ b/android/app/src/main/cpp/ring_buffer.h
@@ -73,6 +73,29 @@ public:
         return toRead;
     }
 
+    // Consumer-side latency cap: drop the oldest samples so that at most
+    // `maxFill` remain available to read. Returns the number dropped.
+    //
+    // Like read(), this only advances readIndex and never touches writeIndex,
+    // so it stays strictly within the SPSC contract — only the single consumer
+    // may call it. Used by the playout mixer to "fast-forward" past an
+    // accumulated backlog (clock drift between producer and consumer, or a
+    // burst draining all at once after a link stall) rather than replaying
+    // stale audio. A no-op when the fill is already at or below `maxFill`.
+    size_t dropOldestToFill(size_t maxFill) {
+        size_t readPos = readIndex.load(std::memory_order_relaxed);
+        size_t writePos = writeIndex.load(std::memory_order_acquire);
+
+        size_t available = availableToRead(readPos, writePos);
+        if (available <= maxFill) {
+            return 0;
+        }
+        size_t toDrop = available - maxFill;
+        size_t newReadPos = (readPos + toDrop) % Capacity;
+        readIndex.store(newReadPos, std::memory_order_release);
+        return toDrop;
+    }
+
     // Peek at samples without consuming them. Returns number of samples copied.
     size_t peek(T* output, size_t count) const {
         size_t readPos = readIndex.load(std::memory_order_relaxed);

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/L2capVoiceTransport.kt
@@ -64,6 +64,24 @@ class L2capVoiceTransport(
          */
         const val SEND_QUEUE_CAPACITY = 6
 
+        /**
+         * Freshness budget for a queued frame. Voice is real-time: a frame
+         * that has waited longer than this before the writer could put it on
+         * the wire is already stale, and writing it only deepens the latency
+         * the listener hears. The writer drops such frames instead.
+         *
+         * This is the sender-side half of the end-to-end "favour the freshest
+         * audio" policy (the receiver caps its jitter buffer + playout ring the
+         * same way). It matters because the bottleneck is usually *below* this
+         * shallow app queue: once the kernel/controller L2CAP TX buffer backs
+         * up, `OutputStream.write()` blocks, queued frames age past this budget,
+         * and we shed them rather than letting the backlog grow unbounded.
+         * 200 ms ≈ 10 frames: comfortably past the [SEND_QUEUE_CAPACITY] (120
+         * ms) so a healthy link never trips it, tight enough that a congested
+         * one can't pin playout seconds stale.
+         */
+        const val STALE_FRAME_BUDGET_MS = 200L
+
         /** Length-prefix size: 2 bytes big-endian. */
         const val LENGTH_PREFIX_SIZE = 2
 
@@ -86,13 +104,20 @@ class L2capVoiceTransport(
      */
     private class SocketIo(
         val socket: BluetoothSocket,
-        val sendQueue: LinkedBlockingQueue<ByteArray>,
+        val sendQueue: LinkedBlockingQueue<QueuedFrame>,
         var recvThread: Thread? = null,
         var writerThread: Thread? = null,
     )
 
+    /**
+     * A frame waiting on the send queue, stamped with the monotonic time it was
+     * enqueued so the writer can shed it if it goes stale before reaching the
+     * wire (see [STALE_FRAME_BUDGET_MS]).
+     */
+    private class QueuedFrame(val bytes: ByteArray, val enqueuedNanos: Long)
+
     /** Sentinel pushed onto the send queue to terminate the writer thread. */
-    private val shutdownSentinel = ByteArray(0)
+    private val shutdownSentinel = QueuedFrame(ByteArray(0), 0L)
 
     // Host-side: server socket + accepted client sockets
     private var serverSocket: android.bluetooth.BluetoothServerSocket? = null
@@ -265,13 +290,28 @@ class L2capVoiceTransport(
             return
         }
         var sent = 0L
+        var droppedStale = 0L
         try {
             while (true) {
-                val frame = io.sendQueue.take()
-                if (frame === shutdownSentinel) break
+                val queued = io.sendQueue.take()
+                if (queued === shutdownSentinel) break
+                val frame = queued.bytes
                 if (frame.isEmpty()) continue
                 if (frame.size > MAX_FRAME_SIZE) {
                     Log.w(TAG, "Dropping oversized frame (${frame.size}B) for $addr")
+                    continue
+                }
+                // Favour the freshest audio: if this frame waited past the
+                // budget (the link couldn't drain it in time), drop it rather
+                // than writing seconds-old audio into the kernel L2CAP TX
+                // buffer — which we can neither flush nor drain. This is what
+                // gives the otherwise-reliable, ordered CoC stream UDP-like
+                // "shed late packets" behaviour at the app layer.
+                if (isFrameStale(System.nanoTime() - queued.enqueuedNanos,
+                                 STALE_FRAME_BUDGET_MS)) {
+                    if (++droppedStale % 50L == 0L) {
+                        Log.i(TAG, "VOICE-DIAG tx $addr dropped $droppedStale stale frames")
+                    }
                     continue
                 }
                 try {
@@ -355,7 +395,8 @@ class L2capVoiceTransport(
      */
     private fun enqueueFrame(io: SocketIo, frame: ByteArray) {
         if (frame.isEmpty()) return
-        while (!io.sendQueue.offer(frame)) {
+        val queued = QueuedFrame(frame, System.nanoTime())
+        while (!io.sendQueue.offer(queued)) {
             io.sendQueue.poll() // drop oldest, retry the offer
         }
     }
@@ -437,6 +478,15 @@ class L2capVoiceTransport(
     fun getConnectedClients(): List<String> =
         synchronized(clientSockets) { clientSockets.keys.toList() }
 }
+
+/**
+ * True if a frame that has waited [ageNanos] on the send queue has exceeded
+ * the [budgetMs] freshness budget and should be dropped rather than written.
+ * Pulled out as a pure function so the writer's drop decision is unit-testable
+ * without standing up real Bluetooth sockets and threads.
+ */
+internal fun isFrameStale(ageNanos: Long, budgetMs: Long): Boolean =
+    ageNanos > budgetMs * 1_000_000L
 
 // ── Framing helpers (package-private for unit tests) ───────────────────────
 

--- a/android/app/src/test/kotlin/com/elodin/walkie_talkie/L2capFramingTest.kt
+++ b/android/app/src/test/kotlin/com/elodin/walkie_talkie/L2capFramingTest.kt
@@ -116,6 +116,30 @@ class L2capFramingTest {
     }
 
     /**
+     * The writer's freshness gate: a frame whose queue wait exceeds the budget
+     * is stale and must be dropped; one within budget is kept. Boundary is
+     * exclusive (exactly-at-budget is still fresh) to match the `>` in
+     * [isFrameStale].
+     */
+    @Test
+    fun staleFrameDetection() {
+        val budgetMs = L2capVoiceTransport.STALE_FRAME_BUDGET_MS
+        val budgetNanos = budgetMs * 1_000_000L
+        // Fresh: well under budget.
+        assertTrue("a just-enqueued frame is fresh", !isFrameStale(0L, budgetMs))
+        assertTrue("half-budget is fresh", !isFrameStale(budgetNanos / 2, budgetMs))
+        // Exactly at the budget is still fresh (strict greater-than).
+        assertTrue("exactly-at-budget is fresh", !isFrameStale(budgetNanos, budgetMs))
+        // One nanosecond over is stale.
+        assertTrue("one ns over budget is stale", isFrameStale(budgetNanos + 1, budgetMs))
+        // Multi-second backlog is unambiguously stale.
+        assertTrue(
+            "a 2 s-old frame is stale",
+            isFrameStale(2_000L * 1_000_000L, budgetMs),
+        )
+    }
+
+    /**
      * The contention test that issue #101 calls out as the missing acceptance
      * criterion: many concurrent producers all push frames into one queue,
      * a single drainer thread writes them framed onto a pipe, and the

--- a/test/cpp/jitter_buffer_test.cpp
+++ b/test/cpp/jitter_buffer_test.cpp
@@ -488,6 +488,53 @@ void testTargetDepthCapsAtMaxTarget() {
     std::cout << "Test Target Depth Caps At Max Target: PASSED" << std::endl;
 }
 
+// Eviction at the cap must not paper over a pre-existing hole-at-head: the
+// genuinely-missing seqs ahead of the playhead stay counted as loss (and
+// PLC-paced); only an eviction of the exact playhead frame advances it. This is
+// the case the always-advance form silently swallowed (PR #481 review).
+void testEvictionPreservesHoleAtHeadLoss() {
+    JitterBuffer jb;
+    const uint8_t data[1] = {0x42};
+
+    // Drain a contiguous run so the playhead sits at 103 with an empty buffer.
+    // popAny() (not pop()) so the drain doesn't stall on the target-depth
+    // underrun gate once the buffer dips below kJitterInitialDepth.
+    seedAtDepth(jb, 100, audio_config::kJitterInitialDepth);  // 100,101,102
+    for (int i = 0; i < 3; ++i) {
+        auto f = jb.popAny();
+        assert(f.has_value());
+    }
+    assert(jb.playhead() == 103);
+
+    // Open a 5-seq hole at the head (103..107 never arrive) and fill to the cap
+    // with 108..(108+max-1).
+    for (size_t i = 0; i < audio_config::kJitterMaxDepth; ++i) {
+        assert(jb.push(static_cast<uint32_t>(108 + i), data, 1));
+    }
+    assert(jb.currentDepth() == audio_config::kJitterMaxDepth);
+    assert(jb.playhead() == 103);  // hole still open
+    const size_t preLost = jb.lostFrameCount();
+
+    // A newer arrival at the cap evicts the oldest (108). Because 108 != the
+    // playhead (103), the playhead must NOT jump — the 103..107 losses are real.
+    assert(jb.push(static_cast<uint32_t>(108 + audio_config::kJitterMaxDepth),
+                   data, 1));
+    assert(jb.playhead() == 103);  // regression guard: not advanced past the hole
+
+    // Drain the hole: 103..107 are true losses (5), then 108 is now missing too
+    // (we evicted it) for 1 more, before 109 finally plays.
+    for (int i = 0; i < 6; ++i) {
+        assert(!jb.pop().has_value());  // hole-at-head -> PLC, playhead++
+    }
+    auto first = jb.pop();
+    assert(first.has_value() && first->seq == 109);
+    // All six skipped seqs counted as loss (the 5 real holes are NOT hidden).
+    assert(jb.lostFrameCount() == preLost + 6);
+
+    std::cout << "Test Eviction Preserves Hole-At-Head Loss: PASSED"
+              << std::endl;
+}
+
 }  // namespace
 
 int main() {
@@ -497,6 +544,7 @@ int main() {
         testHoleAtHeadProducesPLC();
         testMultiFrameHoleProducesContiguousPLC();
         testPushCapsAtMaxDepth();
+        testEvictionPreservesHoleAtHeadLoss();
         testNormalFlowAfterFilling();
         testLateFrameDropped();
         testDuplicateRejected();

--- a/test/cpp/jitter_buffer_test.cpp
+++ b/test/cpp/jitter_buffer_test.cpp
@@ -156,8 +156,11 @@ void testMultiFrameHoleProducesContiguousPLC() {
               << std::endl;
 }
 
-// push() must enforce kJitterMaxDepth. A stalled consumer or flooding
-// producer can't grow the buffer without bound.
+// push() keeps depth <= kJitterMaxDepth. At the cap a *newer* arrival is
+// admitted by evicting the oldest queued frame (freshness bias) — depth stays
+// pinned at the cap and the overflow is recorded in lateFrameCount, but the
+// fresh audio is kept rather than rejected. The eviction must not be miscounted
+// as network loss (lostFrameCount).
 void testPushCapsAtMaxDepth() {
     JitterBuffer jb;
     const uint8_t data[1] = {0x42};
@@ -168,16 +171,25 @@ void testPushCapsAtMaxDepth() {
     }
     assert(jb.currentDepth() == audio_config::kJitterMaxDepth);
 
-    // Next push must be rejected (counts as late so telemetry sees the
-    // overflow signal).
+    // A newer arrival at the cap is accepted by evicting the oldest (seq 100).
     bool ok = jb.push(
         static_cast<uint32_t>(100 + audio_config::kJitterMaxDepth),
         data, 1);
-    assert(!ok);
-    assert(jb.currentDepth() == audio_config::kJitterMaxDepth);
+    assert(ok);
+    assert(jb.currentDepth() == audio_config::kJitterMaxDepth);  // still capped
     assert(jb.lateFrameCount() == 1);
+    assert(jb.lostFrameCount() == 0);  // eviction is not network loss
 
-    std::cout << "Test Push Caps At Max Depth: PASSED" << std::endl;
+    // The freshest audio survived: seq 100 was evicted, so the first frames to
+    // pop are 101, 102, … contiguously (no hole-at-head from the skip).
+    auto f1 = jb.pop();
+    assert(f1.has_value() && f1->seq == 101);
+    auto f2 = jb.pop();
+    assert(f2.has_value() && f2->seq == 102);
+    assert(jb.lostFrameCount() == 0);
+
+    std::cout << "Test Push Caps At Max Depth (favor-fresh evict): PASSED"
+              << std::endl;
 }
 
 void testNormalFlowAfterFilling() {

--- a/test/cpp/ring_buffer_test.cpp
+++ b/test/cpp/ring_buffer_test.cpp
@@ -169,6 +169,62 @@ void testAvailableToWriteAccountsForData() {
     std::cout << "Test AvailableToWrite Accounts For Data: PASSED" << std::endl;
 }
 
+// ── dropOldestToFill: consumer-side latency cap ───────────────────────────────
+
+void testDropOldestToFillNoOpWhenShallow() {
+    RingBuffer<int16_t, 32> rb;
+    int16_t in[4] = {1, 2, 3, 4};
+    rb.write(in, 4);
+    // Already at/below the cap — nothing to drop.
+    CHECK(rb.dropOldestToFill(4) == 0);
+    CHECK(rb.dropOldestToFill(10) == 0);
+    CHECK(rb.availableToRead() == 4);
+    std::cout << "Test dropOldestToFill No-Op When Shallow: PASSED" << std::endl;
+}
+
+void testDropOldestToFillDropsOldestAndKeepsFreshest() {
+    RingBuffer<int16_t, 32> rb;
+    int16_t in[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+    rb.write(in, 8);
+    // Cap to 3: drop the 5 oldest (1..5), keep the freshest 3 (6, 7, 8).
+    CHECK(rb.dropOldestToFill(3) == 5);
+    CHECK(rb.availableToRead() == 3);
+    int16_t out[3] = {};
+    CHECK(rb.read(out, 3) == 3);
+    CHECK(out[0] == 6);
+    CHECK(out[1] == 7);
+    CHECK(out[2] == 8);
+    std::cout << "Test dropOldestToFill Drops Oldest, Keeps Freshest: PASSED"
+              << std::endl;
+}
+
+void testDropOldestToFillWrapsCorrectly() {
+    // Force a wrapped read position, then cap — the dropped span must cross
+    // the array boundary without corrupting the surviving samples.
+    RingBuffer<int16_t, 8> rb;  // capacity 7
+    int16_t a[5] = {1, 2, 3, 4, 5};
+    CHECK(rb.write(a, 5) == 5);
+    CHECK(rb.read(a, 5) == 5);  // readIndex now at 5
+    int16_t b[6] = {10, 20, 30, 40, 50, 60};
+    CHECK(rb.write(b, 6) == 6);  // wraps around the boundary
+    // Keep freshest 2 (50, 60); drop 4 oldest.
+    CHECK(rb.dropOldestToFill(2) == 4);
+    int16_t out[2] = {};
+    CHECK(rb.read(out, 2) == 2);
+    CHECK(out[0] == 50);
+    CHECK(out[1] == 60);
+    std::cout << "Test dropOldestToFill Wraps Correctly: PASSED" << std::endl;
+}
+
+void testDropOldestToFillZeroFlushesAll() {
+    RingBuffer<int16_t, 32> rb;
+    int16_t in[6] = {1, 2, 3, 4, 5, 6};
+    rb.write(in, 6);
+    CHECK(rb.dropOldestToFill(0) == 6);
+    CHECK(rb.availableToRead() == 0);
+    std::cout << "Test dropOldestToFill Zero Flushes All: PASSED" << std::endl;
+}
+
 // ── SPSC stress: producer/consumer threads running concurrently ───────────────
 //
 // The producer writes 1-sample frames and the consumer reads them. After the
@@ -296,6 +352,10 @@ int main() {
     testPeekDoesNotConsume();
     testClearResetsState();
     testAvailableToWriteAccountsForData();
+    testDropOldestToFillNoOpWhenShallow();
+    testDropOldestToFillDropsOldestAndKeepsFreshest();
+    testDropOldestToFillWrapsCorrectly();
+    testDropOldestToFillZeroFlushesAll();
     testSpscStress();
     std::cout << "\nAll RingBuffer tests passed." << std::endl;
     return 0;


### PR DESCRIPTION
## Problem

On-device follow-up to #480: after the link degrades, voice comes back at **awful quality with multi-second lag** — the pipeline ends up seconds behind real time and never recovers.

## Where the buffer is (and why lag persists)

The jitter buffer is hard-capped at 200 ms, so a *seconds*-deep backlog can't be it alone. Tracing the whole path:

| Stage | Cap | Overflow policy (before) |
|---|---|---|
| Sender app send queue | 6 frames (~120 ms) | drop **oldest** ✅ |
| Sender OS/controller L2CAP TX | unbounded-ish | kernel-managed (below our code) |
| Receiver jitter buffer | 200 ms | drop **newest** ❌ |
| Receiver **mixer ring** | **~680 ms** @ codec rate | keep oldest, drop **newest** ❌ |

The dominant hidden buffer is the **per-device mixer ring** (`AudioRingBuffer`, 16384 samples): it's the rendezvous between the decode producer (~50 Hz steady_clock) and the Oboe playout consumer (audio hardware clock). Those clocks aren't synced, so it drifts toward full and **stays** there. The sender's kernel/controller L2CAP TX buffer adds more, *below* our shallow 6-frame app queue (which is why the old `qDepth=0` logs were misleading).

**The actual bug:** every stage except the send queue, on overflow, **keeps the oldest audio and discards the newest** — backwards for real-time voice. Each stage fills with stale audio and faithfully replays it; the only catch-up (the jitter buffer's drift-drain at 1 frame/tick) can't claw back seconds. So it degrades, pins itself stale, and holds there.

## Fix — favour the freshest audio end-to-end

L2CAP CoC is a reliable, **ordered** stream (TCP-like) and Android exposes no unreliable/datagram BLE socket, so we can't make the link lossy. Instead we give it UDP-like "shed late packets" behaviour at the app layer:

- **Playout mixer ring** — new `RingBuffer::dropOldestToFill(maxFill)` (consumer-side, SPSC-safe). Before mixing, the playout consumer fast-forwards past any backlog down to `kPlayoutMaxRingFillSamples` (3 frames / 60 ms). Small drift → a few samples trimmed per callback; a big burst → dropped in one shot. **One mechanism = both the continuous cap and the hard catch-up** the issue called for.
- **Jitter buffer** — at the cap, evict the **oldest** queued frame to admit a newer arrival (advancing the playhead so the skip isn't miscounted as network loss) instead of rejecting the fresh frame. An arrival older than everything queued is itself dropped.
- **Sender TX** — stamp each queued frame with its enqueue time; the writer drops frames older than `STALE_FRAME_BUDGET_MS` (200 ms) rather than feeding seconds-old audio into the kernel L2CAP TX buffer (which we can neither flush nor drain).

## Tests

- **Host C++** (`ring_buffer_test`, `jitter_buffer_test`, `mixer_test`) — all pass locally under `-Wall -Wextra`. New: `dropOldestToFill` (no-op when shallow / keep-freshest / wraparound / flush-all); jitter-buffer favour-fresh eviction at the cap, asserting it is **not** miscounted as `lostFrameCount`.
- **Kotlin** — `isFrameStale` boundary test (exactly-at-budget is fresh; one ns over is stale; 2 s is stale).
- Kotlin/Dart suites run on CI (no Flutter/Android toolchain in the authoring sandbox); host C++ ran locally.

## Notes / scope

- `dropOldestToFill` is applied inside `getMixedAudioForDevice`; in the producer-paced mix-minus path the ring is shallow so it's a no-op, and it's widened to the current read size so it never drops samples the same call is about to consume. The single-consumer-per-ring assumption holds for the 1–2 peer case; the pre-existing multi-consumer-per-ring behaviour for >2 peers is unchanged.
- Transport thoughts (QUIC / true UDP) discussed with the reporter: not applicable over BLE on Android — covered by the app-layer freshness policy here. A future move to a Wi-Fi-Direct/IP transport (WebRTC/SRTP-over-UDP) would be the way to get a genuinely unreliable real-time path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsLeGqW4ZySDSiTXjew5KF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented latency catch-up mechanism to automatically drop older audio samples and reduce playout delay.
  * Added ring buffer anti-bloat policy that discards outdated samples when capacity thresholds are reached.
  * Enabled freshness-bias prioritization for incoming frames, preserving newer data over stale entries during buffer overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->