### PR TITLE
feat(audio): timestamp-based staleness drop + debug telemetry dashboard

### DIFF
--- a/android/app/src/main/cpp/audio_config.h
+++ b/android/app/src/main/cpp/audio_config.h
@@ -121,6 +121,22 @@ constexpr size_t kPlayoutMaxRingFillSamples =
 // Mixer tick.
 constexpr int kMixerTickIntervalMs = kFrameDurationMs;
 
+// End-to-end staleness (Kevin's timestamp-drop). The receiver derives a frame's
+// staleness from the VoiceFrame `senderTsMs` versus local arrival, baselined
+// against a sliding-window minimum to cancel the unknown cross-device clock
+// offset (see playout_lag_estimator.h).
+//   - kLagBaselineWindowMs: how far back the "best recent transit" baseline
+//     looks. Long enough to span a talkspurt and ride out slow clock drift,
+//     short enough that a backlog that builds within it still surfaces as
+//     excess. 5 s.
+//   - kStaleDropBudgetMs: a frame whose transit sits more than this above the
+//     baseline is too late to be worth playing and is dropped before decode
+//     (guarded so we never starve the last available frame into silence). Fixed
+//     at 200 ms — deliberately not adapted to channel quality (that complexity
+//     isn't worth it here).
+constexpr uint32_t kLagBaselineWindowMs = 5000;
+constexpr uint32_t kStaleDropBudgetMs = 200;
+
 }  // namespace audio_config
 
 #endif  // AUDIO_CONFIG_H

--- a/android/app/src/main/cpp/jitter_buffer.cpp
+++ b/android/app/src/main/cpp/jitter_buffer.cpp
@@ -194,6 +194,21 @@ void JitterBuffer::tick() {
     underrunsThisInterval_ = 0;
 }
 
