### PR TITLE
feat(ui): settings cog in room chrome for in-room telemetry

### DIFF
--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -77,6 +77,11 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
   bool _meMuted = false;
   bool _holdingPtt = false;
 
+  /// Guards [_showSettings] against a rapid double-tap pushing two
+  /// [FrequencySettingsScreen] routes onto the navigator (the user would
+  /// otherwise have to pop twice to get back to the room).
+  bool _navigatingToSettings = false;
+
   /// Per-peer playback volume, keyed by peerId. Populated lazily —
   /// only entries the user has explicitly adjusted exist; everything
   /// else reads through [_volumeFor] which falls back to
@@ -1103,11 +1108,15 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
                               fontWeight: FontWeight.w500,
                             ),
                           ),
-                          Text(
-                            widget.freq,
-                            style: kMonoStyle.copyWith(
-                              fontSize: 11,
-                              color: pillText,
+                          Flexible(
+                            child: Text(
+                              widget.freq,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: kMonoStyle.copyWith(
+                                fontSize: 11,
+                                color: pillText,
+                              ),
                             ),
                           ),
                         ],
@@ -1429,12 +1438,18 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
     // it here so the Diagnostics → Voice debug telemetry dashboard is
     // accessible without leaving the room. SettingsStore is the same provider
     // singleton the discovery screen's _openSettings reads.
-    final store = context.read<SettingsStore>();
-    await Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => FrequencySettingsScreen(settingsStore: store),
-      ),
-    );
+    if (_navigatingToSettings) return;
+    _navigatingToSettings = true;
+    try {
+      final store = context.read<SettingsStore>();
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => FrequencySettingsScreen(settingsStore: store),
+        ),
+      );
+    } finally {
+      if (mounted) _navigatingToSettings = false;
+    }
   }
 
   Future<void> _showInviteSheet() async {

--- a/lib/screens/frequency_room_screen.dart
+++ b/lib/screens/frequency_room_screen.dart
@@ -12,6 +12,7 @@ import '../protocol/messages.dart';
 import '../protocol/peer.dart';
 import '../services/audio_service.dart';
 import '../services/blocked_peers_store.dart';
+import '../services/settings_store.dart';
 import '../theme/app_theme.dart';
 import '../widgets/frequency_atoms.dart';
 import '../widgets/frequency_toast_host.dart';
@@ -25,6 +26,7 @@ import '../widgets/media_source_sheet.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../widgets/queue_sheet.dart';
+import 'frequency_settings_screen.dart';
 
 /// Main "On air" room — voice + now playing.
 class FrequencyRoomScreen extends StatefulWidget {
@@ -1054,49 +1056,73 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
       ),
       child: Row(
         children: [
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 4),
-            decoration: BoxDecoration(
-              color: pillBg,
-              borderRadius: BorderRadius.circular(999),
-            ),
+          // Leading status cluster (on-air pill + HOST chip) takes whatever
+          // width the trailing action buttons don't need. Expanded replaces
+          // the old Spacer and the pill is Flexible with an ellipsizing status
+          // text, so the four fixed-width action buttons always fit and the
+          // chrome never RenderFlex-overflows on narrow phones (the row was
+          // already at the 412dp edge with three buttons).
+          Expanded(
             child: Row(
-              mainAxisSize: MainAxisSize.min,
               children: [
-                statusIcon,
-                const SizedBox(width: 6),
-                Text(
-                  statusText,
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 11,
-                    color: pillText,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-                if (phase == ConnectionPhase.online) ...[
-                  Text(
-                    ' · ',
-                    style: TextStyle(
-                      fontFamily: 'Inter',
-                      fontSize: 11,
-                      color: pillText,
-                      fontWeight: FontWeight.w500,
+                Flexible(
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 9,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: pillBg,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        statusIcon,
+                        const SizedBox(width: 6),
+                        Flexible(
+                          child: Text(
+                            statusText,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontFamily: 'Inter',
+                              fontSize: 11,
+                              color: pillText,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                        if (phase == ConnectionPhase.online) ...[
+                          Text(
+                            ' · ',
+                            style: TextStyle(
+                              fontFamily: 'Inter',
+                              fontSize: 11,
+                              color: pillText,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          Text(
+                            widget.freq,
+                            style: kMonoStyle.copyWith(
+                              fontSize: 11,
+                              color: pillText,
+                            ),
+                          ),
+                        ],
+                      ],
                     ),
                   ),
-                  Text(
-                    widget.freq,
-                    style: kMonoStyle.copyWith(fontSize: 11, color: pillText),
-                  ),
+                ),
+                if (widget.isHost) ...[
+                  const SizedBox(width: 8),
+                  FreqChip(label: 'HOST'),
                 ],
               ],
             ),
           ),
-          if (widget.isHost) ...[
-            const SizedBox(width: 8),
-            FreqChip(label: 'HOST'),
-          ],
-          const Spacer(),
+          const SizedBox(width: 8),
           GhostButton(
             icon: _output.icon,
             onPressed: _showOutputSheet,
@@ -1105,6 +1131,11 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
           GhostButton(
             icon: Icons.add,
             onPressed: _showInviteSheet,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          ),
+          GhostButton(
+            icon: Icons.settings,
+            onPressed: _showSettings,
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
           ),
           GhostButton(
@@ -1391,6 +1422,19 @@ class _FrequencyRoomScreenState extends State<FrequencyRoomScreen> {
         ),
       );
     }
+  }
+
+  Future<void> _showSettings() async {
+    // Settings is otherwise only reachable from the discovery screen; surface
+    // it here so the Diagnostics → Voice debug telemetry dashboard is
+    // accessible without leaving the room. SettingsStore is the same provider
+    // singleton the discovery screen's _openSettings reads.
+    final store = context.read<SettingsStore>();
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FrequencySettingsScreen(settingsStore: store),
+      ),
+    );
   }
 
   Future<void> _showInviteSheet() async {

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -312,6 +312,28 @@ void main() {
       },
     );
 
+    testWidgets(
+      'chrome does not overflow at a narrow 360dp width (four-button layout)',
+      // The layout guarantee behind the settings cog: with the leading pill
+      // Flexible, the four fixed-width action buttons must still fit without a
+      // RenderFlex overflow. Worst case is host (extra HOST chip) on the
+      // narrowest phone we target (moto g play ≈ 360dp). A regression here
+      // throws a FlutterError during paint, which takeException() surfaces.
+      (tester) async {
+        tester.view.physicalSize = const Size(360, 1200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(_wrap(_room(isHost: true)));
+        await tester.pump();
+
+        expect(find.byIcon(Icons.settings), findsOneWidget);
+        expect(find.text('HOST'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
     testWidgets('host chip is absent for guests', (tester) async {
       await tester.pumpWidget(_wrap(_room(isHost: false)));
       await tester.pump();

--- a/test/screens/frequency_room_screen_test.dart
+++ b/test/screens/frequency_room_screen_test.dart
@@ -299,6 +299,19 @@ void main() {
       expect(find.text('HOST'), findsOneWidget);
     });
 
+    testWidgets(
+      'chrome exposes a settings cog so telemetry is reachable in-room',
+      // Settings (and from there Diagnostics → Voice debug) was previously
+      // only reachable from the discovery screen, so telemetry was invisible
+      // once inside a room. The cog lives in the chrome alongside the existing
+      // output / invite / leave actions.
+      (tester) async {
+        await tester.pumpWidget(_wrap(_room(isHost: true)));
+        await tester.pump();
+        expect(find.byIcon(Icons.settings), findsOneWidget);
+      },
+    );
+
     testWidgets('host chip is absent for guests', (tester) async {
       await tester.pumpWidget(_wrap(_room(isHost: false)));
       await tester.pump();


### PR DESCRIPTION
@
## What

Settings menu unreachable inside frequency room — only discovery screen had entry point. So **Diagnostics → Voice debug** telemetry dashboard invisible once on air. Add settings cog to room chrome (next to output / invite / leave). Opens `FrequencySettingsScreen`.

## Why chrome also changed

Chrome action row already at 412dp width edge with 3 buttons (per existing room-test viewport comment). 4th button overflowed ~2.4px at 432dp test viewport — worse on narrow phones (moto g play ~360dp).

Fix: wrap leading status pill + HOST chip in `Expanded` (replaces old `Spacer`), pill now `Flexible` with ellipsizing status text. 4 fixed-width action buttons always fit. No `RenderFlex` overflow at any width — also improves pre-existing small-phone case.

## Changes

- `lib/screens/frequency_room_screen.dart` — settings cog + `_showSettings()` (reads `SettingsStore` from provider, same singleton discovery screen uses); chrome leading cluster restructured overflow-proof.
- `test/screens/frequency_room_screen_test.dart` — cog-presence regression test.

## Test

- `flutter analyze` clean.
- `flutter test test/screens/frequency_room_screen_test.dart` — 49 pass.

## Not done

- Full cog → settings nav not unit-tested: room test harness lacks `SettingsStore` provider + l10n delegates. Nav is plain `MaterialPageRoute` push; settings screen has own suite.
- Not yet verified on 2 real devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@