+void JitterBuffer::resyncPlayheadIfEmpty(uint32_t seq) {
+    // Only safe while empty: with frames queued, pop() would clobber the
+    // playhead from the front frame's seq anyway, and we could strand a
+    // queued frame behind an advanced playhead.
+    if (!frames_.empty()) {
+        return;
+    }
+    // Never rewind: if seq is already behind the playhead, leave it.
+    if (playheadInit_ && seqLess(seq, playhead_)) {
+        return;
+    }
+    playhead_ = seq;
+    playheadInit_ = true;
+}
+
 void JitterBuffer::resetAdaptCounters() {
     ticksThisInterval_ = 0;
     underrunsThisInterval_ = 0;

--- a/android/app/src/main/cpp/jitter_buffer.h
+++ b/android/app/src/main/cpp/jitter_buffer.h
@@ -121,6 +121,19 @@ public:
     bool playheadInitialized() const { return playheadInit_; }
     uint32_t playhead() const { return playhead_; }
 
+    // Resync the playhead to `seq` when (and only when) the buffer is empty.
+    //
+    // Used by the caller after it has *intentionally* shed frames before they
+    // entered the buffer (the staleness drop in PeerAudioManager): the seqs it
+    // dropped would otherwise read as a hole-at-head when the next accepted
+    // frame plays, inflating lostFrameCount (which drives bitrate) and forcing
+    // one-frame-per-tick PLC pacing across a gap that wasn't network loss.
+    // Resyncing the playhead to the resumed seq makes the deliberate shed a
+    // clean cut instead. Only moves the playhead forward and only while empty,
+    // so it can never strand a queued frame or rewind the playhead — and it is
+    // gated to the shed path, so genuine packet loss is still counted normally.
+    void resyncPlayheadIfEmpty(uint32_t seq);
+
     // Reset the rolling counters used by adapt(). Stats above continue to
     // accumulate for telemetry; this only affects adaptation decisions.
     void resetAdaptCounters();

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -167,10 +167,11 @@ bool PeerAudioManager::onVoiceFramePushed(const std::string& macAddress,
         state = it->second;  // shared_ptr keeps state alive past unlock.
     }
 
-    // Local arrival time on a monotonic clock. PlayoutLagEstimator only uses
-    // *differences* and its sliding-window-min cancels the (constant) offset
-    // between this steady clock and the sender's wall clock, so mixing the two
-    // domains is fine — and steady_clock avoids NTP wall-clock jumps.
+    // Local arrival time on a monotonic clock. Both ends are now monotonic
+    // (sender: SystemClock.elapsedRealtime; receiver: steady_clock), so neither
+    // jumps under NTP. PlayoutLagEstimator only uses *differences*, and its
+    // sliding-window-min cancels the constant offset between the two monotonic
+    // epochs.
     const int64_t recvMs =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now().time_since_epoch())

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -146,7 +146,8 @@ std::string PeerAudioManager::getMacAddress(int deviceId) {
 }
 
 bool PeerAudioManager::onVoiceFramePushed(const std::string& macAddress,
-                                          uint32_t seq, const uint8_t* opusData,
+                                          uint32_t seq, uint32_t senderTsMs,
+                                          const uint8_t* opusData,
                                           int opusSize) {
     std::shared_ptr<PeerState> state;
     {
@@ -165,11 +166,47 @@ bool PeerAudioManager::onVoiceFramePushed(const std::string& macAddress,
         }
         state = it->second;  // shared_ptr keeps state alive past unlock.
     }
+
+    // Local arrival time on a monotonic clock. PlayoutLagEstimator only uses
+    // *differences* and its sliding-window-min cancels the (constant) offset
+    // between this steady clock and the sender's wall clock, so mixing the two
+    // domains is fine — and steady_clock avoids NTP wall-clock jumps.
+    const int64_t recvMs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count();
+
     // JitterBuffer is not thread-safe; we serialize against the mixer
     // thread's tick/pop here.
     std::lock_guard<std::mutex> stateLock(state->mutex);
-    return state->jitterBuffer->push(seq, opusData,
-                                     static_cast<size_t>(opusSize));
+
+    const int64_t excessMs = state->lagEstimator.feed(senderTsMs, recvMs);
+    state->lastLagMs = excessMs;
+
+    // Staleness drop (Kevin's timestamp-drop). A frame whose transit sits far
+    // above the best recent baseline has been languishing — most likely
+    // seconds deep in the sender's kernel L2CAP TX buffer, which our per-stage
+    // caps can't see. Playing it would pin playout that far behind real time,
+    // so drop it before it enters the jitter buffer.
+    //
+    // No-silence guard: only drop once the stream is live (playhead primed)
+    // AND there's already buffered audio to play in its place. On a cold start
+    // or a fully-drained buffer we accept even a stale frame rather than starve
+    // the consumer to silence — choppy-but-present beats dead air.
+    if (PlayoutLagEstimator::isStale(excessMs) &&
+        state->jitterBuffer->playheadInitialized() &&
+        state->jitterBuffer->currentDepth() > 0) {
+        ++state->staleDropCount;
+        return false;
+    }
+
+    const bool accepted =
+        state->jitterBuffer->push(seq, opusData, static_cast<size_t>(opusSize));
+    if (accepted) {
+        ++state->recvCount;
+        state->lastAcceptedSeq = seq;
+    }
+    return accepted;
 }
 
 int PeerAudioManager::setPeerBitrate(const std::string& macAddress, int bps) {
@@ -250,6 +287,11 @@ PeerAudioManager::LinkTelemetry PeerAudioManager::getTelemetry(
             static_cast<uint32_t>(state->jitterBuffer->targetDepth());
         t.jitterCurrentDepth =
             static_cast<uint32_t>(state->jitterBuffer->currentDepth());
+        t.currentLagMs =
+            static_cast<uint32_t>(std::max<int64_t>(0, state->lastLagMs));
+        t.staleDropCount = state->staleDropCount;
+        t.recvCount = state->recvCount;
+        t.lastSeq = state->lastAcceptedSeq;
     }
     t.currentBitrate = state->bitrate.load(std::memory_order_relaxed);
     t.valid = true;
@@ -821,7 +863,7 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeClear(JNIEnv* env,
 JNIEXPORT void JNICALL
 Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeOnVoiceFrameReceived(
     JNIEnv* env, jobject thiz, jstring macAddress, jbyteArray opusData,
-    jlong seq) {
+    jlong seq, jlong senderTsMs) {
     std::lock_guard<std::mutex> lock(g_peerManagerMutex);
     if (!g_peerAudioManager) return;
     const char* mac = env->GetStringUTFChars(macAddress, nullptr);
@@ -830,6 +872,7 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeOnVoiceFrameReceived(
 
     g_peerAudioManager->onVoiceFramePushed(
         std::string(mac), static_cast<uint32_t>(seq),
+        static_cast<uint32_t>(senderTsMs),
         reinterpret_cast<const uint8_t*>(buf), static_cast<int>(size));
 
     env->ReleaseByteArrayElements(opusData, buf, JNI_ABORT);
@@ -847,12 +890,12 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeSetPeerBitrate(
     return applied;
 }
 
-// Returns a 6-element int array with telemetry, or null if peer not found.
+// Returns a 10-element int array with telemetry, or null if peer not found.
 // Layout: [underrunCount, lateFrameCount, jitterTargetDepth,
-//          jitterCurrentDepth, currentBitrate, lostFrameCount]. lostFrameCount
-// is appended last so the existing index layout is undisturbed. Kotlin unpacks
-// this into a data class — keeping the marshaling cheap (no JNI object
-// allocations) is the point.
+//          jitterCurrentDepth, currentBitrate, lostFrameCount, currentLagMs,
+//          staleDropCount, recvCount, lastSeq]. New fields are appended so the
+// existing index layout (0..5) is undisturbed. Kotlin unpacks this into a data
+// class — keeping the marshaling cheap (no JNI object allocations) is the point.
 JNIEXPORT jintArray JNICALL
 Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeGetTelemetry(
     JNIEnv* env, jobject thiz, jstring macAddress) {
@@ -864,17 +907,21 @@ Java_com_elodin_walkie_1talkie_PeerAudioManager_nativeGetTelemetry(
 
     if (!t.valid) return nullptr;
 
-    jintArray arr = env->NewIntArray(6);
+    jintArray arr = env->NewIntArray(10);
     if (!arr) return nullptr;
-    jint values[6] = {
+    jint values[10] = {
         static_cast<jint>(t.underrunCount),
         static_cast<jint>(t.lateFrameCount),
         static_cast<jint>(t.jitterTargetDepth),
         static_cast<jint>(t.jitterCurrentDepth),
         static_cast<jint>(t.currentBitrate),
         static_cast<jint>(t.lostFrameCount),
+        static_cast<jint>(t.currentLagMs),
+        static_cast<jint>(t.staleDropCount),
+        static_cast<jint>(t.recvCount),
+        static_cast<jint>(t.lastSeq),
     };
-    env->SetIntArrayRegion(arr, 0, 6, values);
+    env->SetIntArrayRegion(arr, 0, 10, values);
     return arr;
 }
 

--- a/android/app/src/main/cpp/peer_audio_manager.cpp
+++ b/android/app/src/main/cpp/peer_audio_manager.cpp
@@ -198,7 +198,18 @@ bool PeerAudioManager::onVoiceFramePushed(const std::string& macAddress,
         state->jitterBuffer->playheadInitialized() &&
         state->jitterBuffer->currentDepth() > 0) {
         ++state->staleDropCount;
+        state->sheddingStale = true;
         return false;
+    }
+
+    // Accepting. If we were shedding a stale backlog, the seqs we dropped would
+    // otherwise read as a hole-at-head when this frame plays — inflating
+    // lostFrameCount (which drives bitrate) and PLC-pacing a gap that wasn't
+    // network loss. Resync the playhead to this seq (effective only once the
+    // buffer has drained to empty) so the shed is a clean cut, not phantom loss.
+    if (state->sheddingStale) {
+        state->jitterBuffer->resyncPlayheadIfEmpty(seq);
+        state->sheddingStale = false;
     }
 
     const bool accepted =

--- a/android/app/src/main/cpp/peer_audio_manager.h
+++ b/android/app/src/main/cpp/peer_audio_manager.h
@@ -79,9 +79,10 @@ public:
     // from the L2CAP receive path. `seq` is the protocol's per-link uint32.
     // Returns true if accepted; false if dropped (late, duplicate, or peer
     // not registered).
-    // `senderTsMs` is the VoiceFrame header's sender encode-time (low 32 bits
-    // of ms-since-epoch); used to estimate end-to-end staleness and drop frames
-    // that arrive too late to be worth playing (see PlayoutLagEstimator).
+    // `senderTsMs` is the VoiceFrame header's sender encode-time on a MONOTONIC
+    // clock (SystemClock.elapsedRealtime, low 32 bits of ms-since-boot — not
+    // wall-clock, so it can't jump under NTP); used to estimate end-to-end
+    // staleness and drop frames that arrive too late to play (PlayoutLagEstimator).
     bool onVoiceFramePushed(const std::string& macAddress, uint32_t seq,
                             uint32_t senderTsMs, const uint8_t* opusData,
                             int opusSize);
@@ -151,6 +152,10 @@ private:
         uint32_t staleDropCount{0};  // frames dropped on arrival as too stale
         uint32_t recvCount{0};       // frames accepted into the jitter buffer
         uint32_t lastAcceptedSeq{0}; // last accepted seq (live head-of-stream)
+        // True while we're shedding a stale backlog (dropping frames before the
+        // jitter buffer). On the next accepted frame we resync the playhead so
+        // the shed gap isn't miscounted as a hole-at-head loss.
+        bool sheddingStale{false};
     };
 
     void mixerTickLoop();

--- a/android/app/src/main/cpp/peer_audio_manager.h
+++ b/android/app/src/main/cpp/peer_audio_manager.h
@@ -14,6 +14,7 @@
 #include "audio_mixer.h"
 #include "jitter_buffer.h"
 #include "opus_codec.h"
+#include "playout_lag_estimator.h"
 #include "vad_detector.h"
 
 // Owns the per-peer audio plumbing on the host (or the host's mirror image
@@ -50,6 +51,16 @@ public:
         uint32_t jitterTargetDepth{0};
         uint32_t jitterCurrentDepth{0};
         int currentBitrate{audio_config::kDefaultBitrate};
+        // End-to-end staleness telemetry (drives the in-app debug dashboard).
+        // currentLagMs: the latest PlayoutLagEstimator excess — how far behind
+        // the best recent transit the most recent frame arrived (ms).
+        // staleDropCount: lifetime frames dropped on arrival as too stale.
+        // recvCount: lifetime frames accepted into the jitter buffer.
+        // lastSeq: most recently accepted seq (the live head-of-stream).
+        uint32_t currentLagMs{0};
+        uint32_t staleDropCount{0};
+        uint32_t recvCount{0};
+        uint32_t lastSeq{0};
         bool valid{false};
     };
 
@@ -68,8 +79,12 @@ public:
     // from the L2CAP receive path. `seq` is the protocol's per-link uint32.
     // Returns true if accepted; false if dropped (late, duplicate, or peer
     // not registered).
+    // `senderTsMs` is the VoiceFrame header's sender encode-time (low 32 bits
+    // of ms-since-epoch); used to estimate end-to-end staleness and drop frames
+    // that arrive too late to be worth playing (see PlayoutLagEstimator).
     bool onVoiceFramePushed(const std::string& macAddress, uint32_t seq,
-                            const uint8_t* opusData, int opusSize);
+                            uint32_t senderTsMs, const uint8_t* opusData,
+                            int opusSize);
 
     // Set this peer's outbound encoder bitrate. Called when LinkQuality
     // telemetry suggests adapting. Clamped to [kBitrateLow, kBitrateHigh].
@@ -128,6 +143,14 @@ private:
             // Per-peer VAD. Guarded by `mutex` so reads from isPeerTalking() are
         // race-free even when the mixer thread is running.
         VadDetector peerVad{audio_config::kCodecSampleRate};
+        // End-to-end staleness (Kevin's timestamp-drop). Fed on the receive
+        // path with each frame's senderTsMs + local arrival time. All fields
+        // below are touched under `mutex`.
+        PlayoutLagEstimator lagEstimator;
+        int64_t lastLagMs{0};        // most recent staleness estimate (ms)
+        uint32_t staleDropCount{0};  // frames dropped on arrival as too stale
+        uint32_t recvCount{0};       // frames accepted into the jitter buffer
+        uint32_t lastAcceptedSeq{0}; // last accepted seq (live head-of-stream)
     };
 
     void mixerTickLoop();

--- a/android/app/src/main/cpp/playout_lag_estimator.h
+++ b/android/app/src/main/cpp/playout_lag_estimator.h
@@ -10,14 +10,17 @@
 // `senderTsMs` (the sender's encode-time wall clock, low 32 bits of
 // ms-since-epoch) and the local arrival time.
 //
-// **Why this is not just `now - senderTsMs`.** The two devices' wall clocks are
-// unsynchronised — the whole reason the audio pipeline jitters — so the raw
-// difference `arrival - senderTsMs` carries an arbitrary, unknown clock offset
-// (and the best-case one-way transit). That absolute number is meaningless on
-// its own. What *is* meaningful is how far a given frame sits **above the best
-// recent frame**: that excess is real queuing/backlog delay (e.g. a frame that
-// languished seconds in the sender's kernel L2CAP TX buffer), independent of
-// the clock offset.
+// **Why this is not just `now - senderTsMs`.** `senderTsMs` and the local
+// arrival time come from two *different* monotonic clocks (sender:
+// SystemClock.elapsedRealtime; receiver: steady_clock), each with its own
+// arbitrary epoch — so the raw difference `arrival - senderTsMs` carries an
+// unknown constant offset (and the best-case one-way transit). That absolute
+// number is meaningless on its own. What *is* meaningful is how far a given
+// frame sits **above the best recent frame**: that excess is real
+// queuing/backlog delay (e.g. a frame that languished seconds in the sender's
+// kernel L2CAP TX buffer), independent of the offset. Both clocks are
+// monotonic, so neither jumps under NTP — only their (constant) difference
+// matters, and the window cancels it.
 //
 // **Method.** Maintain the minimum of `rawDelay = arrival - senderTsMs` over a
 // sliding time window (`kLagBaselineWindowMs`). The offset cancels in the

--- a/android/app/src/main/cpp/playout_lag_estimator.h
+++ b/android/app/src/main/cpp/playout_lag_estimator.h
@@ -7,8 +7,9 @@
 #include "audio_config.h"
 
 // Estimates per-peer end-to-end playout staleness from the VoiceFrame's
-// `senderTsMs` (the sender's encode-time wall clock, low 32 bits of
-// ms-since-epoch) and the local arrival time.
+// `senderTsMs` (the sender's encode-time on a MONOTONIC clock —
+// `SystemClock.elapsedRealtime`, low 32 bits of ms-since-boot, NOT wall-clock)
+// and the local arrival time.
 //
 // **Why this is not just `now - senderTsMs`.** `senderTsMs` and the local
 // arrival time come from two *different* monotonic clocks (sender:

--- a/android/app/src/main/cpp/playout_lag_estimator.h
+++ b/android/app/src/main/cpp/playout_lag_estimator.h
@@ -1,0 +1,95 @@
+#ifndef PLAYOUT_LAG_ESTIMATOR_H
+#define PLAYOUT_LAG_ESTIMATOR_H
+
+#include <cstdint>
+#include <deque>
+
+#include "audio_config.h"
+
+// Estimates per-peer end-to-end playout staleness from the VoiceFrame's
+// `senderTsMs` (the sender's encode-time wall clock, low 32 bits of
+// ms-since-epoch) and the local arrival time.
+//
+// **Why this is not just `now - senderTsMs`.** The two devices' wall clocks are
+// unsynchronised — the whole reason the audio pipeline jitters — so the raw
+// difference `arrival - senderTsMs` carries an arbitrary, unknown clock offset
+// (and the best-case one-way transit). That absolute number is meaningless on
+// its own. What *is* meaningful is how far a given frame sits **above the best
+// recent frame**: that excess is real queuing/backlog delay (e.g. a frame that
+// languished seconds in the sender's kernel L2CAP TX buffer), independent of
+// the clock offset.
+//
+// **Method.** Maintain the minimum of `rawDelay = arrival - senderTsMs` over a
+// sliding time window (`kLagBaselineWindowMs`). The offset cancels in the
+// subtraction, so `excess = rawDelay - windowMin` is a clock-sync-free measure
+// of staleness in milliseconds. A call that "starts clean then degrades" seeds
+// the baseline during the good period, so the later backlog surfaces as a
+// growing excess. Slow clock drift between the crystals is tracked out by the
+// sliding window (a stale lifetime-min would otherwise drift the baseline).
+//
+// **Wraparound.** `senderTsMs` is uint32 and wraps every ~49.7 days; `rawDelay`
+// is computed as a signed int32 modular difference, which is correct for any
+// pair within ±2^31 ms of each other — far beyond the few-second spread within
+// one window.
+//
+// **Threading.** Not thread-safe; the caller serialises feeds (the receive
+// path is single-producer per peer). Cheap: O(1) amortised per feed via a
+// monotonic deque.
+class PlayoutLagEstimator {
+public:
+    PlayoutLagEstimator() = default;
+
+    // Record a frame arrival and return its staleness in ms: how far this
+    // frame's transit delay sits above the best frame seen in the last
+    // kLagBaselineWindowMs. Always >= 0. `recvMs` must be non-decreasing
+    // across calls (a monotonic local clock, e.g. steady_clock ms).
+    int64_t feed(uint32_t senderTsMs, int64_t recvMs) {
+        const int32_t rawDelay = static_cast<int32_t>(
+            static_cast<uint32_t>(recvMs) - senderTsMs);
+
+        // Monotonic-min deque: keep delays increasing front->back so the front
+        // is always the window minimum. Drop larger trailing entries the new
+        // sample dominates.
+        while (!window_.empty() && window_.back().rawDelay >= rawDelay) {
+            window_.pop_back();
+        }
+        window_.push_back({recvMs, rawDelay});
+        // Evict samples older than the baseline window.
+        const int64_t cutoff =
+            recvMs - static_cast<int64_t>(audio_config::kLagBaselineWindowMs);
+        while (!window_.empty() && window_.front().recvMs < cutoff) {
+            window_.pop_front();
+        }
+
+        baselineRawDelay_ = window_.front().rawDelay;
+        lastExcessMs_ = static_cast<int64_t>(rawDelay) - baselineRawDelay_;
+        return lastExcessMs_;
+    }
+
+    // Staleness of the most recent feed(), in ms (>= 0).
+    int64_t lastExcessMs() const { return lastExcessMs_; }
+
+    // True if `excessMs` exceeds the drop budget — the frame is too stale to be
+    // worth playing. The no-silence guard (never drop the only available
+    // frame) lives at the call site, not here.
+    static bool isStale(int64_t excessMs) {
+        return excessMs > static_cast<int64_t>(audio_config::kStaleDropBudgetMs);
+    }
+
+    void reset() {
+        window_.clear();
+        baselineRawDelay_ = 0;
+        lastExcessMs_ = 0;
+    }
+
+private:
+    struct Sample {
+        int64_t recvMs;
+        int32_t rawDelay;
+    };
+    std::deque<Sample> window_;
+    int32_t baselineRawDelay_{0};
+    int64_t lastExcessMs_{0};
+};
+
+#endif  // PLAYOUT_LAG_ESTIMATOR_H

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -548,6 +548,10 @@ class MainActivity : FlutterActivity() {
                                 t.currentDepthFrames,
                                 t.currentBitrateBps,
                                 t.lostFrameCount,
+                                t.currentLagMs,
+                                t.staleDropCount,
+                                t.recvCount,
+                                t.lastSeq,
                             ))
                         }
                     }
@@ -763,11 +767,23 @@ class MainActivity : FlutterActivity() {
                   ((frameBytes[1].toInt() and 0xFF) shl 16) or
                   ((frameBytes[2].toInt() and 0xFF) shl 8) or
                   (frameBytes[3].toInt() and 0xFF)
+        // Bytes 4-7: senderTsMs (low 32 bits of the sender's encode-time wall
+        // clock). Previously parsed-and-discarded; now forwarded so native can
+        // estimate end-to-end staleness and drop frames that arrived too late.
+        val senderTsMs = ((frameBytes[4].toInt() and 0xFF) shl 24) or
+                         ((frameBytes[5].toInt() and 0xFF) shl 16) or
+                         ((frameBytes[6].toInt() and 0xFF) shl 8) or
+                         (frameBytes[7].toInt() and 0xFF)
         val opusPayload = frameBytes.copyOfRange(8, frameBytes.size)
         if (firstDecodedFramePeers.add(addr)) {
             sendEventToFlutter(mapOf("type" to "firstDecodedFrame", "address" to addr))
         }
-        peerAudioManager?.onVoiceFrameReceived(addr, opusPayload, seq.toLong() and 0xFFFFFFFFL)
+        peerAudioManager?.onVoiceFrameReceived(
+            addr,
+            opusPayload,
+            seq.toLong() and 0xFFFFFFFFL,
+            senderTsMs.toLong() and 0xFFFFFFFFL,
+        )
     }
 
     // Register addr as a peer in the native manager and add its mixer slot.

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -767,9 +767,11 @@ class MainActivity : FlutterActivity() {
                   ((frameBytes[1].toInt() and 0xFF) shl 16) or
                   ((frameBytes[2].toInt() and 0xFF) shl 8) or
                   (frameBytes[3].toInt() and 0xFF)
-        // Bytes 4-7: senderTsMs (low 32 bits of the sender's encode-time wall
-        // clock). Previously parsed-and-discarded; now forwarded so native can
-        // estimate end-to-end staleness and drop frames that arrived too late.
+        // Bytes 4-7: senderTsMs (low 32 bits of the sender's encode-time on a
+        // MONOTONIC clock — SystemClock.elapsedRealtime, ms-since-boot, not
+        // wall-clock; see buildVoiceFrame). Previously parsed-and-discarded; now
+        // forwarded so native can estimate end-to-end staleness and drop frames
+        // that arrived too late.
         val senderTsMs = ((frameBytes[4].toInt() and 0xFF) shl 24) or
                          ((frameBytes[5].toInt() and 0xFF) shl 16) or
                          ((frameBytes[6].toInt() and 0xFF) shl 8) or

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/MainActivity.kt
@@ -815,7 +815,13 @@ class MainActivity : FlutterActivity() {
 
     // Encode [opusData] + [seq] into the 8-byte VoiceFrame wire format (big-endian).
     private fun buildVoiceFrame(opusData: ByteArray, seq: Int): ByteArray {
-        val ts = (System.currentTimeMillis() and 0xFFFFFFFFL).toInt()
+        // senderTsMs is a MONOTONIC timestamp (SystemClock.elapsedRealtime, ms
+        // since boot incl. deep sleep), not wall-clock. The receiver's staleness
+        // estimator pairs it with its own monotonic steady_clock; using
+        // System.currentTimeMillis() here would expose senderTsMs to NTP / manual
+        // clock jumps, and a backward jump >= the stale budget would make every
+        // frame look stale and black out audio for a full baseline window.
+        val ts = (android.os.SystemClock.elapsedRealtime() and 0xFFFFFFFFL).toInt()
         val frame = ByteArray(8 + opusData.size)
         frame[0] = ((seq ushr 24) and 0xFF).toByte()
         frame[1] = ((seq ushr 16) and 0xFF).toByte()

--- a/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
+++ b/android/app/src/main/kotlin/com/elodin/walkie_talkie/PeerAudioManager.kt
@@ -66,12 +66,24 @@ class PeerAudioManager {
      * this is an over-the-wire input boundary, and one bad packet must not
      * crash the foreground service.
      */
-    fun onVoiceFrameReceived(macAddress: String, opusData: ByteArray, seq: Long) {
+    fun onVoiceFrameReceived(
+        macAddress: String,
+        opusData: ByteArray,
+        seq: Long,
+        senderTsMs: Long,
+    ) {
         if (seq !in 0..0xFFFF_FFFFL) {
             Log.w(TAG, "Dropping voice frame from $macAddress: seq=$seq is not a valid uint32")
             return
         }
-        nativeOnVoiceFrameReceived(macAddress, opusData, seq)
+        // senderTsMs is the VoiceFrame header's low-32 sender encode time; it is
+        // already masked to a uint32 on the wire, but range-check defensively so
+        // a malformed parse can't sign-extend a negative into native.
+        if (senderTsMs !in 0..0xFFFF_FFFFL) {
+            Log.w(TAG, "Dropping voice frame from $macAddress: senderTsMs=$senderTsMs out of range")
+            return
+        }
+        nativeOnVoiceFrameReceived(macAddress, opusData, seq, senderTsMs)
     }
 
     fun clear() {
@@ -98,6 +110,15 @@ class PeerAudioManager {
         // True network loss (seq-gap). Drives bitrate adaptation; lateFrameCount
         // is kept for observability only.
         val lostFrameCount: Int,
+        // End-to-end staleness telemetry for the debug dashboard.
+        // currentLagMs: latest estimated staleness (ms above best recent transit).
+        // staleDropCount: lifetime frames dropped on arrival as too stale.
+        // recvCount: lifetime frames accepted into the jitter buffer.
+        // lastSeq: most recently accepted seq (live head-of-stream).
+        val currentLagMs: Int,
+        val staleDropCount: Int,
+        val recvCount: Int,
+        val lastSeq: Int,
     )
 
     /**
@@ -129,7 +150,7 @@ class PeerAudioManager {
     /** Returns null if the peer isn't registered. */
     fun getTelemetry(macAddress: String): LinkTelemetry? {
         val raw = nativeGetTelemetry(macAddress) ?: return null
-        if (raw.size != 6) {
+        if (raw.size != 10) {
             Log.w(TAG, "getTelemetry returned unexpected array size ${raw.size}")
             return null
         }
@@ -140,6 +161,10 @@ class PeerAudioManager {
             currentDepthFrames = raw[3],
             currentBitrateBps = raw[4],
             lostFrameCount = raw[5],
+            currentLagMs = raw[6],
+            staleDropCount = raw[7],
+            recvCount = raw[8],
+            lastSeq = raw[9],
         )
     }
 
@@ -163,7 +188,7 @@ class PeerAudioManager {
     private external fun nativeStopMixerThread()
     private external fun nativeSetCallback(callback: Any)
     private external fun nativeClear()
-    private external fun nativeOnVoiceFrameReceived(macAddress: String, opusData: ByteArray, seq: Long)
+    private external fun nativeOnVoiceFrameReceived(macAddress: String, opusData: ByteArray, seq: Long, senderTsMs: Long)
     private external fun nativeSetPeerBitrate(macAddress: String, bps: Int): Int
     private external fun nativeGetTelemetry(macAddress: String): IntArray?
     private external fun nativeSetPeerVolume(macAddress: String, volume: Float)

--- a/lib/protocol/voice_frame.dart
+++ b/lib/protocol/voice_frame.dart
@@ -21,9 +21,12 @@ const int kVoiceHeaderSize = 8;
 /// - `seq` — per-link monotonic counter starting at 1. The host uses it to
 ///   detect drops: if 16 consecutive values are missing from a peer, the
 ///   host stops mixing that peer's stream until the next valid frame.
-/// - `senderTsMs` — low 32 bits of the sender's wall-clock at encode time
-///   (ms-since-epoch mod 2^32). Combined with `seq`, the host estimates
-///   jitter and drops frames whose playback window has already passed.
+/// - `senderTsMs` — low 32 bits of the sender's **monotonic** clock at encode
+///   time (`SystemClock.elapsedRealtime`, ms-since-boot mod 2^32 — NOT
+///   wall-clock, so it can't jump under NTP). The receiver pairs it with its
+///   own monotonic arrival clock to estimate end-to-end staleness and drop
+///   frames whose playback window has already passed (see
+///   `PlayoutLagEstimator`).
 /// - `payload` — Opus-compressed audio; see `docs/protocol.md § Voice plane`
 ///   for the recommended codec parameters (16 kHz, mono, 20 ms, 24 kbps).
 class VoiceFrame {

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -31,6 +31,25 @@ class LinkTelemetrySnapshot {
   /// The encoder bitrate currently emitted toward this peer, in bps.
   final int currentBitrateBps;
 
+  /// Current end-to-end staleness estimate in ms: how far the most recent
+  /// frame's transit sat above the best recent baseline (clock-offset-cancelled
+  /// — see native `PlayoutLagEstimator`). This is the "lag" the listener feels;
+  /// the debug dashboard graphs it over time.
+  final int currentLagMs;
+
+  /// Lifetime frames dropped on arrival because they were too stale to play
+  /// (excess > `kStaleDropBudgetMs`). Rising fast means the link can't keep up
+  /// and we're shedding backlog to stay current.
+  final int staleDropCount;
+
+  /// Lifetime frames accepted into the jitter buffer. Delta over wall-clock
+  /// gives the receive throughput (target ~50/s).
+  final int recvCount;
+
+  /// Most recently accepted sequence number — the live head-of-stream the
+  /// dashboard shows as "current packet".
+  final int lastSeq;
+
   const LinkTelemetrySnapshot({
     required this.underrunCount,
     required this.lateFrameCount,
@@ -38,6 +57,10 @@ class LinkTelemetrySnapshot {
     required this.targetDepthFrames,
     required this.currentDepthFrames,
     required this.currentBitrateBps,
+    required this.currentLagMs,
+    required this.staleDropCount,
+    required this.recvCount,
+    required this.lastSeq,
   });
 
   @override
@@ -49,7 +72,11 @@ class LinkTelemetrySnapshot {
           lostFrameCount == other.lostFrameCount &&
           targetDepthFrames == other.targetDepthFrames &&
           currentDepthFrames == other.currentDepthFrames &&
-          currentBitrateBps == other.currentBitrateBps;
+          currentBitrateBps == other.currentBitrateBps &&
+          currentLagMs == other.currentLagMs &&
+          staleDropCount == other.staleDropCount &&
+          recvCount == other.recvCount &&
+          lastSeq == other.lastSeq;
 
   @override
   int get hashCode => Object.hash(
@@ -59,6 +86,10 @@ class LinkTelemetrySnapshot {
     targetDepthFrames,
     currentDepthFrames,
     currentBitrateBps,
+    currentLagMs,
+    staleDropCount,
+    recvCount,
+    lastSeq,
   );
 }
 
@@ -616,10 +647,11 @@ class AudioService {
         'getLinkTelemetry',
         <String, dynamic>{'macAddress': macAddress},
       );
-      if (raw is! List || raw.length != 6) return null;
-      // Native returns a 6-element int array: [underruns, late, target,
-      // current, bitrate, lost]. lostFrameCount is appended last so the
-      // historical index layout is undisturbed. Element-wise check guards
+      if (raw is! List || raw.length != 10) return null;
+      // Native returns a 10-element int array: [underruns, late, target,
+      // current, bitrate, lost, lagMs, staleDrops, recv, lastSeq]. The newer
+      // fields (indices 6-9, the staleness/dashboard telemetry) are appended so
+      // the historical 0-5 layout is undisturbed. Element-wise check guards
       // against a truncated or padded response from a stale platform handler.
       final values = raw.map((e) => e is int ? e : null).toList();
       if (values.any((v) => v == null)) return null;
@@ -630,6 +662,10 @@ class AudioService {
         currentDepthFrames: values[3]!,
         currentBitrateBps: values[4]!,
         lostFrameCount: values[5]!,
+        currentLagMs: values[6]!,
+        staleDropCount: values[7]!,
+        recvCount: values[8]!,
+        lastSeq: values[9]!,
       );
     } catch (e) {
       if (kDebugMode) {

--- a/lib/services/voice_telemetry_monitor.dart
+++ b/lib/services/voice_telemetry_monitor.dart
@@ -1,0 +1,174 @@
+import 'dart:convert';
+
+import 'audio_service.dart';
+
+/// One derived telemetry data point for the voice debug dashboard, computed
+/// from two consecutive [LinkTelemetrySnapshot]s for a peer.
+///
+/// The native counters are lifetime totals; this turns the per-snapshot deltas
+/// into the rates a human watching a live link wants to see, plus the
+/// instantaneous gauges (lag, depth, bitrate, head-of-stream seq).
+class VoiceTelemetryPoint {
+  /// Local wall-clock (ms since epoch) when this point was sampled.
+  final int tMs;
+
+  /// Frames accepted per second (`recvCount` delta / elapsed) — should sit
+  /// near 50/s on a healthy 20 ms link.
+  final double throughputPerSec;
+
+  /// Frames dropped per second as too stale (`staleDropCount` delta / elapsed).
+  /// A non-zero value means we're actively shedding backlog to stay current.
+  final double staleDropsPerSec;
+
+  /// Instantaneous end-to-end staleness estimate (ms) — the lag the listener
+  /// feels (native `PlayoutLagEstimator` excess).
+  final int lagMs;
+
+  /// Jitter-buffer fill at sample time, in 20 ms frames.
+  final int depthFrames;
+
+  /// Encoder bitrate toward this peer at sample time (bps).
+  final int bitrateBps;
+
+  /// Most recently accepted sequence number (live head-of-stream).
+  final int lastSeq;
+
+  const VoiceTelemetryPoint({
+    required this.tMs,
+    required this.throughputPerSec,
+    required this.staleDropsPerSec,
+    required this.lagMs,
+    required this.depthFrames,
+    required this.bitrateBps,
+    required this.lastSeq,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'tMs': tMs,
+    'throughputPerSec': throughputPerSec,
+    'staleDropsPerSec': staleDropsPerSec,
+    'lagMs': lagMs,
+    'depthFrames': depthFrames,
+    'bitrateBps': bitrateBps,
+    'lastSeq': lastSeq,
+  };
+}
+
+/// Rolling per-peer telemetry buffer that backs the in-app voice debug
+/// dashboard and its "export last minute" button.
+///
+/// Feed it raw [LinkTelemetrySnapshot]s (polled from [AudioService]) via [add];
+/// it differences consecutive snapshots into [VoiceTelemetryPoint]s and retains
+/// the last [window] of them per peer. The dashboard renders [points] (e.g. a
+/// staleness sparkline) and the live aggregates; [exportJson] serialises the
+/// whole retained window to a string the user can write to a file and re-upload
+/// for offline debugging.
+///
+/// Pure logic — no timers, no platform calls — so it unit-tests deterministically
+/// with injected `nowMs` values. The caller owns the polling cadence.
+class VoiceTelemetryMonitor {
+  VoiceTelemetryMonitor({this.window = const Duration(seconds: 60)});
+
+  /// How far back [points] / [exportJson] retain history.
+  final Duration window;
+
+  final Map<String, List<VoiceTelemetryPoint>> _points = {};
+  final Map<String, LinkTelemetrySnapshot> _prev = {};
+  final Map<String, int> _prevAtMs = {};
+
+  /// Difference [snap] against the previous snapshot for [peerId] and append a
+  /// derived point. Returns the new point, or `null` on the first sample for a
+  /// peer (nothing to delta against yet) or a non-positive elapsed interval.
+  VoiceTelemetryPoint? add(String peerId, LinkTelemetrySnapshot snap, int nowMs) {
+    final prev = _prev[peerId];
+    final prevAt = _prevAtMs[peerId];
+    _prev[peerId] = snap;
+    _prevAtMs[peerId] = nowMs;
+    if (prev == null || prevAt == null) return null;
+
+    final elapsedMs = nowMs - prevAt;
+    if (elapsedMs <= 0) return null;
+    final elapsedSec = elapsedMs / 1000.0;
+
+    // Lifetime counters: clamp deltas at 0 so a native-side reset (peer
+    // re-register zeroes recvCount/staleDropCount) reads as "no traffic this
+    // interval" rather than a negative spike.
+    final recvDelta = (snap.recvCount - prev.recvCount).clamp(0, 1 << 31);
+    final staleDelta =
+        (snap.staleDropCount - prev.staleDropCount).clamp(0, 1 << 31);
+
+    final point = VoiceTelemetryPoint(
+      tMs: nowMs,
+      throughputPerSec: recvDelta / elapsedSec,
+      staleDropsPerSec: staleDelta / elapsedSec,
+      lagMs: snap.currentLagMs,
+      depthFrames: snap.currentDepthFrames,
+      bitrateBps: snap.currentBitrateBps,
+      lastSeq: snap.lastSeq,
+    );
+
+    final list = _points.putIfAbsent(peerId, () => <VoiceTelemetryPoint>[]);
+    list.add(point);
+    _evict(list, nowMs);
+    return point;
+  }
+
+  void _evict(List<VoiceTelemetryPoint> list, int nowMs) {
+    final cutoff = nowMs - window.inMilliseconds;
+    // Points are appended in time order, so drop from the front.
+    var drop = 0;
+    while (drop < list.length && list[drop].tMs < cutoff) {
+      drop++;
+    }
+    if (drop > 0) list.removeRange(0, drop);
+  }
+
+  /// The retained window of points for [peerId], oldest first. Empty if unseen.
+  List<VoiceTelemetryPoint> points(String peerId) =>
+      List.unmodifiable(_points[peerId] ?? const []);
+
+  /// Peers with at least one retained point.
+  Iterable<String> get peers => _points.keys;
+
+  /// Mean lag (ms) over the retained window for [peerId], or null if empty.
+  double? avgLagMs(String peerId) {
+    final list = _points[peerId];
+    if (list == null || list.isEmpty) return null;
+    final sum = list.fold<int>(0, (a, p) => a + p.lagMs);
+    return sum / list.length;
+  }
+
+  /// Most recent point for [peerId], or null if unseen.
+  VoiceTelemetryPoint? latest(String peerId) {
+    final list = _points[peerId];
+    return (list == null || list.isEmpty) ? null : list.last;
+  }
+
+  /// Serialise the full retained window (all peers) to a JSON string suitable
+  /// for writing to a file and re-uploading. Stable, self-describing shape:
+  /// `{ "exportedAtMs", "windowMs", "peers": { "<id>": [ point, ... ] } }`.
+  String exportJson({int? exportedAtMs}) {
+    final peersJson = <String, dynamic>{};
+    for (final entry in _points.entries) {
+      peersJson[entry.key] = entry.value.map((p) => p.toJson()).toList();
+    }
+    return const JsonEncoder.withIndent('  ').convert({
+      'exportedAtMs': exportedAtMs ?? DateTime.now().millisecondsSinceEpoch,
+      'windowMs': window.inMilliseconds,
+      'peers': peersJson,
+    });
+  }
+
+  /// Forget a peer's history (e.g. on leave / re-register).
+  void forgetPeer(String peerId) {
+    _points.remove(peerId);
+    _prev.remove(peerId);
+    _prevAtMs.remove(peerId);
+  }
+
+  void clear() {
+    _points.clear();
+    _prev.clear();
+    _prevAtMs.clear();
+  }
+}

--- a/scripts/run_native_cpp_tests.sh
+++ b/scripts/run_native_cpp_tests.sh
@@ -12,6 +12,7 @@ for required in \
     test/cpp/resampler_test.cpp \
     test/cpp/talking_event_queue_test.cpp \
     test/cpp/ring_buffer_test.cpp \
+    test/cpp/playout_lag_estimator_test.cpp \
     test/cpp/opus_codec_test.cpp \
     test/cpp/vad_detector_test.cpp \
     test/cpp/playback_stream_config_test.cpp \
@@ -26,7 +27,8 @@ for required in \
     android/app/src/main/cpp/peer_audio_manager.cpp \
     android/app/src/main/cpp/peer_audio_manager.h \
     android/app/src/main/cpp/jitter_buffer.cpp \
-    android/app/src/main/cpp/jitter_buffer.h; do
+    android/app/src/main/cpp/jitter_buffer.h \
+    android/app/src/main/cpp/playout_lag_estimator.h; do
   if [ ! -f "$required" ]; then
     echo "$required missing — failing fast"
     exit 1
@@ -78,6 +80,15 @@ ${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
     test/cpp/ring_buffer_test.cpp \
     -o build/cpp_test/ring_buffer_test
 build/cpp_test/ring_buffer_test
+
+# playout_lag_estimator_test exercises header-only playout_lag_estimator.h —
+# the sliding-window-min staleness estimator behind the timestamp-drop fix.
+${CXX:-g++} -std=c++17 -Wall -Wextra -pthread \
+    -I test/cpp \
+    -I android/app/src/main/cpp \
+    test/cpp/playout_lag_estimator_test.cpp \
+    -o build/cpp_test/playout_lag_estimator_test
+build/cpp_test/playout_lag_estimator_test
 
 # vad_detector_test exercises the two-sided hysteresis state machine extracted
 # from audio_engine.cpp (#248). Header-only; no extra link deps beyond the STL.

--- a/test/cpp/jitter_buffer_test.cpp
+++ b/test/cpp/jitter_buffer_test.cpp
@@ -535,6 +535,42 @@ void testEvictionPreservesHoleAtHeadLoss() {
               << std::endl;
 }
 
+// resyncPlayheadIfEmpty: used by the stale-shed path so dropped seqs aren't
+// later miscounted as a hole-at-head. Only acts on an empty buffer, only moves
+// forward, and a subsequent contiguous pop sees no hole (no false loss).
+void testResyncPlayheadIfEmpty() {
+    JitterBuffer jb;
+    const uint8_t data[1] = {0x42};
+
+    // Establish a playhead, then drain to empty (playhead at 101).
+    assert(jb.push(100, data, 1));
+    auto f = jb.popAny();
+    assert(f.has_value() && f->seq == 100);
+    assert(jb.playhead() == 101);
+    assert(jb.currentDepth() == 0);
+
+    // Simulate a stale shed: seqs 101..199 were dropped before the buffer.
+    // Resync to the resumed seq 200 — playhead jumps with no loss counted.
+    const auto preLost = jb.lostFrameCount();
+    jb.resyncPlayheadIfEmpty(200);
+    assert(jb.playhead() == 200);
+
+    // The resumed frame now plays as a clean head, NOT a 99-frame hole.
+    assert(jb.push(200, data, 1));
+    seedAtDepth(jb, 201, audio_config::kJitterInitialDepth - 1);  // reach target
+    auto g = jb.pop();
+    assert(g.has_value() && g->seq == 200);
+    assert(jb.lostFrameCount() == preLost);  // no phantom loss from the shed
+
+    // No-op while non-empty (a queued frame must never be stranded).
+    assert(jb.currentDepth() > 0);
+    const uint32_t headBefore = jb.playhead();
+    jb.resyncPlayheadIfEmpty(999);
+    assert(jb.playhead() == headBefore);
+
+    std::cout << "Test Resync Playhead If Empty: PASSED" << std::endl;
+}
+
 }  // namespace
 
 int main() {
@@ -545,6 +581,7 @@ int main() {
         testMultiFrameHoleProducesContiguousPLC();
         testPushCapsAtMaxDepth();
         testEvictionPreservesHoleAtHeadLoss();
+        testResyncPlayheadIfEmpty();
         testNormalFlowAfterFilling();
         testLateFrameDropped();
         testDuplicateRejected();

--- a/test/cpp/peer_audio_manager_test.cpp
+++ b/test/cpp/peer_audio_manager_test.cpp
@@ -76,7 +76,7 @@ uint32_t freshSenderTs() {
 void testUnregisteredPeerReturnsFalse() {
     PeerAudioManager mgr;
 
-    CHECK(!mgr.onVoiceFramePushed(kMacA, 1, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(!mgr.onVoiceFramePushed(kMacA, 1, freshSenderTs(), kFakeOpus, kFakeOpusLen));
 
     std::cout << "Test Unregistered Peer Returns False: PASSED" << std::endl;
 }
@@ -87,7 +87,7 @@ void testNormalSeqAccepted() {
     mgr.registerPeer(kMacA);
 
     for (uint32_t seq = 1; seq <= 10; ++seq) {
-        CHECK(mgr.onVoiceFramePushed(kMacA, seq, nowMs(), kFakeOpus, kFakeOpusLen));
+        CHECK(mgr.onVoiceFramePushed(kMacA, seq, freshSenderTs(), kFakeOpus, kFakeOpusLen));
     }
 
     mgr.clear();
@@ -112,7 +112,7 @@ void testHighUint32SeqCastAndAccepted() {
     // static_cast<uint32_t> used in nativeOnVoiceFrameReceived.
     for (int64_t seqJlong = 0x7FFFFFFDLL; seqJlong != 0x80000002LL; ++seqJlong) {
         uint32_t seq = static_cast<uint32_t>(seqJlong);
-        CHECK(mgr.onVoiceFramePushed(kMacA, seq, nowMs(), kFakeOpus, kFakeOpusLen));
+        CHECK(mgr.onVoiceFramePushed(kMacA, seq, freshSenderTs(), kFakeOpus, kFakeOpusLen));
     }
 
     mgr.clear();
@@ -129,12 +129,12 @@ void testUint32RolloverAccepted() {
     mgr.registerPeer(kMacA);
 
     // 3 frames ending at the max uint32 value.
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFDu, nowMs(), kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFEu, nowMs(), kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFFu, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFDu, freshSenderTs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFEu, freshSenderTs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFFu, freshSenderTs(), kFakeOpus, kFakeOpusLen));
     // 2 frames after the rollover: treated as forward frames by unsigned delta.
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000000u, nowMs(), kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000001u, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000000u, freshSenderTs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000001u, freshSenderTs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test uint32 Rollover Accepted: PASSED" << std::endl;
@@ -149,11 +149,11 @@ void testSeqGapAcceptedByJitterBuffer() {
     mgr.registerPeer(kMacA);
 
     for (uint32_t seq = 1; seq <= 4; ++seq) {
-        CHECK(mgr.onVoiceFramePushed(kMacA, seq, nowMs(), kFakeOpus, kFakeOpusLen));
+        CHECK(mgr.onVoiceFramePushed(kMacA, seq, freshSenderTs(), kFakeOpus, kFakeOpusLen));
     }
 
     // Seqs 5-25 are absent (burst loss). Seq 26 must still be accepted.
-    CHECK(mgr.onVoiceFramePushed(kMacA, 26, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 26, freshSenderTs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test Seq Gap Accepted By JitterBuffer: PASSED" << std::endl;
@@ -164,9 +164,9 @@ void testDuplicateRejected() {
     PeerAudioManager mgr;
     mgr.registerPeer(kMacA);
 
-    CHECK(mgr.onVoiceFramePushed(kMacA, 42, nowMs(), kFakeOpus, kFakeOpusLen));
-    CHECK(!mgr.onVoiceFramePushed(kMacA, 42, nowMs(), kFakeOpus, kFakeOpusLen));  // dup
-    CHECK(mgr.onVoiceFramePushed(kMacA, 43, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 42, freshSenderTs(), kFakeOpus, kFakeOpusLen));
+    CHECK(!mgr.onVoiceFramePushed(kMacA, 42, freshSenderTs(), kFakeOpus, kFakeOpusLen));  // dup
+    CHECK(mgr.onVoiceFramePushed(kMacA, 43, freshSenderTs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test Duplicate Rejected: PASSED" << std::endl;
@@ -194,13 +194,13 @@ void testMultiplePeersAreIndependent() {
     mgr.registerPeer(kMacA);
     mgr.registerPeer(kMacB);
 
-    CHECK(mgr.onVoiceFramePushed(kMacA, 1, nowMs(), kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacB, 100, nowMs(), kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 2, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 1, freshSenderTs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacB, 100, freshSenderTs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 2, freshSenderTs(), kFakeOpus, kFakeOpusLen));
 
     // Duplicate on B must not affect A.
-    CHECK(!mgr.onVoiceFramePushed(kMacB, 100, nowMs(), kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 3, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(!mgr.onVoiceFramePushed(kMacB, 100, freshSenderTs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 3, freshSenderTs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test Multiple Peers Are Independent: PASSED" << std::endl;

--- a/test/cpp/peer_audio_manager_test.cpp
+++ b/test/cpp/peer_audio_manager_test.cpp
@@ -30,7 +30,6 @@
 
 #include "peer_audio_manager.h"
 
-#include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -56,15 +55,17 @@ const int kFakeOpusLen = 1;
 const std::string kMacA = "AA:BB:CC:DD:EE:FF";
 const std::string kMacB = "11:22:33:44:55:66";
 
-// Sender timestamp ≈ "now" on the same monotonic clock the receive path reads,
-// so each frame's estimated transit is ~0 and the staleness-drop never fires —
-// these tests exercise seq handling, not the lag estimator. (The estimator has
-// its own dedicated test in playout_lag_estimator_test.cpp.)
-uint32_t nowMs() {
-    return static_cast<uint32_t>(
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now().time_since_epoch())
-            .count());
+// A strictly-increasing fake sender timestamp. Each call jumps by a large step,
+// so the estimator's rawDelay (recvMs - senderTsMs) strictly DECREASES per
+// frame — every sample becomes a new sliding-window minimum and excess pins at
+// 0, so the staleness-drop never fires no matter how long the scheduler pauses
+// between this call and the native recvMs read. That keeps these seq-handling
+// tests deterministic on a loaded CI host. (The estimator's own behaviour is
+// covered in playout_lag_estimator_test.cpp.)
+uint32_t freshSenderTs() {
+    static uint32_t t = 1;
+    t += 100000;  // 100 s/frame: dwarfs any realistic scheduling gap
+    return t;
 }
 
 }  // namespace

--- a/test/cpp/peer_audio_manager_test.cpp
+++ b/test/cpp/peer_audio_manager_test.cpp
@@ -30,6 +30,7 @@
 
 #include "peer_audio_manager.h"
 
+#include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -55,6 +56,17 @@ const int kFakeOpusLen = 1;
 const std::string kMacA = "AA:BB:CC:DD:EE:FF";
 const std::string kMacB = "11:22:33:44:55:66";
 
+// Sender timestamp ≈ "now" on the same monotonic clock the receive path reads,
+// so each frame's estimated transit is ~0 and the staleness-drop never fires —
+// these tests exercise seq handling, not the lag estimator. (The estimator has
+// its own dedicated test in playout_lag_estimator_test.cpp.)
+uint32_t nowMs() {
+    return static_cast<uint32_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+}
+
 }  // namespace
 
 // Verify that onVoiceFramePushed returns false for an unregistered peer —
@@ -63,7 +75,7 @@ const std::string kMacB = "11:22:33:44:55:66";
 void testUnregisteredPeerReturnsFalse() {
     PeerAudioManager mgr;
 
-    CHECK(!mgr.onVoiceFramePushed(kMacA, 1, kFakeOpus, kFakeOpusLen));
+    CHECK(!mgr.onVoiceFramePushed(kMacA, 1, nowMs(), kFakeOpus, kFakeOpusLen));
 
     std::cout << "Test Unregistered Peer Returns False: PASSED" << std::endl;
 }
@@ -74,7 +86,7 @@ void testNormalSeqAccepted() {
     mgr.registerPeer(kMacA);
 
     for (uint32_t seq = 1; seq <= 10; ++seq) {
-        CHECK(mgr.onVoiceFramePushed(kMacA, seq, kFakeOpus, kFakeOpusLen));
+        CHECK(mgr.onVoiceFramePushed(kMacA, seq, nowMs(), kFakeOpus, kFakeOpusLen));
     }
 
     mgr.clear();
@@ -99,7 +111,7 @@ void testHighUint32SeqCastAndAccepted() {
     // static_cast<uint32_t> used in nativeOnVoiceFrameReceived.
     for (int64_t seqJlong = 0x7FFFFFFDLL; seqJlong != 0x80000002LL; ++seqJlong) {
         uint32_t seq = static_cast<uint32_t>(seqJlong);
-        CHECK(mgr.onVoiceFramePushed(kMacA, seq, kFakeOpus, kFakeOpusLen));
+        CHECK(mgr.onVoiceFramePushed(kMacA, seq, nowMs(), kFakeOpus, kFakeOpusLen));
     }
 
     mgr.clear();
@@ -116,12 +128,12 @@ void testUint32RolloverAccepted() {
     mgr.registerPeer(kMacA);
 
     // 3 frames ending at the max uint32 value.
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFDu, kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFEu, kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFFu, kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFDu, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFEu, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0xFFFFFFFFu, nowMs(), kFakeOpus, kFakeOpusLen));
     // 2 frames after the rollover: treated as forward frames by unsigned delta.
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000000u, kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000001u, kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000000u, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 0x00000001u, nowMs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test uint32 Rollover Accepted: PASSED" << std::endl;
@@ -136,11 +148,11 @@ void testSeqGapAcceptedByJitterBuffer() {
     mgr.registerPeer(kMacA);
 
     for (uint32_t seq = 1; seq <= 4; ++seq) {
-        CHECK(mgr.onVoiceFramePushed(kMacA, seq, kFakeOpus, kFakeOpusLen));
+        CHECK(mgr.onVoiceFramePushed(kMacA, seq, nowMs(), kFakeOpus, kFakeOpusLen));
     }
 
     // Seqs 5-25 are absent (burst loss). Seq 26 must still be accepted.
-    CHECK(mgr.onVoiceFramePushed(kMacA, 26, kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 26, nowMs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test Seq Gap Accepted By JitterBuffer: PASSED" << std::endl;
@@ -151,9 +163,9 @@ void testDuplicateRejected() {
     PeerAudioManager mgr;
     mgr.registerPeer(kMacA);
 
-    CHECK(mgr.onVoiceFramePushed(kMacA, 42, kFakeOpus, kFakeOpusLen));
-    CHECK(!mgr.onVoiceFramePushed(kMacA, 42, kFakeOpus, kFakeOpusLen));  // dup
-    CHECK(mgr.onVoiceFramePushed(kMacA, 43, kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 42, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(!mgr.onVoiceFramePushed(kMacA, 42, nowMs(), kFakeOpus, kFakeOpusLen));  // dup
+    CHECK(mgr.onVoiceFramePushed(kMacA, 43, nowMs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test Duplicate Rejected: PASSED" << std::endl;
@@ -181,13 +193,13 @@ void testMultiplePeersAreIndependent() {
     mgr.registerPeer(kMacA);
     mgr.registerPeer(kMacB);
 
-    CHECK(mgr.onVoiceFramePushed(kMacA, 1, kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacB, 100, kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 2, kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 1, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacB, 100, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 2, nowMs(), kFakeOpus, kFakeOpusLen));
 
     // Duplicate on B must not affect A.
-    CHECK(!mgr.onVoiceFramePushed(kMacB, 100, kFakeOpus, kFakeOpusLen));
-    CHECK(mgr.onVoiceFramePushed(kMacA, 3, kFakeOpus, kFakeOpusLen));
+    CHECK(!mgr.onVoiceFramePushed(kMacB, 100, nowMs(), kFakeOpus, kFakeOpusLen));
+    CHECK(mgr.onVoiceFramePushed(kMacA, 3, nowMs(), kFakeOpus, kFakeOpusLen));
 
     mgr.clear();
     std::cout << "Test Multiple Peers Are Independent: PASSED" << std::endl;

--- a/test/cpp/playout_lag_estimator_test.cpp
+++ b/test/cpp/playout_lag_estimator_test.cpp
@@ -1,0 +1,139 @@
+// Host-buildable test for PlayoutLagEstimator (header-only).
+//
+// Compile (see scripts/run_native_cpp_tests.sh):
+//   g++ -std=c++17 -Wall -Wextra -pthread -I android/app/src/main/cpp
+//       test/cpp/playout_lag_estimator_test.cpp -o build/cpp_test/playout_lag_estimator_test
+
+#include "playout_lag_estimator.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+
+#define CHECK(cond)                                                          \
+    do {                                                                     \
+        if (!(cond)) {                                                       \
+            std::cerr << "CHECK failed: " #cond                              \
+                      << " (" << __FILE__ << ":" << __LINE__ << ")"          \
+                      << std::endl;                                          \
+            std::exit(1);                                                    \
+        }                                                                    \
+    } while (0)
+
+// A constant clock offset + constant transit must cancel to zero staleness,
+// no matter how large the offset (the whole point: no clock sync needed).
+void testConstantOffsetCancels() {
+    PlayoutLagEstimator est;
+    const int64_t offsetPlusTransit = 100;  // ms baked into every sample
+    for (int i = 0; i < 20; ++i) {
+        const int64_t recvMs = 1000 + i * 20;
+        const uint32_t senderTs =
+            static_cast<uint32_t>(recvMs - offsetPlusTransit);
+        CHECK(est.feed(senderTs, recvMs) == 0);
+    }
+    // Even with an absurd offset (sender clock ~100 s behind), excess is 0.
+    PlayoutLagEstimator est2;
+    for (int i = 0; i < 5; ++i) {
+        const int64_t recvMs = 50000 + i * 20;
+        const uint32_t senderTs = static_cast<uint32_t>(recvMs - 100000 - 30);
+        CHECK(est2.feed(senderTs, recvMs) == 0);
+    }
+    std::cout << "Test Constant Offset Cancels: PASSED" << std::endl;
+}
+
+// A backlog (transit jumps above the established baseline) surfaces as excess.
+void testBacklogSurfacesAsExcess() {
+    PlayoutLagEstimator est;
+    // Clean baseline: transit 100 ms.
+    for (int i = 0; i < 10; ++i) {
+        const int64_t recvMs = 1000 + i * 20;
+        est.feed(static_cast<uint32_t>(recvMs - 100), recvMs);
+    }
+    // A frame that languished 500 ms longer in transit.
+    const int64_t recvMs = 1200;
+    const int64_t excess = est.feed(static_cast<uint32_t>(recvMs - 600), recvMs);
+    CHECK(excess == 500);
+    CHECK(PlayoutLagEstimator::isStale(excess));
+    std::cout << "Test Backlog Surfaces As Excess: PASSED" << std::endl;
+}
+
+void testIsStaleBoundary() {
+    // Budget is 200 ms; strict greater-than.
+    CHECK(!PlayoutLagEstimator::isStale(0));
+    CHECK(!PlayoutLagEstimator::isStale(200));
+    CHECK(PlayoutLagEstimator::isStale(201));
+    CHECK(PlayoutLagEstimator::isStale(3000));
+    std::cout << "Test isStale Boundary: PASSED" << std::endl;
+}
+
+// A new lower transit lowers the baseline; later normal frames then read as
+// excess above that new best.
+void testLowerBaselinePullsExcessUp() {
+    PlayoutLagEstimator est;
+    est.feed(static_cast<uint32_t>(1000 - 100), 1000);  // D=100, excess 0
+    CHECK(est.lastExcessMs() == 0);
+    est.feed(static_cast<uint32_t>(1020 - 50), 1020);   // D=50, new min, excess 0
+    CHECK(est.lastExcessMs() == 0);
+    const int64_t excess = est.feed(static_cast<uint32_t>(1040 - 100), 1040);  // D=100
+    CHECK(excess == 50);  // 100 above the new baseline of 50
+    std::cout << "Test Lower Baseline Pulls Excess Up: PASSED" << std::endl;
+}
+
+// Once the window slides past the original low-transit sample, the baseline
+// rises to the recent minimum and a previously-"stale" steady state reads as
+// fresh again.
+void testWindowEvictsStaleBaseline() {
+    PlayoutLagEstimator est;
+    // One good frame at t=1000 (transit 100).
+    est.feed(static_cast<uint32_t>(1000 - 100), 1000);
+    // Steady state at transit 300, still within the window of the t=1000 sample.
+    int64_t excessWithinWindow =
+        est.feed(static_cast<uint32_t>(5000 - 300), 5000);  // t-1000 < 5000ms
+    CHECK(excessWithinWindow == 200);  // 300 above baseline 100
+    // Advance well past the window so the t=1000 baseline is evicted; the
+    // recent 300-transit frames become the new baseline -> excess collapses.
+    int64_t excessAfterEvict =
+        est.feed(static_cast<uint32_t>(7000 - 300), 7000);  // 7000-1000 > 5000ms
+    CHECK(excessAfterEvict == 0);
+    std::cout << "Test Window Evicts Stale Baseline: PASSED" << std::endl;
+}
+
+// senderTsMs wraps at 2^32; modular int32 delay math must still be correct
+// when the sender timestamp is near the top of the range.
+void testWrapAroundDelay() {
+    PlayoutLagEstimator est;
+    // recv low-32 small, senderTs just below it minus 100 -> wraps past 0.
+    for (int i = 0; i < 5; ++i) {
+        const int64_t recvMs = (int64_t{1} << 32) + 50 + i * 20;  // low32 wraps
+        const uint32_t senderTs = static_cast<uint32_t>(recvMs - 100);
+        CHECK(est.feed(senderTs, recvMs) == 0);  // constant D=100 across the wrap
+    }
+    const int64_t recvMs = (int64_t{1} << 32) + 150;
+    const int64_t excess = est.feed(static_cast<uint32_t>(recvMs - 700), recvMs);
+    CHECK(excess == 600);
+    std::cout << "Test Wrap-Around Delay: PASSED" << std::endl;
+}
+
+void testResetClears() {
+    PlayoutLagEstimator est;
+    est.feed(static_cast<uint32_t>(1000 - 100), 1000);
+    est.feed(static_cast<uint32_t>(1020 - 900), 1020);
+    CHECK(est.lastExcessMs() == 800);
+    est.reset();
+    CHECK(est.lastExcessMs() == 0);
+    // After reset the next frame defines a fresh baseline (excess 0).
+    CHECK(est.feed(static_cast<uint32_t>(2000 - 5000), 2000) == 0);
+    std::cout << "Test Reset Clears: PASSED" << std::endl;
+}
+
+int main() {
+    testConstantOffsetCancels();
+    testBacklogSurfacesAsExcess();
+    testIsStaleBoundary();
+    testLowerBaselinePullsExcessUp();
+    testWindowEvictsStaleBaseline();
+    testWrapAroundDelay();
+    testResetClears();
+    std::cout << "\nAll PlayoutLagEstimator tests passed." << std::endl;
+    return 0;
+}

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -836,8 +836,9 @@ void main() {
       });
 
       test('getLinkTelemetry returns parsed snapshot', () async {
-        // Layout: [underrun, late, target, current, bitrate, lost].
-        handler = (_) async => [10, 5, 8, 4, 16000, 3];
+        // Layout: [underrun, late, target, current, bitrate, lost, lagMs,
+        // staleDrops, recv, lastSeq].
+        handler = (_) async => [10, 5, 8, 4, 16000, 3, 120, 7, 2500, 4242];
         final snap = await audioService.getLinkTelemetry('AA:BB');
         expect(snap, isNotNull);
         expect(snap!.underrunCount, 10);
@@ -846,17 +847,21 @@ void main() {
         expect(snap.currentDepthFrames, 4);
         expect(snap.currentBitrateBps, 16000);
         expect(snap.lostFrameCount, 3);
+        expect(snap.currentLagMs, 120);
+        expect(snap.staleDropCount, 7);
+        expect(snap.recvCount, 2500);
+        expect(snap.lastSeq, 4242);
       });
 
       test('getLinkTelemetry returns null on wrong shape (length)', () async {
-        handler = (_) async => [1, 2, 3]; // only 3 elements
+        handler = (_) async => [1, 2, 3]; // not 10 elements
         expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
       });
 
       test('getLinkTelemetry returns null on wrong type element', () async {
-        // 6 elements so the length check passes and the element-type check
+        // 10 elements so the length check passes and the element-type check
         // is what rejects it.
-        handler = (_) async => [1, 2, 3, 4, 5, '16000']; // last is string
+        handler = (_) async => [1, 2, 3, 4, 5, 6, 7, 8, 9, '4242']; // last is string
         expect(await audioService.getLinkTelemetry('AA:BB'), isNull);
       });
 
@@ -892,6 +897,10 @@ void main() {
         targetDepthFrames: 3,
         currentDepthFrames: 4,
         currentBitrateBps: 16000,
+        currentLagMs: 80,
+        staleDropCount: 0,
+        recvCount: 1000,
+        lastSeq: 1234,
       );
       const b = LinkTelemetrySnapshot(
         underrunCount: 1,
@@ -900,6 +909,10 @@ void main() {
         targetDepthFrames: 3,
         currentDepthFrames: 4,
         currentBitrateBps: 16000,
+        currentLagMs: 80,
+        staleDropCount: 0,
+        recvCount: 1000,
+        lastSeq: 1234,
       );
       const c = LinkTelemetrySnapshot(
         underrunCount: 99,
@@ -908,6 +921,10 @@ void main() {
         targetDepthFrames: 3,
         currentDepthFrames: 4,
         currentBitrateBps: 16000,
+        currentLagMs: 80,
+        staleDropCount: 0,
+        recvCount: 1000,
+        lastSeq: 1234,
       );
 
       test('identical instances are equal', () {

--- a/test/services/audio_service_test.dart
+++ b/test/services/audio_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:walkie_talkie/services/audio_service.dart';
@@ -846,6 +848,22 @@ void main() {
         expect(snap.targetDepthFrames, 8);
         expect(snap.currentDepthFrames, 4);
         expect(snap.currentBitrateBps, 16000);
+        expect(snap.lostFrameCount, 3);
+        expect(snap.currentLagMs, 120);
+        expect(snap.staleDropCount, 7);
+        expect(snap.recvCount, 2500);
+        expect(snap.lastSeq, 4242);
+      });
+
+      test('getLinkTelemetry parses an Int32List payload', () async {
+        // StandardMessageCodec encodes Kotlin's IntArray as Int32List, not a
+        // plain List — the parser is written to accept either. Guard that
+        // platform-typed-list path explicitly.
+        handler = (_) async =>
+            Int32List.fromList([10, 5, 8, 4, 16000, 3, 120, 7, 2500, 4242]);
+        final snap = await audioService.getLinkTelemetry('AA:BB');
+        expect(snap, isNotNull);
+        expect(snap!.underrunCount, 10);
         expect(snap.lostFrameCount, 3);
         expect(snap.currentLagMs, 120);
         expect(snap.staleDropCount, 7);

--- a/test/services/link_quality_reporter_test.dart
+++ b/test/services/link_quality_reporter_test.dart
@@ -9,6 +9,10 @@ LinkTelemetrySnapshot _snap({
   int target = 3,
   int current = 3,
   int bps = 16000,
+  int lagMs = 0,
+  int staleDrops = 0,
+  int recv = 0,
+  int lastSeq = 0,
 }) => LinkTelemetrySnapshot(
   underrunCount: underrun,
   lateFrameCount: late,
@@ -16,6 +20,10 @@ LinkTelemetrySnapshot _snap({
   targetDepthFrames: target,
   currentDepthFrames: current,
   currentBitrateBps: bps,
+  currentLagMs: lagMs,
+  staleDropCount: staleDrops,
+  recvCount: recv,
+  lastSeq: lastSeq,
 );
 
 void main() {

--- a/test/services/voice_telemetry_monitor_test.dart
+++ b/test/services/voice_telemetry_monitor_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:walkie_talkie/services/audio_service.dart';
+import 'package:walkie_talkie/services/voice_telemetry_monitor.dart';
+
+LinkTelemetrySnapshot _snap({
+  int recv = 0,
+  int staleDrops = 0,
+  int lagMs = 0,
+  int depth = 3,
+  int bps = 32000,
+  int lastSeq = 0,
+}) => LinkTelemetrySnapshot(
+  underrunCount: 0,
+  lateFrameCount: 0,
+  lostFrameCount: 0,
+  targetDepthFrames: 3,
+  currentDepthFrames: depth,
+  currentBitrateBps: bps,
+  currentLagMs: lagMs,
+  staleDropCount: staleDrops,
+  recvCount: recv,
+  lastSeq: lastSeq,
+);
+
+void main() {
+  group('VoiceTelemetryMonitor', () {
+    test('first sample seeds and returns null (nothing to delta)', () {
+      final m = VoiceTelemetryMonitor();
+      expect(m.add('g1', _snap(recv: 100), 1000), isNull);
+      expect(m.points('g1'), isEmpty);
+      expect(m.latest('g1'), isNull);
+    });
+
+    test('differences consecutive snapshots into rates', () {
+      final m = VoiceTelemetryMonitor();
+      m.add('g1', _snap(recv: 100, staleDrops: 0), 1000);
+      // 1 s later: +50 frames, +10 stale drops.
+      final p = m.add(
+        'g1',
+        _snap(recv: 150, staleDrops: 10, lagMs: 80, lastSeq: 4242),
+        2000,
+      );
+      expect(p, isNotNull);
+      expect(p!.throughputPerSec, 50.0); // 50 frames / 1 s
+      expect(p.staleDropsPerSec, 10.0);
+      expect(p.lagMs, 80);
+      expect(p.lastSeq, 4242);
+      expect(p.tMs, 2000);
+    });
+
+    test('non-positive elapsed is ignored', () {
+      final m = VoiceTelemetryMonitor();
+      m.add('g1', _snap(recv: 100), 2000);
+      expect(m.add('g1', _snap(recv: 150), 2000), isNull); // same timestamp
+      expect(m.add('g1', _snap(recv: 150), 1500), isNull); // clock went back
+    });
+
+    test('counter reset clamps deltas to zero (no negative spike)', () {
+      final m = VoiceTelemetryMonitor();
+      m.add('g1', _snap(recv: 1000, staleDrops: 50), 1000);
+      // Native reset: counters drop back toward zero.
+      final p = m.add('g1', _snap(recv: 5, staleDrops: 0), 2000);
+      expect(p!.throughputPerSec, 0.0);
+      expect(p.staleDropsPerSec, 0.0);
+    });
+
+    test('evicts points older than the window', () {
+      final m = VoiceTelemetryMonitor(window: const Duration(seconds: 10));
+      m.add('g1', _snap(recv: 0), 0);
+      m.add('g1', _snap(recv: 50), 1000); // point at t=1000
+      m.add('g1', _snap(recv: 100), 2000); // point at t=2000
+      expect(m.points('g1').length, 2);
+      // Jump well past the window: the t=1000/2000 points fall outside.
+      m.add('g1', _snap(recv: 150), 13000); // point at t=13000
+      final pts = m.points('g1');
+      expect(pts.length, 1);
+      expect(pts.single.tMs, 13000);
+    });
+
+    test('avgLagMs averages the retained window', () {
+      final m = VoiceTelemetryMonitor();
+      m.add('g1', _snap(recv: 0), 0);
+      m.add('g1', _snap(recv: 50, lagMs: 100), 1000);
+      m.add('g1', _snap(recv: 100, lagMs: 200), 2000);
+      expect(m.avgLagMs('g1'), 150.0);
+      expect(m.avgLagMs('unseen'), isNull);
+    });
+
+    test('exportJson is valid, self-describing, and round-trips', () {
+      final m = VoiceTelemetryMonitor();
+      m.add('g1', _snap(recv: 0), 0);
+      m.add('g1', _snap(recv: 50, lagMs: 80, staleDrops: 2), 1000);
+      final json = m.exportJson(exportedAtMs: 9999);
+      final decoded = jsonDecode(json) as Map<String, dynamic>;
+      expect(decoded['exportedAtMs'], 9999);
+      expect(decoded['windowMs'], 60000);
+      final peers = decoded['peers'] as Map<String, dynamic>;
+      final g1 = peers['g1'] as List<dynamic>;
+      expect(g1.length, 1);
+      expect((g1.single as Map<String, dynamic>)['lagMs'], 80);
+      expect((g1.single)['throughputPerSec'], 50.0);
+    });
+
+    test('forgetPeer and clear drop history', () {
+      final m = VoiceTelemetryMonitor();
+      m.add('g1', _snap(recv: 0), 0);
+      m.add('g1', _snap(recv: 50), 1000);
+      m.add('g2', _snap(recv: 0), 0);
+      m.add('g2', _snap(recv: 50), 1000);
+      m.forgetPeer('g1');
+      expect(m.points('g1'), isEmpty);
+      expect(m.points('g2'), isNotEmpty);
+      // A re-fed g1 seeds fresh (first sample null again).
+      expect(m.add('g1', _snap(recv: 0), 2000), isNull);
+      m.clear();
+      expect(m.peers, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Goal

Two things, in one PR (per request):
1. **Timestamp-based staleness drop** (Kevin's idea) — the fix for the lag that *still* persisted on the latest build.
2. **In-app debug dashboard + telemetry export** — so we can finally *see* where the seconds go.

## Why the lag survived the catch-up fix (#481)

#481 bounds every buffer *we* own (jitter ≤200 ms, playout ring ≤60 ms, send queue). But voice still lags multi-second on a degraded link because the **sender's kernel L2CAP TX buffer holds seconds** *below* our app queue — invisible to per-stage caps. The frame arrives already seconds old; bounding how long it then sits in our buffers doesn't help.

The VoiceFrame **already carries `senderTsMs`** (sender encode time) — it was just parsed and discarded on receive. So no protocol change; we act on it.

## What's in this commit (foundation — fix + telemetry plumbing)

- **`PlayoutLagEstimator`** (new, header-only + host tests): per-frame staleness from `senderTsMs` vs local arrival, baselined against a **sliding-window minimum** so the unknown cross-device clock offset cancels (no clock sync needed). A call that starts clean seeds the baseline, so later backlog surfaces as excess.
- **Receive path**: thread `senderTsMs` through `dispatchVoiceFrame` → Kotlin → JNI → `PeerAudioManager`; feed the estimator and **drop frames whose excess > `kStaleDropBudgetMs` (200 ms)** before they enter the jitter buffer. **No-silence guard**: only drop once the stream is primed *and* there's already buffered audio, so a cold start / drained buffer never starves to silence.
- **Telemetry**: native `LinkTelemetry` gains `currentLagMs` / `staleDropCount` / `recvCount` / `lastSeq`; JNI int array grows 6→10 (appended, old indices intact); threaded through Kotlin + Dart `LinkTelemetrySnapshot`.

Staleness budget is **fixed at 200 ms** (deliberately not adapted to channel quality — that complexity isn't worth it).

## Still to come on this branch (follow-up commits)

- **Debug dashboard screen**: packet throughput (~50/s), current seq, average lag, **staleness-over-time graph**.
- **"Export last 60 s"** → file you can re-upload for offline debugging.

## Tests

- New `PlayoutLagEstimator` host test: offset cancellation, backlog detection, sliding-window eviction, uint32 wraparound. **Full native C++ suite green locally** (libopus). Peer-manager + Dart telemetry tests updated for the new signature/array shape. Dart suite on CI.

## Validation note

The behavior change (staleness drop) can't be validated in the build sandbox — that's exactly what the dashboard is for. The estimator is engineered to be safe (clock-sync-free; no-silence guard), and the dashboard will show whether 200 ms is right and whether the kernel-TX bloat theory holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsLeGqW4ZySDSiTXjew5KF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time audio quality telemetry including lag estimates, frame drop statistics, and reception metrics for comprehensive link performance monitoring.
  * Improved audio clarity through automatic detection and removal of delayed frames, ensuring cleaner and more responsive conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->